### PR TITLE
PATCH explainer attacks, mitigations, and references for spec accuracy

### DIFF
--- a/backend/internal/protocols/oidc/plugin.go
+++ b/backend/internal/protocols/oidc/plugin.go
@@ -547,7 +547,7 @@ func (p *Plugin) GetFlowDefinitions() []plugin.FlowDefinition {
 					Parameters: map[string]string{
 						"validate": "Token signature and expiration",
 						"scope":    "Verify 'openid' scope is present",
-						"subject":  "Look up user by 'sub' claim in token",
+						"sub":      "Look up user by 'sub' claim in token",
 					},
 				},
 				{

--- a/frontend/src/protocols/explainers/oauth2.ts
+++ b/frontend/src/protocols/explainers/oauth2.ts
@@ -122,8 +122,8 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2',
       },
       {
-        label: 'RFC 9700 §4.1 (Insufficient redirect_uri Validation)',
-        href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-4.1',
+        label: 'RFC 9700 §4.1.3 (Countermeasures — redirect URI exact-match)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-4.1.3',
       },
     ],
   },
@@ -420,8 +420,9 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
       },
       {
         action:
-          'OAuth 2.1 removes the implicit grant entirely; RFC 9700 §2.1.2 ' +
-          'says implicit MUST NOT be used.',
+          'OAuth 2.1 removes the implicit grant entirely. RFC 9700 §2.1.2 ' +
+          'says implicit SHOULD NOT be used (carve-out only when access-' +
+          'token injection cannot otherwise be prevented).',
         mitigates: ['implicit-fragment-leak'],
       },
     ],
@@ -663,7 +664,11 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://datatracker.ietf.org/doc/html/rfc6750#section-5',
       },
       {
-        label: 'RFC 9700 §4.3 (Token Leakage)',
+        label: 'RFC 9700 §4.2 (Credential Leakage via Referer Headers)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-4.2',
+      },
+      {
+        label: 'RFC 9700 §4.3 (Credential Leakage via Browser History)',
         href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-4.3',
       },
       {
@@ -696,7 +701,7 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
       },
       {
         id: 'audience-injection',
-        name: 'Audience injection (RFC 9700 §4.10)',
+        name: 'Audience injection',
         scenario:
           'In a deployment with multiple ASes, a malicious AS coerces ' +
           'clients into sending tokens with attacker-chosen audience ' +
@@ -732,7 +737,7 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://datatracker.ietf.org/doc/html/rfc8707',
       },
       {
-        label: 'RFC 9700 §4.10 (Audience Injection)',
+        label: 'RFC 9700 §4.10 (Misuse of Stolen Access Tokens — sender-constraining and audience-restricting)',
         href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-4.10',
       },
     ],
@@ -796,6 +801,132 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
   },
 
+  active: {
+    purpose:
+      'Boolean field in a Token Introspection response (RFC 7662 §2.2). ' +
+      '`true` means the token is currently valid at the AS — not expired, ' +
+      'not revoked, and within any other AS-imposed constraints. Any other ' +
+      'value (including a missing `active`) MUST be treated as inactive. ' +
+      'It is the only REQUIRED member of the introspection response and is ' +
+      'the field a Resource Server keys its accept/reject decision on.',
+    attacks: [
+      {
+        id: 'introspection-result-caching',
+        name: 'Stale `active=true` after revocation',
+        scenario:
+          'The RS introspects Alice\'s token at 10:00, gets `active=true`, ' +
+          'and caches the result for 10 minutes to keep latency down. At ' +
+          '10:02 Alice\'s token is revoked at the AS (logout, password ' +
+          'reset, incident response). Mallory, who captured the token ' +
+          'earlier, keeps using it against the RS until 10:10 because the ' +
+          'cached introspection result still says active.',
+        impact:
+          'Revocation has no effect for the duration of the cache window — ' +
+          'logout and incident-response controls become advisory.',
+      },
+      {
+        id: 'missing-active-check',
+        name: 'RS treats HTTP 200 as token-valid',
+        scenario:
+          'The RS code reads the introspection response body but only ' +
+          'checks `response.ok` / HTTP 200. The AS correctly returns ' +
+          '`{"active": false}` with status 200 for an expired or revoked ' +
+          'token (RFC 7662 §2.2 — `active=false` is not an error). The RS ' +
+          'proceeds as if the token were valid.',
+        impact:
+          'Expired and revoked tokens are honoured indefinitely; ' +
+          'introspection silently fails open.',
+      },
+      {
+        id: 'introspection-response-spoofing',
+        name: 'Forged introspection response',
+        scenario:
+          'The RS reaches the introspection endpoint over plaintext HTTP, ' +
+          'or trusts a response without validating the AS\'s TLS ' +
+          'certificate. A network attacker rewrites the body to ' +
+          '`{"active": true, "scope": "admin", "sub": "alice"}` for any ' +
+          'token the RS asks about.',
+        impact:
+          'Attacker mints arbitrary identities at the RS by intercepting ' +
+          'the introspection channel.',
+      },
+      {
+        id: 'token-scanning',
+        name: 'Token validity scanning via unauthenticated introspection',
+        scenario:
+          'The introspection endpoint accepts queries from any caller. ' +
+          'Mallory feeds it bulk token guesses (leaked logs, captured ' +
+          'snippets, token-format brute-force) and reads the `active` ' +
+          'field to learn which tokens are currently valid — without ' +
+          'needing to use them at any RS, which would generate audit ' +
+          'trails. This is the attack RFC 7662 §2.1 motivates protecting ' +
+          'the endpoint against.',
+        impact:
+          'Attacker enumerates live tokens and target identities silently, ' +
+          'with no per-RS access logs to reveal the probing.',
+      },
+    ],
+    mitigations: [
+      {
+        action:
+          'Treat `active` strictly: accept the token only when `active === ' +
+          'true`. Any other value, missing field, or non-200 response means ' +
+          'reject.',
+        mitigates: ['missing-active-check'],
+      },
+      {
+        action:
+          'Bound introspection caching to short, security-aware windows ' +
+          '(seconds, not minutes), and key the cache on the token value so ' +
+          'a revocation propagates to all RSes via a fresh introspect on ' +
+          'the next request after expiry.',
+        rationale:
+          'RFC 7662 §4 explicitly warns that caching introspection ' +
+          'responses weakens revocation. For high-value APIs, prefer ' +
+          'short-lived self-contained tokens (JWT with small `exp`) plus ' +
+          'introspection only when freshness matters, or push-based ' +
+          'revocation (token blocklist propagated to RSes).',
+        mitigates: ['introspection-result-caching'],
+      },
+      {
+        action:
+          'Always call the introspection endpoint over TLS and validate ' +
+          'the AS certificate against a pinned trust anchor or the ' +
+          'discovery-document issuer.',
+        mitigates: ['introspection-response-spoofing'],
+      },
+      {
+        action:
+          'Protect the introspection endpoint with authorization per RFC ' +
+          '7662 §2.1 — either client authentication (HTTP Basic, mTLS, ' +
+          'JWT-bearer assertion) OR a separate OAuth 2.0 access token ' +
+          'specifically scoped to introspect. The spec leaves the choice ' +
+          'open; the goal is preventing unauthenticated callers from ' +
+          'querying token validity.',
+        rationale:
+          'RFC 7662 §2.1 motivates this requirement specifically against ' +
+          'token-scanning. Per-RS authentication also gives the AS hooks ' +
+          'for rate-limiting and audit, but those are side benefits, not ' +
+          'the spec\'s stated reason.',
+        mitigates: ['token-scanning'],
+      },
+    ],
+    references: [
+      {
+        label: 'RFC 7662 §2.1 (Introspection Request)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc7662#section-2.1',
+      },
+      {
+        label: 'RFC 7662 §2.2 (Introspection Response)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc7662#section-2.2',
+      },
+      {
+        label: 'RFC 7662 §4 (Security Considerations)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc7662#section-4',
+      },
+    ],
+  },
+
   expires_in: {
     purpose:
       'Token lifetime in seconds, returned alongside the access token. Sets ' +
@@ -822,7 +953,18 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
       {
         action:
           'Set short access-token lifetimes (minutes, not hours); rely on ' +
-          'refresh tokens for renewal. RFC 9700 §2.2.1.',
+          'refresh tokens for renewal. RFC 9700 §4.14 explicitly motivates ' +
+          'this: refresh tokens "allow the authorization server to issue ' +
+          'access tokens with a short lifetime and reduced scope, thus ' +
+          'reducing the potential impact of access token leakage."',
+        mitigates: ['persistent-xss-theft'],
+      },
+      {
+        action:
+          'Pair short lifetime with privilege restriction (RFC 9700 §2.3): ' +
+          'audience-restrict and scope-restrict every access token so a ' +
+          'leak only buys access to one resource\'s narrow API surface, ' +
+          'not the user\'s full token-bearer capability.',
         mitigates: ['persistent-xss-theft'],
       },
       {
@@ -838,8 +980,12 @@ export const OAUTH2_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://datatracker.ietf.org/doc/html/rfc6749#section-5.1',
       },
       {
-        label: 'RFC 9700 §2.2.1 (Access Token Privilege Restriction)',
-        href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-2.2.1',
+        label: 'RFC 9700 §2.3 (Access Token Privilege Restriction)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-2.3',
+      },
+      {
+        label: 'RFC 9700 §4.14 (Refresh Token Protection — short access-token lifetimes)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc9700#section-4.14',
       },
     ],
   },

--- a/frontend/src/protocols/explainers/oid4vci.ts
+++ b/frontend/src/protocols/explainers/oid4vci.ts
@@ -133,13 +133,16 @@ export const OID4VCI_EXPLAINERS: Record<string, ParameterExplainer> = {
 
   tx_code: {
     purpose:
-      'A short user-entered code (typically 4-8 digits) the issuer delivers ' +
-      'to the user out-of-band via a separate channel from the credential ' +
-      'offer (SMS to a known phone, email to a known address, displayed on ' +
-      'a kiosk screen). The wallet prompts the user to type it and forwards ' +
-      'it to /token alongside the pre-authorized code. Adds a second factor ' +
-      '(something the user knows / received separately) that an interceptor ' +
-      'of the offer alone cannot supply.',
+      'A short user-entered code the issuer delivers to the user. ' +
+      'OID4VCI 1.0 §4.1.1 lets the issuer declare `input_mode` ' +
+      '(`numeric` or `text`) and `length`; deployments commonly pick 4–8 ' +
+      'digits but neither bound is in the spec. §13.6.2 RECOMMENDS ' +
+      'delivering it via a separate channel from the credential offer ' +
+      '(SMS to a known phone, email to a known address, kiosk display) ' +
+      '— it is RECOMMENDED, not REQUIRED. The wallet prompts the user ' +
+      'to type it and forwards it to /token alongside the pre-authorized ' +
+      'code. Adds a second factor (something the user knows / received ' +
+      'separately) that an interceptor of the offer alone cannot supply.',
     attacks: [
       {
         id: 'pin-channel-cross-protocol-phishing',
@@ -193,12 +196,14 @@ export const OID4VCI_EXPLAINERS: Record<string, ParameterExplainer> = {
 
   c_nonce: {
     purpose:
-      'Challenge nonce the Credential Issuer returns from /token (and ' +
-      'subsequently from /credential). The wallet MUST include this exact ' +
+      'Challenge nonce the Credential Issuer returns from a dedicated ' +
+      'Nonce Endpoint (OID4VCI 1.0 §7). The wallet MUST include this exact ' +
       'value in the `nonce` claim of the proof JWT it sends with its ' +
-      'credential request. Single-use; consumed on each call. ' +
-      'OIDC `nonce` binds an ID Token to an authentication session; ' +
-      '`c_nonce` binds a proof JWT to a specific issuance request.',
+      'credential request. The issuer decides when to issue a fresh ' +
+      'c_nonce versus reusing one across requests; consumers should treat ' +
+      'each as freshness-bounded. OIDC `nonce` binds an ID Token to an ' +
+      'authentication session; `c_nonce` binds a proof JWT to a specific ' +
+      'issuance request.',
     attacks: [
       {
         id: 'proof-jwt-replay',
@@ -222,24 +227,32 @@ export const OID4VCI_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'Issuer MUST consume `c_nonce` on use and reject replays. ' +
-          'Track consumed nonces for the validity window.',
+          'Issuer SHOULD treat `c_nonce` values as freshness-bounded and ' +
+          'reject replays past their validity window. The spec leaves ' +
+          'reuse-vs-rotation to issuer discretion (§7), but tracking ' +
+          'consumed nonces inside the validity window is the cleanest ' +
+          'replay defence.',
         mitigates: ['proof-jwt-replay'],
       },
       {
         action:
-          'Wallet MUST treat each c_nonce as single-use and refresh it ' +
-          'from the next response before issuing a new proof.',
+          'Wallet treats each c_nonce as freshness-bounded and refreshes ' +
+          'it from the next Nonce Endpoint response before issuing a new ' +
+          'proof if the issuer has invalidated the prior one.',
         mitigates: ['proof-jwt-replay'],
       },
     ],
     references: [
       {
-        label: 'OID4VCI 1.0 §7.2 (Nonce Response — c_nonce)',
+        label: 'OID4VCI 1.0 §7 (Nonce Endpoint)',
+        href: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-nonce-endpoint',
+      },
+      {
+        label: 'OID4VCI 1.0 §7.2 (Nonce Response)',
         href: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-nonce-response',
       },
       {
-        label: 'OID4VCI 1.0 §13.6.1 (Replay Prevention)',
+        label: 'OID4VCI 1.0 §13.6 (Replay Prevention)',
         href: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-replay-prevention',
       },
     ],
@@ -247,13 +260,15 @@ export const OID4VCI_EXPLAINERS: Record<string, ParameterExplainer> = {
 
   proof: {
     purpose:
-      'A wallet-signed JWT (or similar) that proves the wallet controls the ' +
-      'private key the issued credential will be bound to. Sent on the ' +
-      'credential request. JWT MUST contain header `typ=' +
-      'openid4vci-proof+jwt`, payload claims `iss` (wallet/client ID), ' +
-      '`aud` (credential issuer identifier), `iat`, `exp`, `nonce` (equal ' +
-      'to current `c_nonce`), and `cnf.jwk` (the wallet\'s public key the ' +
-      'credential will be bound to).',
+      'A wallet-signed JWT (or similar) that proves the wallet controls ' +
+      'the private key the issued credential will be bound to. Sent on ' +
+      'the credential request. Per OID4VCI 1.0 Appendix F.1 (jwt proof ' +
+      'type): JWT MUST contain header `typ=openid4vci-proof+jwt` and the ' +
+      'wallet\'s public key in the JWS header as `jwk`, `kid`, or `x5c`. ' +
+      'Payload MUST contain `aud` (credential issuer identifier), `iat`, ' +
+      'and `nonce` (equal to current `c_nonce`); `iss` is REQUIRED only ' +
+      'when the wallet is a registered OAuth client. The issuer copies ' +
+      'the proof key into the issued credential as `cnf` (RFC 7800).',
     attacks: [
       {
         id: 'credential-lift-and-replay',
@@ -284,8 +299,10 @@ export const OID4VCI_EXPLAINERS: Record<string, ParameterExplainer> = {
       },
       {
         action:
-          'Issuer MUST verify the proof JWT signature against the embedded ' +
-          '`cnf.jwk` and bind that key into the issued credential.',
+          'Issuer MUST verify the proof JWT signature against the key in ' +
+          'the JWS header (`jwk` / `kid` / `x5c`), then copy that key into ' +
+          'the issued credential as the `cnf` claim (RFC 7800) so ' +
+          'verifiers can later check holder binding.',
         mitigates: ['credential-lift-and-replay'],
       },
       {
@@ -503,11 +520,15 @@ export const OID4VCI_EXPLAINERS: Record<string, ParameterExplainer> = {
 
   format: {
     purpose:
-      'Identifies the credential format being issued or presented. Common ' +
-      'values: `dc+sd-jwt` (SD-JWT-VC, selective disclosure JWT), ' +
-      '`jwt_vc_json` (JWT-encoded W3C VC), `jwt_vc_json-ld` (JWT-encoded ' +
-      'JSON-LD VC), `ldp_vc` (Linked Data Proofs VC), `mso_mdoc` ' +
-      '(ISO 18013-5 mobile drivers license).',
+      'Identifies a credential format. In OID4VCI 1.0 it appears inside ' +
+      'each Credential Configuration in the issuer\'s metadata (Appendix ' +
+      'A) — wallets reference a configuration via ' +
+      '`credential_configuration_id` rather than passing `format` ' +
+      'directly on the credential request. Common values: `dc+sd-jwt` ' +
+      '(SD-JWT-VC, selective disclosure JWT), `jwt_vc_json` (JWT-encoded ' +
+      'W3C VC), `jwt_vc_json-ld` (JWT-encoded JSON-LD VC), `ldp_vc` ' +
+      '(Linked Data Proofs VC), `mso_mdoc` (ISO 18013-5 mobile drivers ' +
+      'license).',
     attacks: [
       {
         id: 'format-confusion-bypass',
@@ -544,8 +565,12 @@ export const OID4VCI_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'OID4VCI 1.0 §11.4 (Credential Format Considerations)',
-        href: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html',
+        label: 'OID4VCI 1.0 Appendix A (Credential Format Profiles)',
+        href: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-format-profiles',
+      },
+      {
+        label: 'OID4VCI 1.0 §13 (Security Considerations)',
+        href: 'https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-security-considerations',
       },
     ],
   },

--- a/frontend/src/protocols/explainers/oid4vp.ts
+++ b/frontend/src/protocols/explainers/oid4vp.ts
@@ -234,8 +234,10 @@ export const OID4VP_EXPLAINERS: Record<string, ParameterExplainer> = {
       'Tells the wallet how to deliver the authorization response. ' +
       '`direct_post` POSTs `vp_token` + `state` as form parameters to ' +
       '`response_uri`. `direct_post.jwt` POSTs an encrypted JWE wrapping a ' +
-      'signed inner JWT. Legacy `query` and `fragment` modes return the ' +
-      'response in the redirect URL.',
+      'signed inner JWT. `dc_api` / `dc_api.jwt` (added in OID4VP 1.0 ' +
+      'final) deliver the response via the W3C Digital Credentials browser ' +
+      'API instead of an HTTP POST. Legacy `query` and `fragment` modes ' +
+      'return the response in the redirect URL.',
     attacks: [
       {
         id: 'fragment-leak-response-mode',

--- a/frontend/src/protocols/explainers/oidc.ts
+++ b/frontend/src/protocols/explainers/oidc.ts
@@ -239,7 +239,7 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'OpenID Connect Core 1.0 §3.2.2.10 (at_hash)',
+        label: 'OpenID Connect Core 1.0 §3.2.2.9 (Implicit Flow — Access Token Validation, at_hash check)',
         href: 'https://openid.net/specs/openid-connect-core-1_0.html#ImplicitTokenValidation',
       },
       {
@@ -286,9 +286,11 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'Compute SHA-256(code), take the left-half, base64url-encode, ' +
-          'and compare to the `c_hash` claim. Reject mismatches before ' +
-          'exchanging the code at /token.',
+          'Compute hash(code) using the hash function tied to the ID ' +
+          'Token\'s `alg` (RS256/ES256/HS256 → SHA-256, RS384/ES384 → ' +
+          'SHA-384, RS512/ES512 → SHA-512), take the left-half, base64url-' +
+          'encode, and compare to the `c_hash` claim. Reject mismatches ' +
+          'before exchanging the code at /token.',
         mitigates: ['code-substitution-hybrid'],
       },
       {
@@ -325,11 +327,14 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
 
   azp: {
     purpose:
-      'Authorized Party claim in the ID Token. When the token\'s `aud` ' +
-      'contains multiple audiences (or one audience that is not the ' +
-      'requesting client), `azp` MUST equal the client_id of the party the ' +
-      'token was actually issued to. Lets a recipient distinguish "I am the ' +
-      'audience" from "I am the audience the token was minted for".',
+      'Authorized Party claim in the ID Token. OIDC Core §2 defines `azp` ' +
+      'as OPTIONAL — it appears in practice only when extensions beyond ' +
+      'base OIDC are in use, and the spec advises implementations not ' +
+      'using such extensions to "not use azp and to ignore it when it does ' +
+      'occur". §3.1.3.7 step 4 says that if `azp` is present, the client ' +
+      'SHOULD verify it equals the receiver\'s client_id. Lets a recipient ' +
+      'distinguish "I am in the audience" from "I am the audience the ' +
+      'token was minted for" — but only when the deployment populates it.',
     attacks: [
       {
         id: 'cross-client-id-token-reuse',
@@ -340,9 +345,10 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
           'backend microservices). Mallory operates Service A and persuades ' +
           'Alice to sign in. Mallory takes the resulting ID Token and ' +
           'replays it to Service B, which sees `aud` containing its own ' +
-          'client_id and accepts the login. Without `azp` validation, ' +
-          'Service B has no way to know the token was originally minted ' +
-          'for Service A.',
+          'client_id and accepts the login. The base OIDC defence here is ' +
+          'the §3.1.3.7 step 3 check (`client_id ∈ aud`) — but that check ' +
+          'still passes for Service B. `azp`, when populated, lets Service ' +
+          'B distinguish "originally minted for Service A".',
         impact:
           'Cross-service identity bleed in shared-audience configurations.',
       },
@@ -350,22 +356,29 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'Recipients in multi-audience tokens MUST validate `azp == this ' +
-          'client_id` in addition to `client_id ∈ aud`.',
+          'When `azp` is present, validate `azp == this client_id` per ' +
+          'OIDC Core §3.1.3.7 step 4 (SHOULD). Operationally, deployments ' +
+          'that issue multi-audience ID Tokens often elevate this from ' +
+          'SHOULD to MUST as part of their security profile (e.g. several ' +
+          'IdPs unconditionally emit `azp`).',
         mitigates: ['cross-client-id-token-reuse'],
       },
       {
         action:
           'Prefer single-audience tokens — issue a separate ID Token per ' +
           'recipient instead of "saving tokens" by reusing one across ' +
-          'services.',
+          'services. Removes the need to rely on `azp` at all.',
         mitigates: ['cross-client-id-token-reuse'],
       },
     ],
     references: [
       {
-        label: 'OpenID Connect Core 1.0 §2 (azp claim)',
+        label: 'OpenID Connect Core 1.0 §2 (ID Token — azp claim)',
         href: 'https://openid.net/specs/openid-connect-core-1_0.html#IDToken',
+      },
+      {
+        label: 'OpenID Connect Core §3.1.3.7 (ID Token Validation, steps 4–5 — azp validation)',
+        href: 'https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation',
       },
       {
         label: 'OpenID Connect Core §16.11 (Token Substitution)',
@@ -462,9 +475,9 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
           'SaaS apps still vulnerable per a 2025 study. The OPs vary ' +
           'wildly in how they set this claim: some always set true; some ' +
           'never set the field; some let users in their tenant set ' +
-          'arbitrary unverified email values. The OIDC spec itself says: ' +
-          '"ultimately it is unsafe to rely on the Issuer to verify the ' +
-          'email of a user."',
+          'arbitrary unverified email values. OIDC Core §5.7 explicitly ' +
+          'warns that `email` is not stable or unique and that RPs should ' +
+          'not key user accounts on it.',
         impact:
           'Full account takeover. MFA does not help, EDR does not help, ' +
           'the attack uses the federation exactly as designed.',
@@ -503,7 +516,7 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://www.semperis.com/blog/noauth-abuse-alert-full-account-takeover/',
       },
       {
-        label: 'OpenID Connect Core 1.0 §5.7 (Claim Stability)',
+        label: 'OpenID Connect Core 1.0 §5.7 (Claim Stability and Uniqueness)',
         href: 'https://openid.net/specs/openid-connect-core-1_0.html#ClaimStability',
       },
     ],
@@ -659,7 +672,7 @@ export const OIDC_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'OpenID Connect Core 1.0 §5.7 (Claim Stability)',
+        label: 'OpenID Connect Core 1.0 §5.7 (Claim Stability and Uniqueness)',
         href: 'https://openid.net/specs/openid-connect-core-1_0.html#ClaimStability',
       },
       {

--- a/frontend/src/protocols/explainers/saml.ts
+++ b/frontend/src/protocols/explainers/saml.ts
@@ -196,11 +196,13 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
 
   RelayState: {
     purpose:
-      'Opaque value (max 80 bytes) carried alongside SAMLRequest / ' +
-      'SAMLResponse to preserve SP application state across the SSO round ' +
-      'trip. Common uses: original target URL the user wanted before being ' +
-      'redirected to login, session correlation tokens, simple deep-link ' +
-      'parameters.',
+      'Opaque value carried alongside SAMLRequest / SAMLResponse to ' +
+      'preserve SP application state across the SSO round trip. The 80-' +
+      'byte cap applies only when carried over the HTTP-Redirect (Bindings ' +
+      '§3.4.3) or HTTP-POST (§3.5.3) bindings; other transport bindings do ' +
+      'not impose the same limit. Common uses: the original target URL the ' +
+      'user wanted before being redirected to login, session correlation ' +
+      'tokens, simple deep-link parameters.',
     attacks: [
       {
         id: 'relaystate-open-redirect',
@@ -248,6 +250,10 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
       {
         label: 'Snyk — Common SAML vulnerabilities',
         href: 'https://snyk.io/blog/common-saml-vulnerabilities-remediate/',
+      },
+      {
+        label: 'SAML 2.0 Bindings §3.4.3 / §3.5.3 (RelayState in Redirect / POST)',
+        href: 'https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf',
       },
       {
         label: 'SAML 2.0 Security and Privacy Considerations §7 (Profile-Specific Threats / Bindings)',
@@ -515,7 +521,7 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://duo.com/blog/duo-finds-saml-vulnerabilities-affecting-multiple-implementations',
       },
       {
-        label: 'SAML 2.0 Core §2.2 (NameIDType)',
+        label: 'SAML 2.0 Core §2.2.3 (NameIDType)',
         href: 'http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf',
       },
       {
@@ -579,7 +585,7 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SAML 2.0 Core §2.5 (Conditions)',
+        label: 'SAML 2.0 Core §2.5.1 (Conditions)',
         href: 'http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf',
       },
       {
@@ -692,7 +698,7 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf',
       },
       {
-        label: 'SAML 2.0 Profiles §4.1.4.5 (POST Binding Validation)',
+        label: 'SAML 2.0 Profiles §4.1.4.3 (POST-Specific Processing Rules)',
         href: 'http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf',
       },
       {
@@ -706,10 +712,13 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
     purpose:
       'The URL at which the SP receives SAML Responses. Sent on the ' +
       'AuthnRequest by the SP and pre-registered in the SP\'s metadata. ' +
-      'The IdP MUST validate it matches a registered ACS URL before ' +
-      'sending the Response. SAML\'s analogue of OAuth\'s `redirect_uri` ' +
-      '— the same exact-match story, same attack class when matching is ' +
-      'loose.',
+      'Per Core §3.4.1, the SP can identify its ACS by either the URL ' +
+      'value (`AssertionConsumerServiceURL`) or by index ' +
+      '(`AssertionConsumerServiceIndex`) into the registered ACS list. ' +
+      'The IdP MUST validate the value/index resolves to a registered ACS ' +
+      'before sending the Response. SAML\'s analogue of OAuth\'s ' +
+      '`redirect_uri` — the same exact-match story, same attack class when ' +
+      'matching is loose.',
     attacks: [
       {
         id: 'response-redirection-via-acs',
@@ -821,7 +830,7 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SAML 2.0 Metadata §2.3 (entityID)',
+        label: 'SAML 2.0 Metadata §2.3.2.1 (EntityDescriptor — entityID, max 1024 chars)',
         href: 'http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf',
       },
       {
@@ -885,7 +894,7 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SAML 2.0 Metadata §2.4.2 (WantAssertionsSigned)',
+        label: 'SAML 2.0 Metadata §2.4.4 (SPSSODescriptor — WantAssertionsSigned)',
         href: 'http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf',
       },
       {
@@ -905,7 +914,10 @@ export const SAML_EXPLAINERS: Record<string, ParameterExplainer> = {
       'the IdP should use in the resulting Assertion. Common values: ' +
       '`urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` (stable ' +
       'pseudonym per SP), `transient` (single-session pseudonym), ' +
-      '`emailAddress`, `unspecified`.',
+      '`emailAddress`, `unspecified`. The `AllowCreate` attribute (Core ' +
+      '§3.4.1.1, default `false`) governs whether the IdP may create a new ' +
+      'identifier for this user/format pair if one does not already exist; ' +
+      'SPs that need just-in-time provisioning must set it to `true`.',
     attacks: [
       {
         id: 'nameidpolicy-cross-tenant-confusion',

--- a/frontend/src/protocols/explainers/scim.ts
+++ b/frontend/src/protocols/explainers/scim.ts
@@ -208,7 +208,9 @@ export const SCIM_EXPLAINERS: Record<string, ParameterExplainer> = {
       'PATCH operation type: `add` (insert/append), `replace` (overwrite), ' +
       '`remove` (delete). One of three operations applied at a JSON ' +
       'Pointer `path` on a target resource. SCIM PATCH wraps these in a ' +
-      'PatchOp document with multiple operations applied transactionally.',
+      'PatchOp document with multiple operations applied in sequence per ' +
+      'RFC 7644 §3.5.2 (servers stop on the first error; whether prior ' +
+      'successful operations roll back is implementation-defined).',
     attacks: [
       {
         id: 'op-attribute-escalation',
@@ -501,7 +503,7 @@ export const SCIM_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
   },
 
-  active: {
+  'scim:active': {
     purpose:
       'Boolean attribute on a User resource indicating whether the account ' +
       'is enabled. The IdP\'s SCIM client typically toggles `active=false` ' +
@@ -537,9 +539,13 @@ export const SCIM_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'SCIM `active=false` MUST trigger session/token revocation — ' +
-          'not just a database flag flip. Refresh tokens, API keys, ' +
-          'downstream service sessions all need invalidation.',
+          'Treat SCIM `active=false` as a trigger for full session/token ' +
+          'revocation across every credential surface — not just a ' +
+          'database flag flip. Refresh tokens, API keys, downstream ' +
+          'service sessions all need invalidation. SCIM is a provisioning ' +
+          'protocol; session revocation is the SP\'s responsibility outside ' +
+          'the SCIM RFCs, so this is operational hardening rather than a ' +
+          'spec-normative MUST.',
         mitigates: ['deactivation-session-lag'],
       },
       {
@@ -638,8 +644,8 @@ export const SCIM_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'RFC 7644 §3.7 (Bulk Operations)',
-        href: 'https://datatracker.ietf.org/doc/html/rfc7644#section-3.7',
+        label: 'RFC 7644 §3.7.2 (Bulk Operation Request and Response Structure)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc7644#section-3.7.2',
       },
       {
         label: 'SCIM-SDK BulkId Reference Resolving (cycle detection)',
@@ -705,8 +711,8 @@ export const SCIM_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://datatracker.ietf.org/doc/html/rfc7643#section-4.2',
       },
       {
-        label: 'SOC Prime — SCIM PATCH escalation (related class)',
-        href: 'https://socprime.com/blog/cve-2025-41115-vulnerability/',
+        label: 'RFC 7644 §3.5.2 (Modifying with PATCH)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2',
       },
       {
         label: 'RFC 7644 §7 (Security Considerations)',
@@ -775,8 +781,8 @@ export const SCIM_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'RFC 7644 §3.9 (attributes / excludedAttributes)',
-        href: 'https://datatracker.ietf.org/doc/html/rfc7644#section-3.9',
+        label: 'RFC 7644 §3.4.2.5 (attributes and excludedAttributes)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.5',
       },
       {
         label: 'RFC 7644 §7 (Security Considerations)',

--- a/frontend/src/protocols/explainers/spiffe.ts
+++ b/frontend/src/protocols/explainers/spiffe.ts
@@ -23,15 +23,14 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         id: 'multi-uri-san-smuggling',
         name: 'Multi-URI-SAN smuggling',
         scenario:
-          'A certificate may technically have multiple URI SANs; SPIFFE ' +
-          'spec says exactly one MUST be a SPIFFE ID, but lax parsers ' +
-          'accept the first match anywhere. Mallory obtains a legitimate ' +
-          'certificate for some innocuous workload, but at issuance she ' +
-          'gets the CA to include both her real SPIFFE ID and a higher-' +
-          'privilege one she wants to impersonate (CA hardening prevents ' +
-          'this in SPIRE itself, but bridge implementations and home-grown ' +
-          'CAs are looser). The verifier reads "the first URI SAN" and ' +
-          'gets her chosen target.',
+          'X.509-SVID §2 says an SVID MUST contain exactly one URI SAN, ' +
+          'and §5.2 mandates verifiers reject any cert with more than one. ' +
+          'Lax verifiers — typically bridge implementations or home-grown ' +
+          'CAs that treat URI SAN as just another SAN — read the first ' +
+          'URI SAN they find. Mallory persuades such a CA to issue a cert ' +
+          'with both her own SPIFFE ID and a higher-privilege impersonation ' +
+          'target. A verifier that reads "the first URI SAN" picks ' +
+          'whichever the CA emitted first.',
         impact:
           'Identity confusion → unauthorized service-to-service access.',
       },
@@ -49,8 +48,10 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'Reject certificates with more than one SPIFFE-shaped URI SAN. ' +
-          'SPIFFE spec MANDATES exactly one URI SAN must be a SPIFFE ID.',
+          'Reject any certificate with more than one URI SAN, period. ' +
+          'X.509-SVID §5.2 (Leaf Validation) is explicit: an SVID MUST ' +
+          'contain exactly one URI SAN; verifiers MUST reject if more ' +
+          'than one is present.',
         mitigates: ['multi-uri-san-smuggling'],
       },
       {
@@ -72,12 +73,12 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md',
       },
       {
-        label: 'SPIFFE X.509-SVID §2 (URI SAN)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md',
+        label: 'SPIFFE X.509-SVID §2 (SPIFFE ID)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#2-spiffe-id',
       },
       {
-        label: 'SPIFFE X.509-SVID §4 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#4-security-considerations',
+        label: 'SPIFFE X.509-SVID §5.2 (Leaf Validation)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#52-leaf-validation',
       },
     ],
   },
@@ -131,8 +132,8 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md',
       },
       {
-        label: 'SPIFFE Trust Domain and Bundle §5 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#5-security-considerations',
+        label: 'SPIFFE Trust Domain and Bundle §6 (Security Considerations)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#6-security-considerations',
       },
     ],
   },
@@ -228,8 +229,8 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://github.com/spiffe/spire/tree/main/pkg/agent/plugin/workloadattestor',
       },
       {
-        label: 'SPIFFE Workload API §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#6-security-considerations',
+        label: 'SPIFFE Workload API §4.1 (Identifying the Caller)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#41-identifying-the-caller',
       },
     ],
   },
@@ -278,10 +279,6 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         label: 'SPIRE Registering Workloads — parent_id',
         href: 'https://spiffe.io/docs/latest/deploying/registering/',
       },
-      {
-        label: 'SPIFFE Workload API §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#6-security-considerations',
-      },
     ],
   },
 
@@ -328,12 +325,12 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SPIFFE X.509-SVID §3 (Issuance)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md',
+        label: 'SPIFFE X.509-SVID §3 (Hierarchy)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#3-hierarchy',
       },
       {
-        label: 'SPIFFE X.509-SVID §4 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#4-security-considerations',
+        label: 'SPIFFE X.509-SVID §5 (Validation)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#5-validation',
       },
     ],
   },
@@ -341,22 +338,23 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
   uri_san: {
     purpose:
       'The URI Subject Alternative Name in an X.509-SVID where the SPIFFE ' +
-      'ID is encoded. SPIFFE spec: exactly ONE URI SAN MUST be a valid ' +
-      'SPIFFE ID; certs MAY have other (non-SPIFFE) URI SANs but the ' +
-      'verifier MUST identify the SPIFFE one as the authoritative identity.',
+      'ID is encoded. X.509-SVID §2 mandates that an SVID MUST contain ' +
+      'exactly one URI SAN, and that URI SAN MUST be the SPIFFE ID. ' +
+      '§5.2 (Leaf Validation) requires verifiers to reject any cert with ' +
+      'more than one URI SAN.',
     attacks: [
       {
         id: 'multi-uri-san-attack',
         name: 'Multi-URI-SAN attack',
         scenario:
           'A misbehaving CA (or a SPIRE clone bridging to legacy PKI) ' +
-          'issues a cert with two URI SANs: ' +
+          'issues a cert with two URI SANs in violation of X.509-SVID §2: ' +
           '`spiffe://domain/innocent-service` (the legitimate one Mallory ' +
           'is registered for) and `spiffe://domain/admin-service` (her ' +
-          'target). A naive verifier that iterates URI SANs and stops at ' +
-          'the first SPIFFE-shaped match returns whichever comes first — ' +
-          'and Mallory crafts the cert order to put the privileged ID ' +
-          'first.',
+          'target). A non-conforming verifier that iterates URI SANs and ' +
+          'returns the first one — instead of rejecting the cert outright ' +
+          'as §5.2 requires — picks whichever the CA emitted first, and ' +
+          'Mallory crafts the cert order to put the privileged ID first.',
         impact:
           'Identity confusion in the verifier.',
       },
@@ -364,25 +362,27 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'Count SPIFFE-shaped URI SANs; reject certs with more than one.',
+          'Reject any cert with more than one URI SAN, per X.509-SVID §5.2 ' +
+          'Leaf Validation. Do not "pick the first SPIFFE-shaped one" — ' +
+          'the spec forbids that path entirely.',
         mitigates: ['multi-uri-san-attack'],
       },
       {
         action:
           'Use SPIFFE\'s reference parsing libraries (go-spiffe, ' +
-          'spiffe-rs) which enforce the single-SPIFFE-SAN rule. Do NOT ' +
-          'hand-roll certificate-to-SPIFFE-ID parsing.',
+          'spiffe-rs) which enforce the §5.2 rule. Do NOT hand-roll ' +
+          'certificate-to-SPIFFE-ID parsing.',
         mitigates: ['multi-uri-san-attack'],
       },
     ],
     references: [
       {
-        label: 'SPIFFE X.509-SVID §2 (URI SAN constraints)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md',
+        label: 'SPIFFE X.509-SVID §2 (SPIFFE ID)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#2-spiffe-id',
       },
       {
-        label: 'SPIFFE X.509-SVID §4 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#4-security-considerations',
+        label: 'SPIFFE X.509-SVID §5.2 (Leaf Validation)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#52-leaf-validation',
       },
     ],
   },
@@ -446,12 +446,12 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SPIFFE Trust Domain and Bundle §4',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md',
+        label: 'SPIFFE Trust Domain and Bundle §4 (Bundle Format)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#4-spiffe-bundle-format',
       },
       {
-        label: 'SPIFFE Trust Domain and Bundle §5 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#5-security-considerations',
+        label: 'SPIFFE Trust Domain and Bundle §6 (Security Considerations)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#6-security-considerations',
       },
     ],
   },
@@ -517,8 +517,8 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md',
       },
       {
-        label: 'SPIFFE Federation §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#6-security-considerations',
+        label: 'SPIFFE Federation §7 (Security Considerations)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#7-security-considerations',
       },
     ],
   },
@@ -576,12 +576,12 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SPIFFE Federation §5 (Bundle Endpoint Distribution)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md',
+        label: 'SPIFFE Federation §5 (Serving and Consuming a SPIFFE Bundle Endpoint)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#5-serving-and-consuming-a-spiffe-bundle-endpoint',
       },
       {
-        label: 'SPIFFE Federation §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#6-security-considerations',
+        label: 'SPIFFE Federation §7 (Security Considerations)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#7-security-considerations',
       },
     ],
   },
@@ -636,11 +636,11 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     references: [
       {
         label: 'SPIFFE Federation §5.2 (Endpoint Profiles)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#52-endpoint-profiles',
       },
       {
-        label: 'SPIFFE Federation §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#6-security-considerations',
+        label: 'SPIFFE Federation §7 (Security Considerations)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#7-security-considerations',
       },
     ],
   },
@@ -723,10 +723,6 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         label: 'SPIRE Node Attestation',
         href: 'https://spiffe.io/docs/latest/deploying/configuring/',
       },
-      {
-        label: 'SPIFFE Workload API §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#6-security-considerations',
-      },
     ],
   },
 
@@ -779,10 +775,6 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
       {
         label: 'SPIRE Server — Join Token attestor',
         href: 'https://github.com/spiffe/spire/blob/main/doc/plugin_server_nodeattestor_jointoken.md',
-      },
-      {
-        label: 'SPIFFE Workload API §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#6-security-considerations',
       },
     ],
   },
@@ -846,12 +838,12 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SPIFFE JWT-SVID §3 (audience claim)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md',
+        label: 'SPIFFE JWT-SVID §3.2 (Audience)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#32-audience',
       },
       {
-        label: 'SPIFFE JWT-SVID §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#6-security-considerations',
+        label: 'SPIFFE JWT-SVID §7.2 (Audience — replay protection)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#72-audience',
       },
     ],
   },
@@ -910,10 +902,6 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
         label: 'SPIRE Concepts — Agent SVID lifecycle',
         href: 'https://spiffe.io/docs/latest/spire-about/spire-concepts/',
       },
-      {
-        label: 'SPIFFE Workload API §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#6-security-considerations',
-      },
     ],
   },
 
@@ -946,8 +934,10 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'Agent MUST re-attest on every Workload API call — do not cache ' +
-          'the attestation across calls.',
+          'Re-attest on every Workload API call — do not cache attestation ' +
+          'across calls. SPIRE Agent does this by default; the spec ' +
+          'delegates attestation specifics to implementations, so this is ' +
+          'an implementation requirement rather than a spec MUST.',
         mitigates: ['pid-reuse-race'],
       },
       {
@@ -965,12 +955,199 @@ export const SPIFFE_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'SPIFFE Workload API §3 (Process Identity Verification)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md',
+        label: 'SPIFFE Workload API §3 (Service Definition)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#3-service-definition',
       },
       {
-        label: 'SPIFFE Workload API §6 (Security Considerations)',
-        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#6-security-considerations',
+        label: 'SPIFFE Workload API §4.1 (Identifying the Caller)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#41-identifying-the-caller',
+      },
+    ],
+  },
+
+  'spiffe:format': {
+    purpose:
+      'Wire format of a federated trust-bundle endpoint response — a JWKS ' +
+      '(RFC 7517) document where each entry with `use=x509-svid` carries ' +
+      'an `x5c` parameter holding exactly one base64-DER CA certificate ' +
+      '(SHOULD be self-signed, per X.509-SVID §6.1). The local SPIRE ' +
+      'Server unions these certificates to form the foreign trust ' +
+      'domain\'s X.509 CA bundle.',
+    attacks: [
+      {
+        id: 'rogue-x5c-injection',
+        name: 'Rogue CA injection via attacker-controlled `x5c`',
+        scenario:
+          'The bundle endpoint is reached without proper TLS validation ' +
+          '(missing `endpoint_spiffe_id` check on `https_spiffe`, or wrong ' +
+          'CA pinning on `https_web`). Mallory MITMs the response and ' +
+          'replaces the `x5c` chain with her own CA. The local SPIRE Server ' +
+          'imports the rogue CA into the federated bundle, after which any ' +
+          'workload presenting an SVID signed by Mallory\'s CA is treated ' +
+          'as a legitimate member of the foreign trust domain.',
+        impact:
+          'Attacker mints arbitrary identities in any federated trust ' +
+          'domain — full cross-domain workload impersonation.',
+      },
+      {
+        id: 'jwks-format-drift',
+        name: 'Format-drift attacks (non-conformant JWKS body)',
+        scenario:
+          'X.509-SVID §6.2 requires consumers to ignore any `use=x509-svid` ' +
+          'JWK entry whose `x5c` is missing or empty, and to take only the ' +
+          'first value when multiple are present. A misconfigured (or ' +
+          'compromised) endpoint can serve `use=x509-svid` entries with no ' +
+          '`x5c`, or PEM, or an empty `keys: []`. A consumer that skips ' +
+          'this filtering and just takes whatever it parsed either fails ' +
+          'open (clears the X509-SVID trust bundle, then accepts ' +
+          'anything) or silently retains the previous bundle indefinitely ' +
+          'past `spiffe_refresh_hint`.',
+        impact:
+          'Either no trust enforcement (fail-open) or stale trust ' +
+          'anchors that survive intentional revocation.',
+      },
+    ],
+    mitigations: [
+      {
+        action:
+          'Validate the bundle endpoint TLS chain *before* parsing the ' +
+          'body. For `https_spiffe`, require the endpoint\'s SPIFFE ID to ' +
+          'match the configured `endpoint_spiffe_id`. For `https_web`, pin ' +
+          'the Web-PKI CA used to authenticate the bundle URL.',
+        mitigates: ['rogue-x5c-injection'],
+      },
+      {
+        action:
+          'Strictly parse JWKS: require `Content-Type: application/json`, ' +
+          'reject responses without a non-empty `keys[]` containing ' +
+          '`x5c` chains, and validate each chain up to a known root before ' +
+          'trusting it.',
+        mitigates: ['rogue-x5c-injection', 'jwks-format-drift'],
+      },
+      {
+        action:
+          'On bundle-fetch failure or schema mismatch, retain the last-' +
+          'known-good bundle and alert — do not clear trust anchors. The ' +
+          'spec recommends caching and retrying at the next interval. ' +
+          'Honour `spiffe_refresh_hint` (Trust Domain §4.1.2) for cache ' +
+          'lifetime, and cap maximum age locally so stale bundles cannot ' +
+          'persist forever — the cap is operational hardening, not a ' +
+          'spec requirement.',
+        mitigates: ['jwks-format-drift'],
+      },
+    ],
+    references: [
+      {
+        label: 'SPIFFE Trust Domain and Bundle §4 (Bundle Format)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#4-spiffe-bundle-format',
+      },
+      {
+        label: 'SPIFFE Federation §5.2 (Endpoint Profiles)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#52-endpoint-profiles',
+      },
+      {
+        label: 'SPIFFE X.509-SVID §6.1 (Publishing SPIFFE Bundle Elements)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#61-publishing-spiffe-bundle-elements',
+      },
+      {
+        label: 'SPIFFE X.509-SVID §6.2 (Consuming a SPIFFE Bundle)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#62-consuming-a-spiffe-bundle',
+      },
+      {
+        label: 'RFC 7517 (JSON Web Key)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc7517',
+      },
+    ],
+  },
+
+  'spiffe:issuer': {
+    purpose:
+      'The signing CA that issued an X.509-SVID — typically SPIRE\'s ' +
+      'intermediate CA chained under the trust-domain root. The verifier ' +
+      'uses this together with the trust bundle to decide whether the ' +
+      'presented SVID is a legitimate member of the trust domain.',
+    attacks: [
+      {
+        id: 'intermediate-ca-compromise',
+        name: 'Signing-CA compromise mints arbitrary SVIDs',
+        scenario:
+          'SPIRE Server is configured with the `disk` KeyManager (one of ' +
+          'the default options) so the intermediate CA\'s private key sits ' +
+          'in a file on the host, and the operator has overridden the ' +
+          'default 24h CA TTL to a longer period for "stability." A host ' +
+          'compromise (admin credential leak, container escape, backup ' +
+          'exfiltration) hands Mallory the signing key. She mints SVIDs ' +
+          'for `spiffe://trust-domain/admin/anything` offline, and any ' +
+          'verifier validating chain-to-trust-bundle accepts them as ' +
+          'legitimate.',
+        impact:
+          'Trust-domain-wide impersonation. Until the intermediate is ' +
+          'rotated and the old key removed from the trust bundle, every ' +
+          'workload in the domain is impersonable.',
+      },
+      {
+        id: 'chain-validation-skipped',
+        name: 'Verifier accepts SVID without validating issuer chain',
+        scenario:
+          'Verifier code extracts the SPIFFE ID from the SVID\'s URI SAN ' +
+          'and authorises on that, but does not validate the X.509 chain ' +
+          'up to a CA in the trust bundle. Attacker presents a self-signed ' +
+          'cert, or a cert signed by an unrelated CA, with a URI SAN of ' +
+          'the target SPIFFE ID. Verifier honours the identity.',
+        impact:
+          'No cryptographic binding between identity claim and trust ' +
+          'domain — anyone can claim any SPIFFE ID.',
+      },
+    ],
+    mitigations: [
+      {
+        action:
+          'Hold the signing key in a managed key store via SPIRE\'s ' +
+          'KeyManager plugin: `aws_kms`, `gcp_kms`, or `azure_key_vault` ' +
+          '(rather than the `disk` or `memory` defaults). Separately, ' +
+          'consider chaining SPIRE\'s CA under an external root via the ' +
+          'UpstreamAuthority plugin (`vault`, `awspca`, `cert-manager`). ' +
+          'Keep CA TTL at or below SPIRE\'s 24h default and monitor for ' +
+          'SVID-issuance anomalies (unexpected SPIFFE IDs, off-hours ' +
+          'minting).',
+        rationale:
+          'KeyManager controls *where the private key lives*; ' +
+          'UpstreamAuthority controls *what root signs SPIRE\'s ' +
+          'intermediate*. Conflating them is a common configuration error.',
+        mitigates: ['intermediate-ca-compromise'],
+      },
+      {
+        action:
+          'Verifiers MUST validate the full X.509 chain from the SVID up ' +
+          'to a CA present in the local or federated trust bundle BEFORE ' +
+          'authorising on the URI SAN. Reject any SVID whose chain does ' +
+          'not terminate at a trusted root.',
+        mitigates: ['chain-validation-skipped', 'intermediate-ca-compromise'],
+      },
+      {
+        action:
+          'Keep SVID lifetimes short (default `default_x509_svid_ttl=1h` ' +
+          'in SPIRE) so a compromised intermediate has a bounded blast ' +
+          'radius after rotation — old SVIDs naturally expire.',
+        mitigates: ['intermediate-ca-compromise'],
+      },
+    ],
+    references: [
+      {
+        label: 'SPIFFE X.509-SVID §5 (Validation)',
+        href: 'https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#5-validation',
+      },
+      {
+        label: 'SPIRE KeyManager — AWS KMS plugin',
+        href: 'https://github.com/spiffe/spire/blob/main/doc/plugin_server_keymanager_aws_kms.md',
+      },
+      {
+        label: 'SPIRE UpstreamAuthority configuration',
+        href: 'https://spiffe.io/docs/latest/deploying/configuring/#configuring-which-trust-root--upstream-authority-your-application-will-use',
+      },
+      {
+        label: 'RFC 5280 §6 (Certification Path Validation)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc5280#section-6',
       },
     ],
   },

--- a/frontend/src/protocols/explainers/ssf.ts
+++ b/frontend/src/protocols/explainers/ssf.ts
@@ -74,8 +74,11 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
       {
         action:
           'Apply standard JWT validation: pin allowed `alg` from ' +
-          'Transmitter metadata; verify signature; validate `iss`, `aud`, ' +
-          'and `iat`/exp.',
+          'Transmitter metadata; verify signature; validate `iss` (REQUIRED ' +
+          'per RFC 8417 §2.2), `aud` (RECOMMENDED), and apply a freshness ' +
+          'window on `iat`. Note: SETs do not carry an `exp` claim per ' +
+          '§2.2 — they are point-in-time event reports, not bearer ' +
+          'credentials with a validity window.',
         mitigates: [
           'set-jwt-validation-pitfalls',
           'set-token-type-confusion',
@@ -248,10 +251,6 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
       {
         label: 'OpenID CAEP §4 (Security Considerations)',
         href: 'https://openid.net/specs/openid-caep-1_0-final.html',
-      },
-      {
-        label: 'OpenID RISC §4 (Security Considerations)',
-        href: 'https://openid.net/specs/openid-risc-1_0.html',
       },
     ],
   },
@@ -455,12 +454,12 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
     ],
     references: [
       {
-        label: 'OpenID SSF §7 (Stream Management)',
-        href: 'https://openid.net/specs/openid-sharedsignals-framework-1_0-final.html',
+        label: 'OpenID SSF §8 (Event Stream Management)',
+        href: 'https://openid.net/specs/openid-sharedsignals-framework-1_0.html',
       },
       {
-        label: 'OpenID SSF §11 (Security Considerations)',
-        href: 'https://openid.net/specs/openid-sharedsignals-framework-1_0-final.html',
+        label: 'OpenID SSF §9 (Security Considerations)',
+        href: 'https://openid.net/specs/openid-sharedsignals-framework-1_0.html',
       },
     ],
   },
@@ -539,8 +538,8 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://datatracker.ietf.org/doc/html/rfc9493',
       },
       {
-        label: 'RFC 9493 §6 (Security Considerations)',
-        href: 'https://datatracker.ietf.org/doc/html/rfc9493#section-6',
+        label: 'RFC 9493 §7 (Security Considerations)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc9493#section-7',
       },
     ],
   },
@@ -571,8 +570,9 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
     mitigations: [
       {
         action:
-          'Transmitter MUST include `initiating_entity` on every CAEP ' +
-          'event.',
+          'Transmitter SHOULD include `initiating_entity` on every CAEP ' +
+          'event. CAEP §2 lists it as an OPTIONAL claim, so this is ' +
+          'deployment policy rather than a spec MUST.',
         mitigates: ['initiating-entity-audit-trail-confusion'],
       },
       {
@@ -652,11 +652,7 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
     references: [
       {
         label: 'OpenID RISC Profile §2.3 (account-disabled)',
-        href: 'https://openid.net/specs/openid-risc-1_0.html',
-      },
-      {
-        label: 'OpenID RISC §4 (Security Considerations)',
-        href: 'https://openid.net/specs/openid-risc-1_0.html',
+        href: 'https://openid.net/specs/openid-risc-1_0.html#section-2.3',
       },
     ],
   },
@@ -680,9 +676,9 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
           'method, the suspected attacker\'s IP, and internal ticket ID. ' +
           'All of that lands in the SaaS\'s logs, accessible to the SaaS\'s ' +
           'support staff and any subprocessor of the SaaS\'s logging ' +
-          'pipeline. RISC §2.7 explicitly warns: "Do NOT include actual ' +
-          'compromised credential values in the SET" — but the broader ' +
-          'principle (don\'t leak detection details) is often missed.',
+          'pipeline. The OpenID specs do not give explicit text on what ' +
+          'belongs in `reason_admin`; treating it as cross-organisation ' +
+          'data sharing is operational hygiene, not a spec mandate.',
         impact:
           'Privacy and operational-information leakage outside the ' +
           'organisation.',
@@ -716,7 +712,7 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
         href: 'https://openid.net/specs/openid-caep-1_0-final.html',
       },
       {
-        label: 'OpenID CAEP §4 (Security Considerations) / RISC §2.7 Privacy Warning',
+        label: 'OpenID CAEP §4 (Security Considerations)',
         href: 'https://openid.net/specs/openid-caep-1_0-final.html',
       },
     ],
@@ -781,10 +777,11 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
   change_type: {
     purpose:
       'CAEP `credential-change` event property: `create` (new credential ' +
-      'added), `revoke` (credential removed), or `update` (credential ' +
-      'modified, e.g. password reset). Drives the Receiver\'s response — ' +
-      '`revoke` triggers token invalidation; `create` may be ' +
-      'informational; `update` requires nuanced response.',
+      'added), `revoke` (credential removed), `update` (credential ' +
+      'modified, e.g. password reset), or `delete` (credential record ' +
+      'removed). Drives the Receiver\'s response — `revoke`/`delete` ' +
+      'trigger token invalidation; `create` may be informational; ' +
+      '`update` requires nuanced response.',
     attacks: [
       {
         id: 'change-type-revoke-as-create',
@@ -845,6 +842,105 @@ export const SSF_EXPLAINERS: Record<string, ParameterExplainer> = {
       {
         label: 'OpenID CAEP §4 (Security Considerations)',
         href: 'https://openid.net/specs/openid-caep-1_0-final.html',
+      },
+    ],
+  },
+
+  'ssf:scope': {
+    purpose:
+      'Breadth of session/token termination a Receiver applies in response ' +
+      'to a SET. The OpenID RISC profile defines the events but leaves ' +
+      'Receiver response behaviour to the deployment — it does not ' +
+      'mandate "all sessions, all devices, all tokens." Defence-in-depth ' +
+      'practice for high-severity events (credential-compromise, account-' +
+      'disabled) is to revoke comprehensively; anything narrower lets the ' +
+      'attacker survive the event through a path the Receiver forgot to cut.',
+    attacks: [
+      {
+        id: 'partial-revocation-residual-access',
+        name: 'Residual access through forgotten revocation paths',
+        scenario:
+          'IdP fires credential-compromise for Alice. Receiver terminates ' +
+          'browser sessions and access tokens but does NOT revoke: refresh ' +
+          'tokens (Mallory mints fresh access tokens for hours), API keys ' +
+          '(Mallory keeps using them), downstream service sessions ' +
+          '(Mallory remains signed-in to federated SPs), mobile-app long-' +
+          'lived tokens, or cached introspection results (RS still trusts ' +
+          'the old token until cache expires). Same class as the ' +
+          'SCIM `active=false` session-lag attack but triggered out-of-band ' +
+          'via SET delivery.',
+        impact:
+          'Compromise event is fired, audit logs show "handled", but the ' +
+          'attacker retains usable credentials through every revocation ' +
+          'path the Receiver did not enumerate.',
+      },
+      {
+        id: 'forged-set-mass-disruption',
+        name: 'Forged SET triggers mass session termination (DoS)',
+        scenario:
+          'Receiver accepts SETs without strict signature validation ' +
+          'against the Transmitter\'s pinned JWKS, or trusts SETs from any ' +
+          'issuer in its config. An attacker who can submit a SET (compromised ' +
+          'intermediate, lax `aud`/`iss` checks, replayed `jti`) fires ' +
+          'credential-compromise events for arbitrary subjects. The ' +
+          'Receiver dutifully terminates every session for those users.',
+        impact:
+          'Targeted denial-of-service: legitimate users repeatedly logged ' +
+          'out, sessions killed mid-transaction, user trust in the platform ' +
+          'eroded. At scale: a tool for mass logout of an organisation.',
+      },
+    ],
+    mitigations: [
+      {
+        action:
+          'Enumerate every credential surface the Receiver controls and ' +
+          'cut all of them on credential-compromise: browser sessions, ' +
+          'refresh tokens, API keys, mobile/long-lived tokens, downstream ' +
+          'federated sessions, cached introspection results, in-flight ' +
+          'API requests bearing the affected token. Document the list and ' +
+          'review it whenever a new credential surface is added.',
+        rationale:
+          'The "forgotten path" is always added later by some other team. ' +
+          'A documented, auditable list is the only defence against drift.',
+        mitigates: ['partial-revocation-residual-access'],
+      },
+      {
+        action:
+          'For high-impact RISC events (credential-compromise, account-' +
+          'disabled), require strict SET validation. Spec-mandated by ' +
+          'RFC 8417 §2.2: signature on the JWS by a trusted issuer, `iss` ' +
+          'present and recognised. Receiver hardening beyond spec: exact ' +
+          '`aud` match (RECOMMENDED in §2.2, not REQUIRED), `jti` replay-' +
+          'tracking (§2.2 says "MAY"), freshness window on `iat` (not in ' +
+          'the spec). Reject on any failure; do not fail open.',
+        mitigates: ['forged-set-mass-disruption'],
+      },
+      {
+        action:
+          'Rate-limit and monitor mass-termination events. A spike in ' +
+          'credential-compromise SETs from one Transmitter, especially ' +
+          'across many users in a short window, is a forged-SET DoS ' +
+          'pattern even if individual signatures validate. Operational ' +
+          'guidance, not a spec requirement.',
+        mitigates: ['forged-set-mass-disruption'],
+      },
+    ],
+    references: [
+      {
+        label: 'OpenID RISC Profile §2.7 (Credential Compromise)',
+        href: 'https://openid.net/specs/openid-risc-1_0.html#section-2.7',
+      },
+      {
+        label: 'RFC 8417 §2.2 (SET Claims)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc8417#section-2.2',
+      },
+      {
+        label: 'RFC 8417 §5 (Security Considerations)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc8417#section-5',
+      },
+      {
+        label: 'RFC 8935 §3 (Authentication and Authorization)',
+        href: 'https://datatracker.ietf.org/doc/html/rfc8935#section-3',
       },
     ],
   },


### PR DESCRIPTION
## What does this PR do?

Fact-checks every parameter explainer entry against its underlying spec. The explainer registry was already designed to let OAuth-derived protocols (OIDC, OID4VCI, OID4VP) inherit OAuth2 base entries by parameter name — that part of the design is working and stays as is. What this PR fixes is a different class of issue: parameters that share a *name* across unrelated protocols where the semantics genuinely differ (so the bare-key inheritance was rendering wrong-protocol attack content), plus a long tail of section-number and section-title drift across the explainer files, plus three OID4VCI entries that described pre-1.0-final spec behaviour.

Highlights:

- **Cross-family name collisions resolved.** Where two protocols use the same name for unrelated concepts, the lookup was falling through to whichever protocol's file happened to define the bare key. SCIM `active` (User-resource enabled flag) was shadowing OAuth introspection's `active` (token validity). SPIFFE `format` (federated bundle JWKS structure) and `issuer` (X.509 signing CA) were resolving to OID4VCI credential format and OIDC OP issuer. SSF `scope` (revocation breadth on credential-compromise) was resolving to OAuth scope. Each fixed by adding a protocol-scoped `'protocol:name'` entry; legitimate cross-protocol inheritance (e.g. OIDC inheriting OAuth's `state`, `redirect_uri`, `scope`, `code`, `code_challenge`, etc.) is unchanged and still works as before.
- **Section-number and title corrections** across OAuth2, OIDC, OID4VCI, OID4VP, SAML, SPIFFE, SCIM, SSF. Examples: RFC 9700 §2.1.2 says SHOULD NOT, not MUST NOT; RFC 8417 §5 (not §7) is Security Considerations; SPIFFE Workload API has no Security Considerations section so seven fabricated references were dropped or remapped; OIDC `c_hash` no longer hardcodes SHA-256.
- **OID4VCI updates to 1.0 final.** `c_nonce` now describes the dedicated Nonce Endpoint (not /token); `proof` corrects the holder-key location (JWS header, not payload `cnf.jwk`) and required-claims list; `format` reflects that it is now in issuer metadata, not the credential request.
- **Backend rename.** `oidc/plugin.go` renames the `subject` Parameters key to `sub` so the UserInfo flow's lookup resolves to OIDC's own `sub` explainer instead of falling through to SSF's subject content.

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New protocol implementation

## How was this tested?

- [x] Tested locally with \`go run ./cmd/server\` and \`npm run dev\`
- [x] Other (describe below)

Each new and modified explainer entry was checked against the cited RFC, OpenID, and SPIFFE specifications. Every reference URL was opened to confirm the anchor lands on the section whose title the label claims. The four highest-impact rewrites (OAuth \`active\`, \`'spiffe:format'\`, \`'spiffe:issuer'\`, \`'ssf:scope'\`) were sanity-checked end-to-end in the UI.

## Checklist

- [x] My commits are signed off (\`git commit -s\`) per the [DCO](https://developercertificate.org/)
- [x] I have read the [CONTRIBUTING](https://github.com/ParleSec/ProtocolSoup/blob/master/CONTRIBUTING.md) guide
- [x] Backend compiles: \`cd backend && go build ./...\`
- [x] Backend passes lint: \`cd backend && golangci-lint run ./...\` (1 pre-existing govet warning in \`scim/patch.go\` unrelated to this PR)
- [x] Frontend passes lint: \`cd frontend && npm run lint\`
- [x] Frontend type-checks: \`cd frontend && npx tsc --noEmit\`
- [x] I have updated documentation if needed (no doc changes needed; this PR is content corrections to existing explainer entries)
- [x] I have not committed secrets, credentials, or \`.env\` files

## Screenshots / Looking Glass output

No UI changes; explainer content swap only. The Introspection Response \`active\` field card now shows OAuth-correct attack content (token replay prevention, missing-active-check, response spoofing, token scanning) instead of the SCIM User-resource session-lag content it was rendering before.