### PR TITLE
Feature/content retrieval

### DIFF
--- a/.github/workflows/palette-content.yml
+++ b/.github/workflows/palette-content.yml
@@ -1,0 +1,51 @@
+name: Palette content
+
+on:
+  push:
+    branches: [ '**' ]
+    paths:
+      - 'content/**'
+      - 'backend/cmd/content-validate/**'
+      - 'backend/cmd/palette-indexer/**'
+      - 'backend/internal/palette/**'
+      - 'backend/go.mod'
+      - 'backend/go.sum'
+      - '.github/workflows/palette-content.yml'
+  pull_request:
+    branches: [ master, develop ]
+    paths:
+      - 'content/**'
+      - 'backend/cmd/content-validate/**'
+      - 'backend/cmd/palette-indexer/**'
+      - 'backend/internal/palette/**'
+      - 'backend/go.mod'
+      - 'backend/go.sum'
+      - '.github/workflows/palette-content.yml'
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: '1.25.9'
+
+jobs:
+  validate:
+    name: Validate content frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: backend/go.sum
+
+      - name: Run content validator
+        working-directory: backend
+        run: go run ./cmd/content-validate -content ../content
+
+      - name: Run palette unit tests
+        working-directory: backend
+        run: go test ./internal/palette/...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,6 +307,31 @@ The build is idempotent — same input produces byte-identical output. Backed by
 
 Mounted at `POST /api/palette/query`. Implementation lives in `backend/internal/palette/`. The pipeline is parse → candidates → rank → match-reason emission → refinement chips. P99 latency budget is 20ms in-process. Tunable weights live in `rank.go`.
 
+### Frontend surfaces
+
+Two mount points share one component (`frontend/src/components/palette/Palette.tsx`):
+
+| Surface | Where | Notes |
+|---------|-------|-------|
+| Homepage input | `/` hero | URL persistence via `?q=&scope=&filter=`; shareable searches |
+| cmd+K modal | all other routes | `Cmd/Ctrl+K` or `/`; header **Search** chip on non-home pages |
+
+Keyboard (both surfaces unless noted):
+
+- `↑` / `↓` — navigate results
+- `Enter` — open result or dispatch runnable flow to Looking Glass
+- `Tab` — apply first refinement chip
+- `Esc` — close modal (cmd+K) or reset search (homepage)
+- `Cmd/Ctrl+K` — focus homepage input on `/`; toggle modal elsewhere
+
+Homepage URL shape (invalid values are ignored):
+
+```
+/?q=pkce&scope=concept&filter=use_cases:mobile_app
+```
+
+Recent searches (last 5) persist in `localStorage` under `protocolsoup.palette.recent.v1` and appear in the empty state.
+
 ## Project Architecture
 
 Understanding the codebase helps you contribute effectively:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,8 @@ Run the smallest set that covers your change. CI may run additional checks, but 
 | OpenAPI contracts | `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1` |
 | Docker or service topology | `cd docker && docker compose config` and, when practical, `docker compose up -d` |
 | OID4VCI/OID4VP protocol behavior | `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1` |
+| Palette content (`content/**`) | `cd backend && go run ./cmd/content-validate -content ../content && go test ./internal/palette/...` |
+| Palette indexer or query service | `cd backend && go test ./internal/palette/... && go run ./cmd/palette-indexer -content ../content -out ../frontend/public/palette.db` |
 
 When Snyk or other security scans are skipped for forked PRs because repository secrets are unavailable, maintainers may rerun or review those checks after initial triage.
 
@@ -266,6 +268,45 @@ When proposing a new protocol:
 3. **Start with core flows** before edge cases
 4. **Emit Looking Glass events** for all significant operations-visibility is our differentiator
 
+## Palette Content (`content/`)
+
+The homepage search input and global cmd+K palette retrieve from a deterministic in-process index built from the `content/` tree at the repo root. There is no external search service, no embeddings, and no probabilistic ranking. Every result row must carry visible match-reason metadata that points at the structured field that caused it to surface.
+
+### Authoring rules
+
+- **Source of truth is frontmatter** in markdown files under `content/protocols/`, `content/flows/<protocol>/`, `content/concepts/`, and (when produced) `content/spec-assertions/<protocol>/`.
+- **Schema**: see [`content/SCHEMA.md`](content/SCHEMA.md) for the full frontmatter contract (required, recommended, and optional fields). That document is canonical; do not duplicate the rules elsewhere.
+- **Controlled vocabulary**: only values declared in [`content/taxonomy.yaml`](content/taxonomy.yaml) are valid for the `use_cases`, `actors`, `patterns`, and `problem_domains` axes. New values require a taxonomy PR with a one-line semantic note.
+- **Synonyms**: add user-language synonyms to [`content/aliases.yaml`](content/aliases.yaml). Ambiguous aliases keep all mappings; the palette surfaces refinement chips when intent is genuinely ambiguous.
+- **Edges**: list `related_concepts` (and, where appropriate, `prerequisite_of` / `governs`) to enable one-hop traversals during retrieval.
+
+### Validator
+
+Every PR that touches `content/` or `backend/internal/palette/` must pass:
+
+```bash
+cd backend
+go run ./cmd/content-validate -content ../content
+go test ./internal/palette/...
+```
+
+The validator fails on unknown axis values, missing required fields, duplicate alias keys, dangling edge references, filename/id mismatches, and unknown top-level fields. CI enforces the same set; see `.github/workflows/palette-content.yml`.
+
+### Indexer
+
+A deploy-time Go binary builds the runtime SQLite file:
+
+```bash
+cd backend
+go run ./cmd/palette-indexer -content ../content -out ../frontend/public/palette.db
+```
+
+The build is idempotent — same input produces byte-identical output. Backed by SQLite FTS5 plus structured tables (`artefacts`, `axis_values`, `edges`, `aliases`).
+
+### Query service
+
+Mounted at `POST /api/palette/query`. Implementation lives in `backend/internal/palette/`. The pipeline is parse → candidates → rank → match-reason emission → refinement chips. P99 latency budget is 20ms in-process. Tunable weights live in `rank.go`.
+
 ## Project Architecture
 
 Understanding the codebase helps you contribute effectively:
@@ -273,21 +314,33 @@ Understanding the codebase helps you contribute effectively:
 ```
 ProtocolSoup/
 ├── backend/
-│   ├── cmd/server/          # Application entry point
+│   ├── cmd/
+│   │   ├── server/              # Application entry point
+│   │   ├── content-validate/    # Palette content frontmatter validator
+│   │   └── palette-indexer/     # Builds the SQLite palette index
 │   └── internal/
-│       ├── core/            # HTTP server, config, middleware
-│       ├── crypto/          # JWT/JWK key management
-│       ├── lookingglass/    # Real-time protocol inspection
-│       ├── mockidp/         # Mock identity provider
-│       ├── plugin/          # Plugin system interfaces
-│       └── protocols/       # Protocol implementations
+│       ├── core/                # HTTP server, config, middleware
+│       ├── crypto/              # JWT/JWK key management
+│       ├── lookingglass/        # Real-time protocol inspection
+│       ├── mockidp/             # Mock identity provider
+│       ├── palette/             # Indexer + query service for the search palette
+│       ├── plugin/              # Plugin system interfaces
+│       └── protocols/           # Protocol implementations
+├── content/                     # Source of truth for palette artefacts
+│   ├── taxonomy.yaml            # Controlled axis vocabulary
+│   ├── aliases.yaml             # Synonym map
+│   ├── SCHEMA.md                # Frontmatter contract (canonical)
+│   ├── protocols/               # Protocol artefacts
+│   ├── flows/<protocol>/        # Flow artefacts
+│   └── concepts/                # Concept artefacts
 ├── frontend/
 │   └── src/
-│       ├── components/      # Shared UI components
-│       ├── lookingglass/    # Flow executors & visualization
-│       ├── pages/           # Route pages
-│       └── protocols/       # Protocol registry
-└── docker/                  # Container configurations
+│       ├── components/
+│       │   └── palette/         # Shared retrieval surface (homepage + cmd+K)
+│       ├── lookingglass/        # Flow executors & visualization
+│       ├── pages/               # Route pages
+│       └── protocols/           # Protocol registry
+└── docker/                      # Container configurations
 ```
 
 See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed system design documentation.

--- a/backend/cmd/content-validate/main.go
+++ b/backend/cmd/content-validate/main.go
@@ -1,0 +1,40 @@
+// Command content-validate walks the ProtocolSoup content tree, validates
+// every artefact's frontmatter against the taxonomy, and verifies cross-
+// artefact edges. It exits non-zero if any issue is found so it can be wired
+// directly into CI.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ParleSec/ProtocolSoup/internal/palette"
+)
+
+func main() {
+	contentDir := flag.String("content", "content", "path to content directory")
+	flag.Parse()
+
+	if err := run(*contentDir); err != nil {
+		fmt.Fprintln(os.Stderr, "content-validate:", err)
+		os.Exit(2)
+	}
+}
+
+func run(contentDir string) error {
+	artefacts, _, _, issues, err := palette.ValidateContent(contentDir)
+	if err != nil {
+		return err
+	}
+	if len(issues) == 0 {
+		fmt.Printf("content-validate: %d artefacts OK\n", len(artefacts))
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "content-validate: %d issue(s) across %d artefact(s)\n", len(issues), len(artefacts))
+	for _, issue := range issues {
+		fmt.Fprintln(os.Stderr, "  "+issue.Format())
+	}
+	os.Exit(1)
+	return nil
+}

--- a/backend/cmd/palette-indexer/main.go
+++ b/backend/cmd/palette-indexer/main.go
@@ -1,0 +1,25 @@
+// Command palette-indexer builds the ProtocolSoup palette SQLite index from a
+// content tree. The output file is deterministic for fixed input: running the
+// indexer twice on the same tree produces a byte-identical database, which is
+// what lets CI compare deploy artefacts.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ParleSec/ProtocolSoup/internal/palette"
+)
+
+func main() {
+	contentDir := flag.String("content", "content", "path to content directory")
+	outPath := flag.String("out", "dist/palette.db", "output sqlite path")
+	flag.Parse()
+
+	if err := palette.BuildIndex(*contentDir, *outPath); err != nil {
+		fmt.Fprintln(os.Stderr, "palette-indexer:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("palette-indexer: wrote %s\n", *outPath)
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -26,6 +26,7 @@ func main() {
 		EnableKeySet:       true,
 		EnableMockIdP:      true,
 		EnableLookingGlass: true,
+		EnablePalette:      true,
 	})
 	if err != nil {
 		log.Fatalf("Failed to bootstrap server: %v", err)
@@ -93,7 +94,8 @@ func main() {
 	log.Printf("Initialized %d protocol plugins", len(registry.List()))
 
 	// Create and configure server
-	server := core.NewServer(bootstrap.Config, registry, bootstrap.LookingGlass, bootstrap.KeySet)
+	server := core.NewServer(bootstrap.Config, registry, bootstrap.LookingGlass, bootstrap.KeySet).
+		WithPalette(bootstrap.Palette)
 	httpServer := &http.Server{
 		Addr:         bootstrap.Config.ListenAddr,
 		Handler:      server.Router(),

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/backend/internal/core/bootstrap.go
+++ b/backend/internal/core/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ParleSec/ProtocolSoup/internal/crypto"
 	"github.com/ParleSec/ProtocolSoup/internal/lookingglass"
 	"github.com/ParleSec/ProtocolSoup/internal/mockidp"
+	"github.com/ParleSec/ProtocolSoup/internal/palette"
 	"github.com/ParleSec/ProtocolSoup/internal/plugin"
 )
 
@@ -15,6 +16,7 @@ type BootstrapOptions struct {
 	EnableKeySet       bool
 	EnableMockIdP      bool
 	EnableLookingGlass bool
+	EnablePalette      bool
 }
 
 // BootstrapResult holds initialized dependencies and plugin config.
@@ -23,6 +25,7 @@ type BootstrapResult struct {
 	KeySet       *crypto.KeySet
 	MockIdP      *mockidp.MockIdP
 	LookingGlass *lookingglass.Engine
+	Palette      *palette.Service
 	PluginConfig plugin.PluginConfig
 }
 
@@ -56,6 +59,17 @@ func Bootstrap(opts BootstrapOptions) (*BootstrapResult, error) {
 		log.Println("Looking Glass engine initialized")
 	}
 
+	var paletteSvc *palette.Service
+	if opts.EnablePalette && cfg.PaletteDBPath != "" {
+		svc, err := palette.NewService(cfg.PaletteDBPath)
+		if err != nil {
+			log.Printf("Palette service disabled: %v", err)
+		} else {
+			paletteSvc = svc
+			log.Printf("Palette service initialized from %s", cfg.PaletteDBPath)
+		}
+	}
+
 	pluginConfig := plugin.PluginConfig{
 		BaseURL:      cfg.BaseURL,
 		DataDir:      cfg.DataDir,
@@ -69,6 +83,7 @@ func Bootstrap(opts BootstrapOptions) (*BootstrapResult, error) {
 		KeySet:       keySet,
 		MockIdP:      idp,
 		LookingGlass: lg,
+		Palette:      paletteSvc,
 		PluginConfig: pluginConfig,
 	}, nil
 }

--- a/backend/internal/core/config.go
+++ b/backend/internal/core/config.go
@@ -30,6 +30,10 @@ type Config struct {
 
 	// Data directory for durable protocol state (wallet lineage, verifier sessions)
 	DataDir string
+
+	// PaletteDBPath points at the prebuilt palette SQLite index. Empty
+	// disables the palette query service (and the /api/palette/query route).
+	PaletteDBPath string
 }
 
 // LoadConfig loads configuration from environment variables with sensible defaults
@@ -43,6 +47,7 @@ func LoadConfig() *Config {
 		Debug:          getEnvBool("SHOWCASE_DEBUG", false),
 		FrontendOrigin: getEnv("SHOWCASE_FRONTEND_ORIGIN", ""),
 		DataDir:        getEnv("SHOWCASE_DATA_DIR", ""),
+		PaletteDBPath: getEnv("SHOWCASE_PALETTE_DB", ""),
 	}
 
 	return cfg

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ParleSec/ProtocolSoup/internal/crypto"
 	"github.com/ParleSec/ProtocolSoup/internal/lookingglass"
+	"github.com/ParleSec/ProtocolSoup/internal/palette"
 	"github.com/ParleSec/ProtocolSoup/internal/plugin"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -23,10 +24,12 @@ type Server struct {
 	registry     *plugin.Registry
 	lookingGlass *lookingglass.Engine
 	keySet       *crypto.KeySet
+	palette      *palette.Service
 	router       chi.Router
 }
 
-// NewServer creates a new server instance
+// NewServer creates a new server instance. Pass nil for paletteSvc when the
+// palette index is not loaded — the route is then omitted entirely.
 func NewServer(cfg *Config, registry *plugin.Registry, lg *lookingglass.Engine, ks *crypto.KeySet) *Server {
 	s := &Server{
 		config:       cfg,
@@ -34,6 +37,17 @@ func NewServer(cfg *Config, registry *plugin.Registry, lg *lookingglass.Engine, 
 		lookingGlass: lg,
 		keySet:       ks,
 	}
+	s.setupRouter()
+	return s
+}
+
+// WithPalette mounts the palette query handler. Returns the server for
+// fluent use during bootstrap. A nil service is a no-op.
+func (s *Server) WithPalette(paletteSvc *palette.Service) *Server {
+	if paletteSvc == nil {
+		return s
+	}
+	s.palette = paletteSvc
 	s.setupRouter()
 	return s
 }
@@ -94,6 +108,13 @@ func (s *Server) setupRouter() {
 		// JWKS endpoint (optional)
 		if s.keySet != nil {
 			r.Get("/.well-known/jwks.json", s.handleJWKS)
+		}
+
+		// Palette query (optional). The handler is mounted only when an
+		// index is loaded; otherwise the route is absent so clients can
+		// detect availability via /api.
+		if s.palette != nil {
+			r.Post("/palette/query", s.palette.Handler())
 		}
 	})
 
@@ -222,6 +243,9 @@ func (s *Server) handleAPIIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.keySet != nil {
 		endpoints["jwks"] = "/api/.well-known/jwks.json"
+	}
+	if s.palette != nil {
+		endpoints["palette"] = "/api/palette/query"
 	}
 
 	writeJSON(w, http.StatusOK, APIIndexResponse{

--- a/backend/internal/palette/api.go
+++ b/backend/internal/palette/api.go
@@ -1,0 +1,39 @@
+package palette
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// Handler returns the HTTP handler for POST /api/palette/query. The handler
+// rejects non-POST methods, decodes the request body, dispatches to
+// Service.Query, and JSON-encodes the response. Errors map to 400 (bad
+// request shape) or 500 (server failure).
+func (s *Service) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method_not_allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		defer r.Body.Close()
+
+		var req Request
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid_json"}`, http.StatusBadRequest)
+			return
+		}
+
+		start := time.Now()
+		resp, err := s.Query(r.Context(), req)
+		if err != nil {
+			http.Error(w, `{"error":"query_failed"}`, http.StatusInternalServerError)
+			return
+		}
+		resp.ElapsedMicros = time.Since(start).Microseconds()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/backend/internal/palette/artefact.go
+++ b/backend/internal/palette/artefact.go
@@ -1,0 +1,445 @@
+// Package palette contains the content substrate, indexer, and query service
+// for the ProtocolSoup multi-axis content retrieval surface ("palette"). All
+// retrieval is deterministic: no embeddings, no LLM calls, no probabilistic
+// ranking. The package is split across files by stage so each stage can be
+// tested in isolation.
+//
+// File map:
+//
+//	artefact.go   - artefact and frontmatter types + filesystem walking
+//	taxonomy.go   - taxonomy.yaml and aliases.yaml types + loading
+//	validate.go   - validation rules used by content-validate and the indexer
+//	schema.go     - SQLite DDL constants used by the indexer
+//	index.go      - palette.db construction (idempotent)
+//	parse.go      - query tokenisation and alias resolution
+//	candidates.go - FTS5/axis/edge candidate retrieval
+//	rank.go       - deterministic ranking and match-reason emission
+//	query.go      - Service.Query() entry point
+//	api.go        - HTTP handler for POST /api/palette/query
+package palette
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// mdLinkPattern matches a markdown link [text](url) and captures the text.
+// We use this in stripInlineMarkdown to keep link text in the preview but
+// drop the URL.
+var mdLinkPattern = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
+
+// Artefact types recognised by the validator and indexer. The set is closed.
+const (
+	ArtefactProtocol      = "protocol"
+	ArtefactFlow          = "flow"
+	ArtefactConcept       = "concept"
+	ArtefactWalkthrough   = "walkthrough"
+	ArtefactSpecAssertion = "spec-assertion"
+)
+
+// Status values recognised on artefact frontmatter.
+const (
+	StatusLive       = "live"
+	StatusPlanned    = "planned"
+	StatusDeprecated = "deprecated"
+)
+
+// Normative-level values recognised on spec-assertion artefacts.
+var NormativeLevels = map[string]struct{}{
+	"MUST":       {},
+	"SHOULD":     {},
+	"MAY":        {},
+	"MUST NOT":   {},
+	"SHOULD NOT": {},
+}
+
+// dirToType maps the directory immediately under content/ to an artefact type.
+// Markdown files outside these directories are a validation error so the file
+// layout is enforced.
+var dirToType = map[string]string{
+	"protocols":    ArtefactProtocol,
+	"flows":        ArtefactFlow,
+	"concepts":     ArtefactConcept,
+	"walkthroughs": ArtefactWalkthrough,
+	"assertions":   ArtefactSpecAssertion,
+}
+
+// NormativeAnchor is one RFC/section reference. Sections is a free-form list
+// of section identifiers (e.g. "4.1.3"). The JSON tags lowercase the field
+// names so they match the frontend types and the documented response shape;
+// without them Go would emit "RFC"/"Sections" which crashes lowercase-aware
+// consumers.
+type NormativeAnchor struct {
+	RFC      string   `yaml:"rfc"      json:"rfc"`
+	Sections []string `yaml:"sections" json:"sections"`
+}
+
+// Artefact is the parsed frontmatter of a single content file plus the
+// markdown body. Type, Path, ProtocolFromDir and Body are filled in by the
+// walker and are not represented in the YAML frontmatter directly.
+type Artefact struct {
+	ID               string            `yaml:"id"`
+	Name             string            `yaml:"name"`
+	Protocol         string            `yaml:"protocol,omitempty"`
+	Protocols        []string          `yaml:"protocols,omitempty"`
+	UseCases         []string          `yaml:"use_cases,omitempty"`
+	Actors           []string          `yaml:"actors,omitempty"`
+	Patterns         []string          `yaml:"patterns,omitempty"`
+	ProblemDomains   []string          `yaml:"problem_domains,omitempty"`
+	RelatedConcepts  []string          `yaml:"related_concepts,omitempty"`
+	Prerequisites    []string          `yaml:"prerequisites,omitempty"`
+	NormativeAnchors []NormativeAnchor `yaml:"normative_anchors,omitempty"`
+	NormativeLevel   string            `yaml:"normative_level,omitempty"`
+	Runnable         *bool             `yaml:"runnable,omitempty"`
+	Status           string            `yaml:"status,omitempty"`
+	Href             string            `yaml:"href,omitempty"`
+	Summary          string            `yaml:"summary,omitempty"`
+	Aliases          []string          `yaml:"aliases,omitempty"`
+	BackendID        string            `yaml:"backend_id,omitempty"`
+	AssertionText    string            `yaml:"assertion_text,omitempty"`
+
+	Type            string `yaml:"-"`
+	Path            string `yaml:"-"`
+	ProtocolFromDir string `yaml:"-"`
+	Body            string `yaml:"-"`
+}
+
+// allowedFrontmatterFields is the closed set of frontmatter keys. Unknown keys
+// are a validation error so frontmatter stays under positive control.
+var allowedFrontmatterFields = map[string]struct{}{
+	"id":                {},
+	"name":              {},
+	"protocol":          {},
+	"protocols":         {},
+	"use_cases":         {},
+	"actors":            {},
+	"patterns":          {},
+	"problem_domains":   {},
+	"related_concepts":  {},
+	"prerequisites":     {},
+	"normative_anchors": {},
+	"normative_level":   {},
+	"runnable":          {},
+	"status":            {},
+	"href":              {},
+	"summary":           {},
+	"aliases":           {},
+	"backend_id":        {},
+	"assertion_text":    {},
+}
+
+// IsRunnable reports whether the artefact is runnable, applying the type
+// defaults. Flows default to true, everything else defaults to false.
+func (a Artefact) IsRunnable() bool {
+	if a.Runnable != nil {
+		return *a.Runnable
+	}
+	return a.Type == ArtefactFlow
+}
+
+// EffectiveStatus returns the explicit status or the default ("live") when
+// none is set on the artefact.
+func (a Artefact) EffectiveStatus() string {
+	if a.Status == "" {
+		return StatusLive
+	}
+	return a.Status
+}
+
+// DefaultHref returns the canonical site URL for an artefact, or the empty
+// string for artefact types that are inline-only.
+//
+// Concepts, walkthroughs, and spec-assertions are inline-only by design:
+// their canonical surface is the palette's expanded row (full markdown body,
+// normative anchors, related-concept chips). No /concept/{id},
+// /walkthrough/{id}, or /assertion/{id} route exists in the Next.js app, so
+// returning an empty href is the explicit signal to the frontend to skip
+// router.push and hide "Open page" affordances for those types.
+//
+// An empty href is returned for these types even when the frontmatter sets
+// `href` explicitly — earlier content baked `/concept/{id}` into the
+// frontmatter, and we never want to ship a link that 404s. If/when a
+// canonical concept page route is added, this rule moves and the explicit
+// `href` field starts to be honoured again.
+func (a Artefact) DefaultHref() string {
+	switch a.Type {
+	case ArtefactConcept, ArtefactWalkthrough, ArtefactSpecAssertion:
+		return ""
+	}
+	if a.Href != "" {
+		return a.Href
+	}
+	switch a.Type {
+	case ArtefactProtocol:
+		return "/protocol/" + a.ID
+	case ArtefactFlow:
+		if a.Protocol != "" {
+			return "/protocol/" + a.Protocol + "/flow/" + a.ID
+		}
+		return "/looking-glass"
+	}
+	return "/"
+}
+
+// PlainTextPreview returns the first paragraph of the artefact body with
+// markdown stripped, truncated to maxChars on a word boundary. Used by the
+// indexer to bake an always-displayable preview into the payload, so the
+// frontend can show "search-result snippets" without re-parsing the body.
+// A paragraph break is two consecutive newlines (the convention every
+// artefact body in content/ follows).
+func (a Artefact) PlainTextPreview(maxChars int) string {
+	if a.Body == "" {
+		return ""
+	}
+	// First paragraph: everything up to the first blank line.
+	end := strings.Index(a.Body, "\n\n")
+	first := a.Body
+	if end >= 0 {
+		first = a.Body[:end]
+	}
+	first = strings.TrimSpace(first)
+
+	// Strip a leading heading marker if the first paragraph happens to be a
+	// single `# Heading` line (kept short and human-readable that way).
+	if strings.HasPrefix(first, "#") {
+		first = strings.TrimLeft(first, "# ")
+	}
+
+	plain := stripInlineMarkdown(first)
+	plain = collapseWhitespace(plain)
+	if maxChars <= 0 || len(plain) <= maxChars {
+		return plain
+	}
+	// Truncate on a word boundary when possible, append a unicode ellipsis.
+	cut := plain[:maxChars]
+	if sp := strings.LastIndex(cut, " "); sp > maxChars/2 {
+		cut = cut[:sp]
+	}
+	return strings.TrimRight(cut, " ,.;:") + "..."
+}
+
+// stripInlineMarkdown removes the inline markdown syntax used in the
+// content corpus: backticks for code, **bold**, *italic*, and link syntax
+// `[text](url)` → `text`. The full body keeps the markdown; this is for the
+// preview field only.
+func stripInlineMarkdown(s string) string {
+	// Links: [text](url) → text
+	s = mdLinkPattern.ReplaceAllString(s, "$1")
+	// Bold/italic: leave inner text, drop the markers.
+	s = strings.ReplaceAll(s, "**", "")
+	s = strings.ReplaceAll(s, "__", "")
+	// Backticks → keep the content, drop the marker.
+	s = strings.ReplaceAll(s, "`", "")
+	return s
+}
+
+func collapseWhitespace(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	lastWasSpace := false
+	for _, r := range s {
+		if r == '\n' || r == '\r' || r == '\t' {
+			r = ' '
+		}
+		if r == ' ' {
+			if lastWasSpace {
+				continue
+			}
+			lastWasSpace = true
+		} else {
+			lastWasSpace = false
+		}
+		b.WriteRune(r)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// ProtocolList returns the set of protocols an artefact relates to, drawn
+// from Protocol (single-protocol) or Protocols (cross-cutting) or the
+// directory-inferred protocol for flows.
+func (a Artefact) ProtocolList() []string {
+	if len(a.Protocols) > 0 {
+		out := make([]string, len(a.Protocols))
+		copy(out, a.Protocols)
+		return out
+	}
+	if a.Protocol != "" {
+		return []string{a.Protocol}
+	}
+	if a.Type == ArtefactProtocol {
+		return []string{a.ID}
+	}
+	if a.ProtocolFromDir != "" {
+		return []string{a.ProtocolFromDir}
+	}
+	return nil
+}
+
+// ContentReader walks a content directory and parses every markdown file into
+// an Artefact. It returns artefacts sorted by Path so downstream output is
+// stable (which the indexer relies on for byte-identical builds).
+type ContentReader struct {
+	Root string
+}
+
+// Read parses every artefact under Root. It does not validate cross-artefact
+// references; that is the validator's job. Returns artefacts sorted by Path.
+func (r ContentReader) Read() ([]Artefact, error) {
+	var artefacts []Artefact
+
+	err := filepath.WalkDir(r.Root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".md" {
+			return nil
+		}
+		base := filepath.Base(path)
+		if base == "SCHEMA.md" || strings.HasPrefix(base, ".") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(r.Root, path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		rel = filepath.ToSlash(rel)
+
+		artefact, err := parseArtefactFile(path, rel)
+		if err != nil {
+			return fmt.Errorf("%s: %w", rel, err)
+		}
+		artefacts = append(artefacts, artefact)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(artefacts, func(i, j int) bool {
+		return artefacts[i].Path < artefacts[j].Path
+	})
+	return artefacts, nil
+}
+
+// parseArtefactFile reads a single content file and parses the YAML
+// frontmatter delimited by `---`. The first `---` must be on line 1.
+func parseArtefactFile(absPath, relPath string) (Artefact, error) {
+	parts := strings.SplitN(relPath, "/", 3)
+	if len(parts) < 2 {
+		return Artefact{}, fmt.Errorf("markdown file outside recognised directory: %s", relPath)
+	}
+	topDir := parts[0]
+	artefactType, ok := dirToType[topDir]
+	if !ok {
+		return Artefact{}, fmt.Errorf("markdown file under unknown directory %q (expected one of protocols/, flows/, concepts/, walkthroughs/, assertions/)", topDir)
+	}
+
+	frontmatter, body, err := readFrontmatter(absPath)
+	if err != nil {
+		return Artefact{}, err
+	}
+
+	if err := assertNoUnknownFields(frontmatter); err != nil {
+		return Artefact{}, err
+	}
+
+	var a Artefact
+	if err := yaml.Unmarshal(frontmatter, &a); err != nil {
+		return Artefact{}, fmt.Errorf("invalid frontmatter YAML: %w", err)
+	}
+	a.Type = artefactType
+	a.Path = relPath
+	a.Body = body
+
+	if artefactType == ArtefactFlow && len(parts) >= 3 {
+		a.ProtocolFromDir = parts[1]
+	}
+
+	return a, nil
+}
+
+func readFrontmatter(path string) ([]byte, string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	if !scanner.Scan() {
+		return nil, "", fmt.Errorf("empty file")
+	}
+	if strings.TrimRight(scanner.Text(), "\r") != "---" {
+		return nil, "", fmt.Errorf("missing frontmatter: file must start with ---")
+	}
+
+	var fm strings.Builder
+	closed := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimRight(line, "\r") == "---" {
+			closed = true
+			break
+		}
+		fm.WriteString(line)
+		fm.WriteByte('\n')
+	}
+	if !closed {
+		return nil, "", fmt.Errorf("unterminated frontmatter: missing closing ---")
+	}
+
+	var body strings.Builder
+	for scanner.Scan() {
+		body.WriteString(scanner.Text())
+		body.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, "", err
+	}
+	return []byte(fm.String()), strings.TrimSpace(body.String()), nil
+}
+
+// assertNoUnknownFields walks the frontmatter as a generic YAML map and
+// rejects any unknown top-level keys. We do this in a separate pass instead
+// of using yaml.Unmarshal strict mode so that the error message can name the
+// offending key without aborting on the first unknown field encountered by
+// the Decoder.
+func assertNoUnknownFields(raw []byte) error {
+	var node yaml.Node
+	if err := yaml.Unmarshal(raw, &node); err != nil {
+		return fmt.Errorf("invalid frontmatter YAML: %w", err)
+	}
+	if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {
+		return nil
+	}
+	root := node.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("frontmatter must be a YAML mapping at the top level")
+	}
+	var unknown []string
+	for i := 0; i < len(root.Content); i += 2 {
+		key := root.Content[i].Value
+		if _, ok := allowedFrontmatterFields[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("unknown frontmatter fields: %s", strings.Join(unknown, ", "))
+	}
+	return nil
+}

--- a/backend/internal/palette/artefact_href_test.go
+++ b/backend/internal/palette/artefact_href_test.go
@@ -1,0 +1,74 @@
+package palette
+
+import "testing"
+
+// TestDefaultHref_InlineOnlyTypesReturnEmpty locks the rule that
+// concept, walkthrough, and spec-assertion artefacts are inline-only:
+// their canonical surface is the palette's expanded row, not a dedicated
+// page route. Without this rule the frontend would emit /concept/{id} and
+// similar links that 404 because no matching Next.js route exists.
+func TestDefaultHref_InlineOnlyTypesReturnEmpty(t *testing.T) {
+	cases := []Artefact{
+		{ID: "pkce", Type: ArtefactConcept},
+		{ID: "oauth2-tour", Type: ArtefactWalkthrough},
+		{ID: "must-use-pkce", Type: ArtefactSpecAssertion},
+	}
+	for _, a := range cases {
+		t.Run(a.Type, func(t *testing.T) {
+			if got := a.DefaultHref(); got != "" {
+				t.Errorf("DefaultHref for %s = %q; want empty (inline-only types)", a.Type, got)
+			}
+		})
+	}
+}
+
+// TestDefaultHref_InlineOnlyIgnoresExplicitHref guards against stale
+// content frontmatter (older concept files baked href: /concept/{id} in
+// before the inline-only design was finalised). Even when Href is set,
+// inline-only types must return empty so the frontend never ships a
+// link to a phantom route.
+func TestDefaultHref_InlineOnlyIgnoresExplicitHref(t *testing.T) {
+	a := Artefact{ID: "pkce", Type: ArtefactConcept, Href: "/concept/pkce"}
+	if got := a.DefaultHref(); got != "" {
+		t.Errorf("DefaultHref with explicit Href on concept = %q; want empty", got)
+	}
+}
+
+// TestDefaultHref_LinkableTypes pins the canonical routes for the
+// artefact types that do have pages, so a future refactor of route shapes
+// breaks loudly here rather than producing silent 404s in the palette.
+func TestDefaultHref_LinkableTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		a    Artefact
+		want string
+	}{
+		{
+			name: "protocol",
+			a:    Artefact{ID: "oauth2", Type: ArtefactProtocol},
+			want: "/protocol/oauth2",
+		},
+		{
+			name: "flow with protocol",
+			a:    Artefact{ID: "authorization-code", Type: ArtefactFlow, Protocol: "oauth2"},
+			want: "/protocol/oauth2/flow/authorization-code",
+		},
+		{
+			name: "flow without protocol falls back to looking-glass",
+			a:    Artefact{ID: "ad-hoc", Type: ArtefactFlow},
+			want: "/looking-glass",
+		},
+		{
+			name: "protocol with explicit href honours it",
+			a:    Artefact{ID: "oauth2", Type: ArtefactProtocol, Href: "/protocols/oauth2"},
+			want: "/protocols/oauth2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.DefaultHref(); got != tc.want {
+				t.Errorf("DefaultHref = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/palette/candidates.go
+++ b/backend/internal/palette/candidates.go
@@ -1,0 +1,329 @@
+package palette
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// candidate is the working representation of a result row before ranking.
+// Each candidate accumulates evidence from every source that produced it
+// (FTS5, axis-value join, edge traversal). The ranker uses these traces
+// both to score the row and to emit visible match reasons.
+type candidate struct {
+	ID         string
+	BM25       float64
+	BM25Phrase string
+	axisHits   []axisHit
+	edgeHits   []edgeHit
+	aliasHits  []aliasHit
+	protocolHit *protocolNameHit
+}
+
+type axisHit struct {
+	axis         string
+	value        string
+	matchedToken string // empty when the hit came from an explicit filter
+}
+
+type edgeHit struct {
+	via  string // the seed artefact id that hopped to this one
+	kind string
+}
+
+type aliasHit struct {
+	axis         string
+	value        string
+	artefact     string
+	matchedToken string
+}
+
+type protocolNameHit struct {
+	matchedToken string
+}
+
+// maxCandidatesPerSource caps how many rows each retrieval source produces
+// before ranking. The prompt requires 100 max per source.
+const maxCandidatesPerSource = 100
+
+// gatherCandidates fans the parsed query out across three retrieval sources
+// in parallel and merges the resulting candidates by id. The function is
+// deterministic: candidates are merged in id order at the end.
+func (s *Service) gatherCandidates(ctx context.Context, parsed ParsedQuery, cat catalog) map[string]*candidate {
+	merged := make(map[string]*candidate)
+
+	for _, axis := range parsed.axisHitsFromAliases() {
+		for _, id := range lookupAxis(cat, axis.Axis, axis.Value) {
+			c := getOrCreate(merged, id)
+			c.aliasHits = append(c.aliasHits, aliasHit{
+				axis:         axis.Axis,
+				value:        axis.Value,
+				matchedToken: axis.MatchedToken,
+			})
+			c.axisHits = append(c.axisHits, axisHit{
+				axis:         axis.Axis,
+				value:        axis.Value,
+				matchedToken: axis.MatchedToken,
+			})
+		}
+	}
+
+	for _, hit := range parsed.artefactHitsFromAliases() {
+		if _, ok := cat.artefacts[hit.Artefact]; !ok {
+			continue
+		}
+		c := getOrCreate(merged, hit.Artefact)
+		c.aliasHits = append(c.aliasHits, aliasHit{
+			artefact:     hit.Artefact,
+			matchedToken: hit.MatchedToken,
+		})
+		if cat.artefacts[hit.Artefact].Type == ArtefactProtocol {
+			c.protocolHit = &protocolNameHit{matchedToken: hit.MatchedToken}
+		}
+	}
+
+	for _, f := range parsed.Filters {
+		for _, id := range lookupAxis(cat, f.Axis, f.Value) {
+			c := getOrCreate(merged, id)
+			c.axisHits = append(c.axisHits, axisHit{
+				axis:  f.Axis,
+				value: f.Value,
+			})
+		}
+	}
+
+	if ftsRows := s.runFTS(ctx, parsed); len(ftsRows) > 0 {
+		for _, row := range ftsRows {
+			c := getOrCreate(merged, row.id)
+			if row.bm25 > c.BM25 {
+				c.BM25 = row.bm25
+				c.BM25Phrase = row.phrase
+			}
+		}
+	}
+
+	// Edge fan-out from current seeds, one hop. We don't need to query
+	// SQLite for this; the edges map is loaded into the in-memory catalog.
+	seeds := make([]string, 0, len(merged))
+	for id := range merged {
+		seeds = append(seeds, id)
+	}
+	sort.Strings(seeds)
+
+	for _, seed := range seeds {
+		for _, e := range cat.edges[seed] {
+			if _, ok := merged[e.To]; ok {
+				// Already a candidate — record the edge as additional evidence
+				merged[e.To].edgeHits = append(merged[e.To].edgeHits, edgeHit{via: seed, kind: e.Kind})
+				continue
+			}
+			if len(merged) >= maxCandidatesPerSource*3 {
+				break
+			}
+			c := getOrCreate(merged, e.To)
+			c.edgeHits = append(c.edgeHits, edgeHit{via: seed, kind: e.Kind})
+		}
+	}
+
+	return merged
+}
+
+func getOrCreate(m map[string]*candidate, id string) *candidate {
+	c, ok := m[id]
+	if !ok {
+		c = &candidate{ID: id}
+		m[id] = c
+	}
+	return c
+}
+
+func lookupAxis(cat catalog, axis, value string) []string {
+	byValue, ok := cat.axisIndex[axis]
+	if !ok {
+		return nil
+	}
+	ids := byValue[value]
+	if len(ids) > maxCandidatesPerSource {
+		ids = ids[:maxCandidatesPerSource]
+	}
+	return ids
+}
+
+// axisHitsFromAliases reduces parsed.Resolved to only the axis-typed
+// entries, deduplicating identical hits.
+func (p ParsedQuery) axisHitsFromAliases() []ResolvedAlias {
+	seen := make(map[string]ResolvedAlias)
+	for _, r := range p.Resolved {
+		if r.Axis == "" {
+			continue
+		}
+		key := r.Axis + "::" + r.Value
+		if existing, ok := seen[key]; ok {
+			if len(r.MatchedToken) > len(existing.MatchedToken) {
+				seen[key] = r
+			}
+			continue
+		}
+		seen[key] = r
+	}
+	out := make([]ResolvedAlias, 0, len(seen))
+	for _, v := range seen {
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Axis != out[j].Axis {
+			return out[i].Axis < out[j].Axis
+		}
+		return out[i].Value < out[j].Value
+	})
+	return out
+}
+
+// artefactHitsFromAliases reduces parsed.Resolved to the artefact-typed
+// entries.
+func (p ParsedQuery) artefactHitsFromAliases() []ResolvedAlias {
+	seen := make(map[string]ResolvedAlias)
+	for _, r := range p.Resolved {
+		if r.Axis != "" {
+			continue
+		}
+		if existing, ok := seen[r.Artefact]; ok {
+			if len(r.MatchedToken) > len(existing.MatchedToken) {
+				seen[r.Artefact] = r
+			}
+			continue
+		}
+		seen[r.Artefact] = r
+	}
+	out := make([]ResolvedAlias, 0, len(seen))
+	for _, v := range seen {
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Artefact < out[j].Artefact
+	})
+	return out
+}
+
+type ftsRow struct {
+	id     string
+	bm25   float64
+	phrase string
+}
+
+// runFTS issues a single FTS5 MATCH query covering free tokens and any
+// phrase requirements. The BM25 score is normalised by FTS5 to a magnitude
+// roughly suitable for blending with the axis weights; we further compress
+// it with 1/(1+bm25) so high-scoring rows do not overwhelm axis matches.
+func (s *Service) runFTS(ctx context.Context, parsed ParsedQuery) []ftsRow {
+	expr := buildFTSExpression(parsed)
+	if expr == "" {
+		return nil
+	}
+
+	query := fmt.Sprintf(`
+        SELECT id, bm25(artefacts_fts) AS rank
+        FROM artefacts_fts
+        WHERE artefacts_fts MATCH ?
+        ORDER BY rank
+        LIMIT %d
+    `, maxCandidatesPerSource)
+
+	rows, err := s.db.QueryContext(ctx, query, expr)
+	if err != nil {
+		// FTS5 syntax errors are possible when a free token contains
+		// FTS5-reserved characters; we degrade silently to no FTS hits.
+		return nil
+	}
+	defer rows.Close()
+
+	var out []ftsRow
+	for rows.Next() {
+		var id string
+		var rank float64
+		if err := rows.Scan(&id, &rank); err != nil {
+			continue
+		}
+		// bm25() returns negative numbers (lower is better). Convert into
+		// a positive magnitude so the blend below behaves predictably.
+		magnitude := -rank
+		if magnitude < 0 {
+			magnitude = 0
+		}
+		out = append(out, ftsRow{
+			id:     id,
+			bm25:   magnitude / (1.0 + magnitude),
+			phrase: expr,
+		})
+	}
+	return out
+}
+
+// buildFTSExpression turns parsed free tokens and phrases into an FTS5
+// MATCH expression. Tokens we cannot safely express are dropped.
+func buildFTSExpression(parsed ParsedQuery) string {
+	var parts []string
+
+	for _, phrase := range parsed.PhraseMatches {
+		safe := sanitisePhrase(phrase)
+		if safe == "" {
+			continue
+		}
+		parts = append(parts, `"`+safe+`"`)
+	}
+	for _, tok := range parsed.FreeTokens {
+		safe := sanitiseToken(tok)
+		if safe == "" {
+			continue
+		}
+		parts = append(parts, safe+"*")
+	}
+
+	return strings.Join(parts, " OR ")
+}
+
+// sanitiseToken filters a single FTS5 term to characters known not to break
+// the parser. Anything else is dropped to keep the MATCH expression valid.
+func sanitiseToken(t string) string {
+	var b strings.Builder
+	b.Grow(len(t))
+	for _, r := range t {
+		if r >= 'a' && r <= 'z' {
+			b.WriteRune(r)
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			b.WriteRune(r)
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+			continue
+		}
+		// Tokens preserve internal hyphens but for FTS5 we treat them as
+		// word separators; replace with space so the term-prefix wildcard
+		// matches the leading sub-term.
+		if r == '-' || r == '_' {
+			b.WriteRune(' ')
+			continue
+		}
+	}
+	cleaned := strings.TrimSpace(b.String())
+	if cleaned == "" {
+		return ""
+	}
+	// If a single token expanded to multiple sub-tokens, keep the first.
+	fields := strings.Fields(cleaned)
+	return fields[0]
+}
+
+func sanitisePhrase(p string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '"' {
+			return -1
+		}
+		return r
+	}, p)
+	return strings.TrimSpace(cleaned)
+}

--- a/backend/internal/palette/index.go
+++ b/backend/internal/palette/index.go
@@ -1,0 +1,402 @@
+package palette
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+// IndexVersion is the on-disk format version. Bump when the schema or the
+// emitted JSON payload shape changes in a way clients must observe.
+const IndexVersion = "1"
+
+// BuildIndex constructs a SQLite palette index at outPath from the content
+// tree rooted at contentRoot. The function is deterministic: with identical
+// inputs it produces a byte-identical SQLite file, which lets CI compare
+// build artefacts and lets atomic deploys be byte-precise.
+//
+// The build runs in three steps:
+//
+//  1. Validate the content tree. Any issue aborts the build; the indexer
+//     refuses to emit a partial database.
+//  2. Open a fresh SQLite database at a temporary path, apply schema, and
+//     insert every row in deterministic order.
+//  3. VACUUM the database so the file is compact and reproducible, then
+//     atomically rename it into place.
+//
+// On any error the temporary file is removed.
+func BuildIndex(contentRoot, outPath string) error {
+	artefacts, taxonomy, aliasesFile, issues, err := ValidateContent(contentRoot)
+	if err != nil {
+		return fmt.Errorf("validate content: %w", err)
+	}
+	if len(issues) > 0 {
+		var lines []string
+		for _, i := range issues {
+			lines = append(lines, i.Format())
+		}
+		return fmt.Errorf("content has %d validation issue(s):\n  %s", len(issues), strings.Join(lines, "\n  "))
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	tmpPath := outPath + ".tmp"
+	_ = os.Remove(tmpPath)
+	_ = os.Remove(outPath)
+
+	if err := buildIntoFile(tmpPath, artefacts, taxonomy, aliasesFile); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, outPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, outPath, err)
+	}
+	return nil
+}
+
+func buildIntoFile(path string, artefacts []Artefact, taxonomy Taxonomy, aliases AliasesFile) error {
+	dsn := fmt.Sprintf("file:%s?_pragma=page_size(4096)&_pragma=journal_mode(off)&_pragma=synchronous(off)&_pragma=locking_mode(exclusive)", filepath.ToSlash(path))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return fmt.Errorf("open sqlite: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(schemaDDL); err != nil {
+		return fmt.Errorf("apply schema: %w", err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	rollback := func() { _ = tx.Rollback() }
+
+	if err := insertArtefacts(tx, artefacts); err != nil {
+		rollback()
+		return err
+	}
+	if err := insertAxisValues(tx, artefacts); err != nil {
+		rollback()
+		return err
+	}
+	if err := insertEdges(tx, artefacts); err != nil {
+		rollback()
+		return err
+	}
+	if err := insertAliases(tx, aliases); err != nil {
+		rollback()
+		return err
+	}
+	if err := insertMeta(tx, taxonomy); err != nil {
+		rollback()
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+
+	if _, err := db.Exec("VACUUM"); err != nil {
+		return fmt.Errorf("vacuum: %w", err)
+	}
+	return nil
+}
+
+func insertArtefacts(tx *sql.Tx, artefacts []Artefact) error {
+	stmtMain, err := tx.Prepare(`
+        INSERT INTO artefacts(id, type, name, protocol, href, runnable, status, summary, backend_id, payload)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+	if err != nil {
+		return fmt.Errorf("prepare artefacts: %w", err)
+	}
+	defer stmtMain.Close()
+
+	stmtFTS, err := tx.Prepare(`
+        INSERT INTO artefacts_fts(id, type, name, body, aliases)
+        VALUES (?, ?, ?, ?, ?)
+    `)
+	if err != nil {
+		return fmt.Errorf("prepare artefacts_fts: %w", err)
+	}
+	defer stmtFTS.Close()
+
+	sorted := make([]Artefact, len(artefacts))
+	copy(sorted, artefacts)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	for _, a := range sorted {
+		runnable := 0
+		if a.IsRunnable() {
+			runnable = 1
+		}
+		payload, err := buildPayload(a)
+		if err != nil {
+			return fmt.Errorf("payload for %s: %w", a.ID, err)
+		}
+
+		protocol := a.Protocol
+		if protocol == "" && len(a.Protocols) == 1 {
+			protocol = a.Protocols[0]
+		}
+		if protocol == "" && a.Type == ArtefactProtocol {
+			protocol = a.ID
+		}
+
+		if _, err := stmtMain.Exec(
+			a.ID,
+			a.Type,
+			a.Name,
+			nullableString(protocol),
+			a.DefaultHref(),
+			runnable,
+			a.EffectiveStatus(),
+			nullableString(a.Summary),
+			nullableString(a.BackendID),
+			payload,
+		); err != nil {
+			return fmt.Errorf("insert artefact %s: %w", a.ID, err)
+		}
+
+		body := a.Body
+		aliasesField := strings.Join(a.Aliases, " ")
+		if _, err := stmtFTS.Exec(a.ID, a.Type, a.Name, body, aliasesField); err != nil {
+			return fmt.Errorf("insert artefacts_fts %s: %w", a.ID, err)
+		}
+	}
+	return nil
+}
+
+func insertAxisValues(tx *sql.Tx, artefacts []Artefact) error {
+	stmt, err := tx.Prepare(`INSERT INTO axis_values(artefact_id, axis, value) VALUES (?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare axis_values: %w", err)
+	}
+	defer stmt.Close()
+
+	type axisRow struct{ artefact, axis, value string }
+	var rows []axisRow
+	for _, a := range artefacts {
+		for _, v := range a.UseCases {
+			rows = append(rows, axisRow{a.ID, AxisUseCases, v})
+		}
+		for _, v := range a.Actors {
+			rows = append(rows, axisRow{a.ID, AxisActors, v})
+		}
+		for _, v := range a.Patterns {
+			rows = append(rows, axisRow{a.ID, AxisPatterns, v})
+		}
+		for _, v := range a.ProblemDomains {
+			rows = append(rows, axisRow{a.ID, AxisProblemDomains, v})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].artefact != rows[j].artefact {
+			return rows[i].artefact < rows[j].artefact
+		}
+		if rows[i].axis != rows[j].axis {
+			return rows[i].axis < rows[j].axis
+		}
+		return rows[i].value < rows[j].value
+	})
+	for _, r := range rows {
+		if _, err := stmt.Exec(r.artefact, r.axis, r.value); err != nil {
+			return fmt.Errorf("insert axis_values (%s, %s, %s): %w", r.artefact, r.axis, r.value, err)
+		}
+	}
+	return nil
+}
+
+func insertEdges(tx *sql.Tx, artefacts []Artefact) error {
+	stmt, err := tx.Prepare(`INSERT OR IGNORE INTO edges(from_id, to_id, kind) VALUES (?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare edges: %w", err)
+	}
+	defer stmt.Close()
+
+	type edgeRow struct {
+		from string
+		to   string
+		kind string
+	}
+	var rows []edgeRow
+	for _, a := range artefacts {
+		for _, ref := range a.RelatedConcepts {
+			rows = append(rows, edgeRow{a.ID, ref, string(EdgeRelatedTo)})
+			rows = append(rows, edgeRow{ref, a.ID, string(EdgeRelatedTo)})
+		}
+		for _, ref := range a.Prerequisites {
+			rows = append(rows, edgeRow{ref, a.ID, string(EdgePrerequisiteOf)})
+		}
+		if a.Type == ArtefactFlow && a.Protocol != "" {
+			rows = append(rows, edgeRow{a.ID, a.Protocol, string(EdgeProtocolOf)})
+			rows = append(rows, edgeRow{a.Protocol, a.ID, string(EdgeProtocolOf)})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].from != rows[j].from {
+			return rows[i].from < rows[j].from
+		}
+		if rows[i].to != rows[j].to {
+			return rows[i].to < rows[j].to
+		}
+		return rows[i].kind < rows[j].kind
+	})
+	for _, r := range rows {
+		if _, err := stmt.Exec(r.from, r.to, r.kind); err != nil {
+			return fmt.Errorf("insert edges (%s, %s, %s): %w", r.from, r.to, r.kind, err)
+		}
+	}
+	return nil
+}
+
+func insertAliases(tx *sql.Tx, file AliasesFile) error {
+	stmt, err := tx.Prepare(`INSERT OR IGNORE INTO aliases(alias, canonical, axis) VALUES (?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare aliases: %w", err)
+	}
+	defer stmt.Close()
+
+	type aliasRow struct {
+		alias     string
+		canonical string
+		axis      string
+	}
+	var rows []aliasRow
+	for _, entry := range file.Aliases {
+		alias := strings.ToLower(strings.TrimSpace(entry.Alias))
+		for _, c := range entry.Canonical {
+			if c.Axis != "" {
+				rows = append(rows, aliasRow{alias, c.Value, c.Axis})
+			} else {
+				rows = append(rows, aliasRow{alias, c.Artefact, ""})
+			}
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].alias != rows[j].alias {
+			return rows[i].alias < rows[j].alias
+		}
+		if rows[i].axis != rows[j].axis {
+			return rows[i].axis < rows[j].axis
+		}
+		return rows[i].canonical < rows[j].canonical
+	})
+	for _, r := range rows {
+		if _, err := stmt.Exec(r.alias, r.canonical, r.axis); err != nil {
+			return fmt.Errorf("insert alias (%s, %s, %s): %w", r.alias, r.canonical, r.axis, err)
+		}
+	}
+	return nil
+}
+
+func insertMeta(tx *sql.Tx, taxonomy Taxonomy) error {
+	stmt, err := tx.Prepare(`INSERT INTO meta(key, value) VALUES (?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare meta: %w", err)
+	}
+	defer stmt.Close()
+
+	keys := []struct{ k, v string }{
+		{"index_version", IndexVersion},
+		{"axes", strings.Join(AllAxes, ",")},
+		{"use_cases_count", fmt.Sprintf("%d", len(taxonomy.UseCases))},
+		{"actors_count", fmt.Sprintf("%d", len(taxonomy.Actors))},
+		{"patterns_count", fmt.Sprintf("%d", len(taxonomy.Patterns))},
+		{"problem_domains_count", fmt.Sprintf("%d", len(taxonomy.ProblemDomains))},
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].k < keys[j].k })
+	for _, kv := range keys {
+		if _, err := stmt.Exec(kv.k, kv.v); err != nil {
+			return fmt.Errorf("insert meta (%s): %w", kv.k, err)
+		}
+	}
+	return nil
+}
+
+// ArtefactPayload is the JSON shape stored in artefacts.payload. The query
+// service reads this column to assemble result rows without rejoining axis
+// tables, so the shape is intentionally redundant but stable.
+type ArtefactPayload struct {
+	ID               string            `json:"id"`
+	Type             string            `json:"type"`
+	Name             string            `json:"name"`
+	Protocol         string            `json:"protocol,omitempty"`
+	Protocols        []string          `json:"protocols,omitempty"`
+	UseCases         []string          `json:"use_cases"`
+	Actors           []string          `json:"actors"`
+	Patterns         []string          `json:"patterns,omitempty"`
+	ProblemDomains   []string          `json:"problem_domains"`
+	RelatedConcepts  []string          `json:"related_concepts,omitempty"`
+	Prerequisites    []string          `json:"prerequisites,omitempty"`
+	NormativeAnchors []NormativeAnchor `json:"normative_anchors,omitempty"`
+	NormativeLevel   string            `json:"normative_level,omitempty"`
+	AssertionText    string            `json:"assertion_text,omitempty"`
+	Runnable         bool              `json:"runnable"`
+	Status           string            `json:"status"`
+	Href             string            `json:"href"`
+	Summary          string            `json:"summary,omitempty"`
+	BackendID        string            `json:"backend_id,omitempty"`
+	Aliases          []string          `json:"aliases,omitempty"`
+
+	// Body holds the full markdown body of the artefact. Kept in the payload
+	// so the query service can stream the answer text inline with results
+	// without a second fetch — the corpus is small enough that the
+	// memory/disk cost is negligible. Use BodyPreview for list summaries.
+	Body string `json:"body,omitempty"`
+
+	// BodyPreview is the first paragraph of Body with markdown stripped and
+	// truncated for inline display. Always safe to render as plain text.
+	BodyPreview string `json:"body_preview,omitempty"`
+}
+
+func buildPayload(a Artefact) (string, error) {
+	p := ArtefactPayload{
+		ID:               a.ID,
+		Type:             a.Type,
+		Name:             a.Name,
+		Protocol:         a.Protocol,
+		Protocols:        a.Protocols,
+		UseCases:         a.UseCases,
+		Actors:           a.Actors,
+		Patterns:         a.Patterns,
+		ProblemDomains:   a.ProblemDomains,
+		RelatedConcepts:  a.RelatedConcepts,
+		Prerequisites:    a.Prerequisites,
+		NormativeAnchors: a.NormativeAnchors,
+		NormativeLevel:   a.NormativeLevel,
+		AssertionText:    a.AssertionText,
+		Runnable:         a.IsRunnable(),
+		Status:           a.EffectiveStatus(),
+		Href:             a.DefaultHref(),
+		Summary:          a.Summary,
+		BackendID:        a.BackendID,
+		Aliases:          a.Aliases,
+		Body:             a.Body,
+		BodyPreview:      a.PlainTextPreview(280),
+	}
+	buf, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/backend/internal/palette/index_test.go
+++ b/backend/internal/palette/index_test.go
@@ -1,0 +1,126 @@
+package palette
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestBuildIndexIdempotent(t *testing.T) {
+	contentDir := seedContent(t)
+	out1 := filepath.Join(t.TempDir(), "palette.db")
+	out2 := filepath.Join(t.TempDir(), "palette.db")
+
+	if err := BuildIndex(contentDir, out1); err != nil {
+		t.Fatalf("BuildIndex #1: %v", err)
+	}
+	if err := BuildIndex(contentDir, out2); err != nil {
+		t.Fatalf("BuildIndex #2: %v", err)
+	}
+
+	b1, err := os.ReadFile(out1)
+	if err != nil {
+		t.Fatalf("read out1: %v", err)
+	}
+	b2, err := os.ReadFile(out2)
+	if err != nil {
+		t.Fatalf("read out2: %v", err)
+	}
+	if !bytes.Equal(b1, b2) {
+		h1 := sha256.Sum256(b1)
+		h2 := sha256.Sum256(b2)
+		t.Fatalf("indexer is not idempotent: sha256(out1)=%s sha256(out2)=%s",
+			hex.EncodeToString(h1[:]), hex.EncodeToString(h2[:]))
+	}
+}
+
+func TestBuildIndexContent(t *testing.T) {
+	contentDir := seedContent(t)
+	out := filepath.Join(t.TempDir(), "palette.db")
+	if err := BuildIndex(contentDir, out); err != nil {
+		t.Fatalf("BuildIndex: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(out)+"?mode=ro")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	var artefactCount, axisCount, edgeCount, aliasCount, ftsCount int
+	row := db.QueryRow("SELECT COUNT(*) FROM artefacts")
+	if err := row.Scan(&artefactCount); err != nil {
+		t.Fatalf("count artefacts: %v", err)
+	}
+	if artefactCount != 3 {
+		t.Errorf("expected 3 artefacts, got %d", artefactCount)
+	}
+
+	if err := db.QueryRow("SELECT COUNT(*) FROM axis_values").Scan(&axisCount); err != nil {
+		t.Fatalf("count axis_values: %v", err)
+	}
+	if axisCount == 0 {
+		t.Errorf("axis_values is empty")
+	}
+
+	if err := db.QueryRow("SELECT COUNT(*) FROM edges").Scan(&edgeCount); err != nil {
+		t.Fatalf("count edges: %v", err)
+	}
+	if edgeCount == 0 {
+		t.Errorf("edges is empty (expected at least the flow→protocol edge)")
+	}
+
+	if err := db.QueryRow("SELECT COUNT(*) FROM aliases").Scan(&aliasCount); err != nil {
+		t.Fatalf("count aliases: %v", err)
+	}
+	if aliasCount == 0 {
+		t.Errorf("aliases is empty")
+	}
+
+	if err := db.QueryRow("SELECT COUNT(*) FROM artefacts_fts").Scan(&ftsCount); err != nil {
+		t.Fatalf("count artefacts_fts: %v", err)
+	}
+	if ftsCount != artefactCount {
+		t.Errorf("FTS row count (%d) != artefacts count (%d)", ftsCount, artefactCount)
+	}
+
+	// FTS5 lookup works.
+	var name string
+	err = db.QueryRow(`SELECT name FROM artefacts WHERE id IN (SELECT id FROM artefacts_fts WHERE artefacts_fts MATCH 'pkce') LIMIT 1`).Scan(&name)
+	if err != nil {
+		t.Fatalf("FTS5 lookup failed: %v", err)
+	}
+	if name == "" {
+		t.Errorf("FTS5 returned empty name")
+	}
+}
+
+func TestBuildIndexAliasComposite(t *testing.T) {
+	// aliases.yaml in seed has the "pkce" alias mapping to both an axis value
+	// and an artefact. Both rows must be present.
+	contentDir := seedContent(t)
+	out := filepath.Join(t.TempDir(), "palette.db")
+	if err := BuildIndex(contentDir, out); err != nil {
+		t.Fatalf("BuildIndex: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(out)+"?mode=ro")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM aliases WHERE alias = 'pkce'`).Scan(&n); err != nil {
+		t.Fatalf("count pkce: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 alias rows for 'pkce', got %d", n)
+	}
+}

--- a/backend/internal/palette/parse.go
+++ b/backend/internal/palette/parse.go
@@ -1,0 +1,272 @@
+package palette
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ParsedQuery is the structured form of a request after tokenisation and
+// alias resolution. Every field is deterministic given the same input and
+// catalog state.
+type ParsedQuery struct {
+	Original string
+
+	// LowerNormalised is the query lower-cased with extraneous whitespace
+	// collapsed. Used both for substring lookups and for record-keeping.
+	LowerNormalised string
+
+	// Scope and Filters are forwarded from the request after validation.
+	Scope   string
+	Filters []Filter
+
+	// PhraseMatches contains exact-phrase requirements extracted from
+	// double-quoted spans in the query.
+	PhraseMatches []string
+
+	// FreeTokens are tokens that did not participate in an alias match.
+	FreeTokens []string
+
+	// Resolved is the list of alias resolutions hit by the query. Each
+	// resolution carries the original substring that matched so the ranker
+	// can attach it to a result row as a match reason.
+	Resolved []ResolvedAlias
+}
+
+// ResolvedAlias is one alias hit. Either (Axis,Value) or Artefact is set,
+// matching the AliasCanonical shape on disk.
+type ResolvedAlias struct {
+	MatchedToken string `json:"matched_token"`
+	Axis         string `json:"axis,omitempty"`
+	Value        string `json:"value,omitempty"`
+	Artefact     string `json:"artefact,omitempty"`
+}
+
+// IsVague reports whether the runnable boost applies. A query is "vague"
+// when the user clearly has no specific concept in mind: no scope filter,
+// no explicit phrase, and no resolved canonical value.
+func (p ParsedQuery) IsVague() bool {
+	if p.Scope != "" {
+		return false
+	}
+	if len(p.Filters) > 0 {
+		return false
+	}
+	if len(p.PhraseMatches) > 0 {
+		return false
+	}
+	if len(p.Resolved) > 0 {
+		return false
+	}
+	if len(p.FreeTokens) == 0 {
+		return false
+	}
+	return true
+}
+
+// parseQuery tokenises and resolves the request. Resolution proceeds via a
+// greedy longest-match scan over up to 4-gram windows so multi-word aliases
+// such as "single sign-on" win over their component tokens.
+func parseQuery(req Request, cat catalog) ParsedQuery {
+	out := ParsedQuery{
+		Original: req.Q,
+		Scope:    sanitiseScope(req.Scope),
+		Filters:  filterValidFilters(req.Filters),
+	}
+
+	q := req.Q
+	q, phrases := extractPhrases(q)
+	out.PhraseMatches = phrases
+
+	q = strings.ToLower(q)
+	out.LowerNormalised = strings.TrimSpace(collapseSpaces(q))
+
+	q, prefixScope := extractScopePrefix(q)
+	if out.Scope == "" && prefixScope != "" {
+		out.Scope = prefixScope
+	}
+
+	tokens := tokenise(q)
+
+	used := make([]bool, len(tokens))
+	for windowSize := 4; windowSize >= 1; windowSize-- {
+		for start := 0; start+windowSize <= len(tokens); start++ {
+			if anyUsed(used, start, windowSize) {
+				continue
+			}
+			phrase := strings.Join(tokens[start:start+windowSize], " ")
+			rows, ok := cat.aliases[phrase]
+			if !ok {
+				continue
+			}
+			for _, r := range rows {
+				out.Resolved = append(out.Resolved, ResolvedAlias{
+					MatchedToken: phrase,
+					Axis:         r.Axis,
+					Value:        canonicalValue(r),
+					Artefact:     canonicalArtefact(r),
+				})
+			}
+			markUsed(used, start, windowSize)
+		}
+	}
+
+	for i, tok := range tokens {
+		if used[i] {
+			continue
+		}
+		if isStopword(tok) {
+			continue
+		}
+		out.FreeTokens = append(out.FreeTokens, tok)
+	}
+	return out
+}
+
+func canonicalValue(r aliasRow) string {
+	if r.Axis != "" {
+		return r.Canonical
+	}
+	return ""
+}
+
+func canonicalArtefact(r aliasRow) string {
+	if r.Axis != "" {
+		return ""
+	}
+	return r.Canonical
+}
+
+// scopePrefixMap defines accepted "kind:" prefixes in the free-form query.
+var scopePrefixMap = map[string]string{
+	"flow":     ScopeFlow,
+	"protocol": ScopeProtocol,
+	"spec":     ScopeSpec,
+	"concept":  ScopeConcept,
+}
+
+// extractScopePrefix consumes a leading "kind:" token if present and returns
+// the remaining query and the inferred scope. The check is performed on
+// already-lowercased input.
+func extractScopePrefix(q string) (string, string) {
+	q = strings.TrimSpace(q)
+	for prefix, scope := range scopePrefixMap {
+		if strings.HasPrefix(q, prefix+":") {
+			return strings.TrimSpace(q[len(prefix)+1:]), scope
+		}
+	}
+	return q, ""
+}
+
+// extractPhrases pulls out every double-quoted span. The returned query has
+// those spans replaced with spaces so subsequent tokenisation does not see
+// them again.
+func extractPhrases(q string) (string, []string) {
+	var phrases []string
+	var builder strings.Builder
+	builder.Grow(len(q))
+
+	inside := false
+	start := 0
+	for i, r := range q {
+		if r == '"' {
+			if inside {
+				phrase := strings.TrimSpace(q[start:i])
+				if phrase != "" {
+					phrases = append(phrases, phrase)
+				}
+				inside = false
+			} else {
+				inside = true
+				start = i + 1
+			}
+			builder.WriteByte(' ')
+			continue
+		}
+		if !inside {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String(), phrases
+}
+
+// tokenise splits on whitespace and strips trailing punctuation. Hyphens and
+// underscores stay so values like "did:web" or "openid-configuration" survive
+// (after the colon is also rewritten to a space — see explicit handling).
+func tokenise(q string) []string {
+	q = strings.ReplaceAll(q, "/", " ")
+	q = strings.ReplaceAll(q, ":", " ")
+	q = strings.ReplaceAll(q, ",", " ")
+	q = strings.ReplaceAll(q, ";", " ")
+	q = strings.ReplaceAll(q, "?", " ")
+	q = strings.ReplaceAll(q, "!", " ")
+	q = strings.ReplaceAll(q, ".", " ")
+	fields := strings.Fields(q)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimFunc(f, func(r rune) bool {
+			return unicode.IsPunct(r) && r != '-' && r != '_'
+		})
+		if f == "" {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// stopwords is intentionally small — the corpus is too domain-specific to
+// drop most "common" words.
+var stopwords = map[string]struct{}{
+	"a": {}, "an": {}, "the": {}, "of": {}, "to": {}, "for": {},
+	"with": {}, "and": {}, "or": {}, "in": {}, "on": {}, "at": {},
+	"my": {}, "our": {}, "your": {}, "their": {}, "this": {}, "that": {},
+	"how": {}, "what": {}, "where": {}, "when": {}, "do": {}, "does": {},
+	"i": {}, "me": {}, "we": {}, "is": {}, "are": {},
+}
+
+func isStopword(t string) bool {
+	_, ok := stopwords[t]
+	return ok
+}
+
+func collapseSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func anyUsed(used []bool, start, n int) bool {
+	for i := start; i < start+n; i++ {
+		if used[i] {
+			return true
+		}
+	}
+	return false
+}
+
+func markUsed(used []bool, start, n int) {
+	for i := start; i < start+n; i++ {
+		used[i] = true
+	}
+}
+
+func sanitiseScope(scope string) string {
+	if _, ok := scopeToType[scope]; ok {
+		return scope
+	}
+	return ""
+}
+
+// filterValidFilters drops filter entries with empty axis or value and
+// rejects any with an unknown axis name.
+func filterValidFilters(filters []Filter) []Filter {
+	out := make([]Filter, 0, len(filters))
+	for _, f := range filters {
+		if f.Axis == "" || f.Value == "" {
+			continue
+		}
+		if !axisAllowed(f.Axis) {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}

--- a/backend/internal/palette/query.go
+++ b/backend/internal/palette/query.go
@@ -1,0 +1,354 @@
+package palette
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	_ "modernc.org/sqlite"
+)
+
+// Scope values constrain results to one artefact type.
+const (
+	ScopeFlow     = "flow"
+	ScopeProtocol = "protocol"
+	ScopeSpec     = "spec"
+	ScopeConcept  = "concept"
+)
+
+// scopeToType maps a Request.Scope value to an artefact type. Empty scope
+// means "no scope filter".
+var scopeToType = map[string]string{
+	ScopeFlow:     ArtefactFlow,
+	ScopeProtocol: ArtefactProtocol,
+	ScopeSpec:     ArtefactSpecAssertion,
+	ScopeConcept:  ArtefactConcept,
+}
+
+// Filter is one (axis, value) constraint applied to the result set. A request
+// can carry any number of filters; they are AND-ed.
+type Filter struct {
+	Axis  string `json:"axis"`
+	Value string `json:"value"`
+}
+
+// Request is the input to Service.Query. The shape matches what the HTTP
+// handler accepts at POST /api/palette/query.
+type Request struct {
+	Q       string   `json:"q"`
+	Scope   string   `json:"scope,omitempty"`
+	Filters []Filter `json:"filters,omitempty"`
+	Limit   int      `json:"limit,omitempty"`
+}
+
+// MatchReason explains why a row surfaced. Each row carries one or two
+// reasons selected by ranker weight. The query service never synthesises
+// reasons on the frontend's behalf: every reason references a real row in
+// the index.
+type MatchReason struct {
+	Kind          string  `json:"kind"`                     // axis | alias | fts | edge | runnable | protocol-name
+	Axis          string  `json:"axis,omitempty"`           // for kind=axis | alias (when axis-typed)
+	Value         string  `json:"value,omitempty"`          // for kind=axis | alias (when axis-typed)
+	Artefact      string  `json:"artefact,omitempty"`       // for kind=alias (when artefact-typed) | edge
+	MatchedToken  string  `json:"matched_token,omitempty"`  // the query substring that triggered the match
+	MatchedPhrase string  `json:"matched_phrase,omitempty"` // for kind=fts: the FTS match snippet
+	EdgeKind      string  `json:"edge_kind,omitempty"`      // for kind=edge
+	Weight        float64 `json:"weight"`
+}
+
+// AxisChip is one labelled axis value rendered next to a result. Chips are
+// taken from the artefact's own axis lists and prioritised so the most
+// salient (e.g. matched) chips appear first.
+type AxisChip struct {
+	Axis  string `json:"axis"`
+	Value string `json:"value"`
+}
+
+// Result is a single returned row. The shape matches the prompt's example
+// response so frontend rendering does not need to translate.
+type Result struct {
+	ID           string        `json:"id"`
+	Type         string        `json:"type"`
+	Name         string        `json:"name"`
+	Summary      string        `json:"summary,omitempty"`
+	Protocol     string        `json:"protocol,omitempty"`
+	AxisChips    []AxisChip    `json:"axis_chips"`
+	MatchReasons []MatchReason `json:"match_reasons"`
+	Runnable     bool          `json:"runnable"`
+	Href         string        `json:"href"`
+	RunURL       string        `json:"run_url,omitempty"`
+	Score        float64       `json:"score"`
+	Status       string        `json:"status,omitempty"`
+
+	// BodyPreview is a plain-text first-paragraph excerpt suitable for an
+	// always-visible row summary. Distinct from Summary (which is the
+	// frontmatter `summary:` field, written for navigation labels):
+	// BodyPreview is the start of the actual answer.
+	BodyPreview string `json:"body_preview,omitempty"`
+
+	// Body is the full markdown body of the artefact. Returned on every
+	// result so the selected row can render the full answer inline without
+	// a second round-trip. The frontend renders it through a small markdown
+	// component; no HTML is ever shipped from the backend.
+	Body string `json:"body,omitempty"`
+
+	// Snippet is a query-aware excerpt of Body, with the matching tokens
+	// emitted as `<mark>` spans. Populated only when one of the free tokens
+	// hit a region of Body. Empty otherwise; callers fall back to
+	// BodyPreview when Snippet is empty.
+	Snippet string `json:"snippet,omitempty"`
+
+	// NormativeAnchors is the artefact's RFC/section list. Mirrored onto
+	// the Result so frontends can render anchor chips next to spec-cited
+	// concepts without re-reading the payload column.
+	NormativeAnchors []NormativeAnchor `json:"normative_anchors,omitempty"`
+
+	// RelatedConcepts is the artefact's `related_concepts:` list. Each
+	// entry is an artefact id; the frontend resolves names by looking up
+	// the id in the catalog (or by issuing follow-up queries via the chip).
+	RelatedConcepts []string `json:"related_concepts,omitempty"`
+
+	// SpecAssertion populates only for artefacts of type spec-assertion. The
+	// frontend renders a normative-level pill and the assertion text.
+	SpecAssertion *SpecAssertionDetails `json:"spec_assertion,omitempty"`
+}
+
+// SpecAssertionDetails carries the fields a spec-assertion result needs to
+// render. Kept out of the base Result so other result types stay compact.
+type SpecAssertionDetails struct {
+	NormativeLevel string            `json:"normative_level"`
+	AssertionText  string            `json:"assertion_text"`
+	Anchors        []NormativeAnchor `json:"anchors"`
+}
+
+// RefinementChip is shown above the result list when intent is ambiguous
+// along an axis. Clicking a chip adds it as a Filter in the next request.
+type RefinementChip struct {
+	Axis  string `json:"axis"`
+	Value string `json:"value"`
+	Count int    `json:"count"`
+}
+
+// Response is the JSON returned from Service.Query.
+type Response struct {
+	Query            string           `json:"query"`
+	Results          []Result         `json:"results"`
+	RefinementChips  []RefinementChip `json:"refinement_chips"`
+	ResolvedAliases  []ResolvedAlias  `json:"resolved_aliases"`
+	TotalCandidates  int              `json:"total_candidates"`
+	ElapsedMicros    int64            `json:"elapsed_micros"`
+}
+
+// Weights tunes scoring per axis. Use-case matches outrank everything else,
+// protocol-name aliases second, patterns and actors third. Adjusted in
+// tests; never tuned per-request.
+type Weights struct {
+	BM25            float64
+	UseCase         float64
+	ProblemDomain   float64
+	Actor           float64
+	Pattern         float64
+	ProtocolName    float64
+	Edge            float64
+	RunnableBoost   float64
+	AliasArtefact   float64
+	StatusLivePref  float64
+}
+
+// DefaultWeights returns the production weight schedule.
+func DefaultWeights() Weights {
+	return Weights{
+		BM25:           1.0,
+		UseCase:        4.0,
+		ProblemDomain:  2.0,
+		Actor:          1.5,
+		Pattern:        1.5,
+		ProtocolName:   3.0,
+		Edge:           0.5,
+		RunnableBoost:  1.0,
+		AliasArtefact:  3.5,
+		StatusLivePref: 0.25,
+	}
+}
+
+// Service is the in-memory query service. It opens the SQLite palette file
+// once at construction time and serves concurrent queries from prepared
+// statements. The DB is held in process memory after first access via
+// SQLite's mmap, but we additionally cache the artefacts table in a
+// catalog so reasoning over results does not require extra round-trips.
+type Service struct {
+	db      *sql.DB
+	weights Weights
+	catalog catalog
+	closed  bool
+	mu      sync.RWMutex
+}
+
+// catalog holds the small static tables in memory. Reloading is cheap
+// because the index is small (<200 KB for the current corpus).
+type catalog struct {
+	artefacts map[string]ArtefactPayload
+	axisIndex map[string]map[string][]string // axis -> value -> []artefactID
+	edges     map[string][]edgeRow           // from -> []edge
+	aliases   map[string][]aliasRow          // lower(alias) -> []alias-row
+}
+
+type edgeRow struct {
+	To   string
+	Kind string
+}
+
+type aliasRow struct {
+	Canonical string
+	Axis      string // "" for artefact-typed aliases
+}
+
+// NewService opens the palette database at dbPath, primes the catalog, and
+// returns a ready-to-serve Service.
+func NewService(dbPath string) (*Service, error) {
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=mmap_size(67108864)")
+	if err != nil {
+		return nil, fmt.Errorf("open palette db: %w", err)
+	}
+	db.SetMaxOpenConns(8)
+
+	svc := &Service{db: db, weights: DefaultWeights()}
+	if err := svc.loadCatalog(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return svc, nil
+}
+
+// SetWeights overrides the default weights. Mainly used in tests.
+func (s *Service) SetWeights(w Weights) {
+	s.mu.Lock()
+	s.weights = w
+	s.mu.Unlock()
+}
+
+// Close releases the underlying database handle.
+func (s *Service) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.db.Close()
+}
+
+func (s *Service) loadCatalog() error {
+	c := catalog{
+		artefacts: make(map[string]ArtefactPayload),
+		axisIndex: make(map[string]map[string][]string),
+		edges:     make(map[string][]edgeRow),
+		aliases:   make(map[string][]aliasRow),
+	}
+
+	rows, err := s.db.Query(`SELECT id, payload FROM artefacts`)
+	if err != nil {
+		return fmt.Errorf("load artefacts: %w", err)
+	}
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			rows.Close()
+			return err
+		}
+		var p ArtefactPayload
+		if err := json.Unmarshal([]byte(payload), &p); err != nil {
+			rows.Close()
+			return fmt.Errorf("decode payload for %s: %w", id, err)
+		}
+		c.artefacts[id] = p
+	}
+	rows.Close()
+
+	axisRows, err := s.db.Query(`SELECT artefact_id, axis, value FROM axis_values`)
+	if err != nil {
+		return fmt.Errorf("load axis_values: %w", err)
+	}
+	for axisRows.Next() {
+		var artefactID, axis, value string
+		if err := axisRows.Scan(&artefactID, &axis, &value); err != nil {
+			axisRows.Close()
+			return err
+		}
+		byValue, ok := c.axisIndex[axis]
+		if !ok {
+			byValue = make(map[string][]string)
+			c.axisIndex[axis] = byValue
+		}
+		byValue[value] = append(byValue[value], artefactID)
+	}
+	axisRows.Close()
+	for _, byValue := range c.axisIndex {
+		for v := range byValue {
+			sort.Strings(byValue[v])
+		}
+	}
+
+	edgeRows, err := s.db.Query(`SELECT from_id, to_id, kind FROM edges`)
+	if err != nil {
+		return fmt.Errorf("load edges: %w", err)
+	}
+	for edgeRows.Next() {
+		var from, to, kind string
+		if err := edgeRows.Scan(&from, &to, &kind); err != nil {
+			edgeRows.Close()
+			return err
+		}
+		c.edges[from] = append(c.edges[from], edgeRow{To: to, Kind: kind})
+	}
+	edgeRows.Close()
+
+	aliasRows, err := s.db.Query(`SELECT alias, canonical, axis FROM aliases`)
+	if err != nil {
+		return fmt.Errorf("load aliases: %w", err)
+	}
+	for aliasRows.Next() {
+		var alias, canonical, axis string
+		if err := aliasRows.Scan(&alias, &canonical, &axis); err != nil {
+			aliasRows.Close()
+			return err
+		}
+		c.aliases[alias] = append(c.aliases[alias], aliasRow{Canonical: canonical, Axis: axis})
+	}
+	aliasRows.Close()
+
+	s.catalog = c
+	return nil
+}
+
+// Query runs the full retrieval pipeline against the catalog and the
+// underlying FTS5 index. It is concurrency-safe: multiple queries can run
+// in parallel against the read-only DB handle.
+func (s *Service) Query(ctx context.Context, req Request) (Response, error) {
+	s.mu.RLock()
+	weights := s.weights
+	cat := s.catalog
+	s.mu.RUnlock()
+
+	limit := req.Limit
+	if limit <= 0 || limit > 50 {
+		limit = 20
+	}
+
+	parsed := parseQuery(req, cat)
+
+	cands := s.gatherCandidates(ctx, parsed, cat)
+
+	results, refinement := rankCandidates(cands, parsed, cat, weights, limit)
+
+	return Response{
+		Query:           parsed.Original,
+		Results:         results,
+		RefinementChips: refinement,
+		ResolvedAliases: parsed.Resolved,
+		TotalCandidates: len(cands),
+	}, nil
+}

--- a/backend/internal/palette/query_test.go
+++ b/backend/internal/palette/query_test.go
@@ -1,0 +1,430 @@
+package palette
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// queryServiceForTest builds an index from a temporary content tree and
+// returns a ready Service plus the temp dir. Caller closes the service.
+func queryServiceForTest(t *testing.T, contentRoot string) *Service {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "palette.db")
+	if err := BuildIndex(contentRoot, out); err != nil {
+		t.Fatalf("BuildIndex: %v", err)
+	}
+	svc, err := NewService(out)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+	return svc
+}
+
+// TestParseExtractsScopePrefix confirms a "flow:" / "protocol:" prefix sets
+// the scope without consuming the rest of the query.
+func TestParseExtractsScopePrefix(t *testing.T) {
+	cat := catalog{aliases: map[string][]aliasRow{}}
+	p := parseQuery(Request{Q: "flow:authorization code"}, cat)
+	if p.Scope != ScopeFlow {
+		t.Errorf("expected scope=%s, got %q", ScopeFlow, p.Scope)
+	}
+	if !contains(p.FreeTokens, "authorization") || !contains(p.FreeTokens, "code") {
+		t.Errorf("expected free tokens to retain query body, got %v", p.FreeTokens)
+	}
+}
+
+func TestParseResolvesAliasGreedy(t *testing.T) {
+	cat := catalog{aliases: map[string][]aliasRow{
+		"single sign on": {{Canonical: "single-sign-on", Axis: AxisUseCases}},
+		"sso":            {{Canonical: "single-sign-on", Axis: AxisUseCases}},
+	}}
+	p := parseQuery(Request{Q: "single sign on"}, cat)
+	if len(p.Resolved) != 1 {
+		t.Fatalf("expected 1 resolution, got %v", p.Resolved)
+	}
+	if p.Resolved[0].Value != "single-sign-on" || p.Resolved[0].MatchedToken != "single sign on" {
+		t.Errorf("unexpected resolution: %+v", p.Resolved[0])
+	}
+	if len(p.FreeTokens) != 0 {
+		t.Errorf("expected greedy alias to consume tokens, got free=%v", p.FreeTokens)
+	}
+}
+
+func TestParseAmbiguousAliasKeepsAllMappings(t *testing.T) {
+	cat := catalog{aliases: map[string][]aliasRow{
+		"auth": {
+			{Canonical: "authentication", Axis: AxisProblemDomains},
+			{Canonical: "authorization", Axis: AxisProblemDomains},
+		},
+	}}
+	p := parseQuery(Request{Q: "auth"}, cat)
+	if len(p.Resolved) != 2 {
+		t.Fatalf("expected 2 resolutions for ambiguous alias, got %d (%v)", len(p.Resolved), p.Resolved)
+	}
+}
+
+func TestParseIsVague(t *testing.T) {
+	cases := []struct {
+		name   string
+		req    Request
+		cat    catalog
+		expect bool
+	}{
+		{
+			name:   "no tokens",
+			req:    Request{Q: ""},
+			cat:    catalog{aliases: map[string][]aliasRow{}},
+			expect: false,
+		},
+		{
+			name:   "free tokens only",
+			req:    Request{Q: "something"},
+			cat:    catalog{aliases: map[string][]aliasRow{}},
+			expect: true,
+		},
+		{
+			name: "alias resolved",
+			req:  Request{Q: "pkce"},
+			cat: catalog{aliases: map[string][]aliasRow{
+				"pkce": {{Canonical: "pkce", Axis: ""}},
+			}},
+			expect: false,
+		},
+		{
+			name: "phrase present",
+			req:  Request{Q: `"sign in"`},
+			cat:  catalog{aliases: map[string][]aliasRow{}},
+			expect: false,
+		},
+		{
+			name: "scope set",
+			req:  Request{Q: "stuff", Scope: ScopeFlow},
+			cat:  catalog{aliases: map[string][]aliasRow{}},
+			expect: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := parseQuery(tc.req, tc.cat)
+			if got := p.IsVague(); got != tc.expect {
+				t.Errorf("IsVague() = %v, want %v (parsed=%+v)", got, tc.expect, p)
+			}
+		})
+	}
+}
+
+func TestQueryPrecisePKCE(t *testing.T) {
+	dir := seedContent(t)
+	svc := queryServiceForTest(t, dir)
+
+	resp, err := svc.Query(context.Background(), Request{Q: "pkce"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatalf("expected at least one result for 'pkce'")
+	}
+	// First result should be the pkce concept or the pkce flow.
+	first := resp.Results[0]
+	if first.ID != "pkce" && first.ID != "authorization-code-pkce" {
+		t.Errorf("unexpected top result for 'pkce': %s", first.ID)
+	}
+	// Every result must carry at least one match reason.
+	for _, r := range resp.Results {
+		if len(r.MatchReasons) == 0 {
+			t.Errorf("result %s missing match_reasons (rule: every row carries a visible reason)", r.ID)
+		}
+	}
+}
+
+func TestQueryDomainAwareSignIn(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "aliases.yaml", seedAliases+`
+  - alias: sign in
+    canonical:
+      - axis: use_cases
+        value: user-login-via-own-idp
+`)
+	svc := queryServiceForTest(t, dir)
+
+	resp, err := svc.Query(context.Background(), Request{Q: "let users sign in to my app"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatalf("expected results for 'sign in' query")
+	}
+	// "sign in" must resolve to the use_cases axis.
+	if !hasResolvedAxis(resp.ResolvedAliases, AxisUseCases, "user-login-via-own-idp") {
+		t.Errorf("expected alias resolution to user-login-via-own-idp, got %+v", resp.ResolvedAliases)
+	}
+}
+
+func TestQueryWanderingShowsRunnableBoost(t *testing.T) {
+	dir := seedContent(t)
+	svc := queryServiceForTest(t, dir)
+
+	// "authorization" hits the FTS5 index (present in every seed body) but
+	// does not match any alias, has no scope, and no quoted phrase. That's
+	// the vague case: the runnable boost should fire and the runnable
+	// authorization-code-pkce flow should outrank non-runnable peers.
+	resp, err := svc.Query(context.Background(), Request{Q: "authorization"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatalf("expected results")
+	}
+	var found bool
+	for _, r := range resp.Results {
+		for _, mr := range r.MatchReasons {
+			if mr.Kind == "runnable" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a runnable boost match reason on vague query, got results: %+v", resp.Results)
+	}
+}
+
+func TestQueryScopeFilter(t *testing.T) {
+	dir := seedContent(t)
+	svc := queryServiceForTest(t, dir)
+
+	resp, err := svc.Query(context.Background(), Request{Q: "pkce", Scope: ScopeFlow})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	for _, r := range resp.Results {
+		if r.Type != ArtefactFlow {
+			t.Errorf("scope=flow returned non-flow %s (%s)", r.ID, r.Type)
+		}
+	}
+}
+
+func TestQueryFilters(t *testing.T) {
+	dir := seedContent(t)
+	svc := queryServiceForTest(t, dir)
+
+	resp, err := svc.Query(context.Background(), Request{
+		Q: "",
+		Filters: []Filter{
+			{Axis: AxisUseCases, Value: "user-login-via-own-idp"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	for _, r := range resp.Results {
+		if !hasAxisChip(r.AxisChips, AxisUseCases, "user-login-via-own-idp") {
+			t.Errorf("result %s does not carry the filtered axis value", r.ID)
+		}
+	}
+}
+
+func TestHTTPHandlerHappyPath(t *testing.T) {
+	dir := seedContent(t)
+	svc := queryServiceForTest(t, dir)
+
+	body, _ := json.Marshal(Request{Q: "pkce"})
+	r := httptest.NewRequest(http.MethodPost, "/api/palette/query", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, r)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatalf("expected results in response, got: %s", rec.Body.String())
+	}
+}
+
+func TestHTTPHandlerRejectsGET(t *testing.T) {
+	dir := seedContent(t)
+	svc := queryServiceForTest(t, dir)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/palette/query", nil)
+	rec := httptest.NewRecorder()
+	svc.Handler().ServeHTTP(rec, r)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestQueryLatencyBudget(t *testing.T) {
+	dir := seedContent(t)
+	svc := queryServiceForTest(t, dir)
+	// Warm caches with one query.
+	_, _ = svc.Query(context.Background(), Request{Q: "pkce"})
+
+	const iterations = 50
+	var max time.Duration
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		if _, err := svc.Query(context.Background(), Request{Q: "let users sign in"}); err != nil {
+			t.Fatalf("Query: %v", err)
+		}
+		if d := time.Since(start); d > max {
+			max = d
+		}
+	}
+	if max > 20*time.Millisecond {
+		t.Errorf("worst-case query latency %v exceeds the 20ms in-process budget", max)
+	}
+}
+
+func hasResolvedAxis(resolved []ResolvedAlias, axis, value string) bool {
+	for _, r := range resolved {
+		if r.Axis == axis && r.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAxisChip(chips []AxisChip, axis, value string) bool {
+	for _, c := range chips {
+		if c.Axis == axis && c.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestQueryRefinementChips ensures axis-ambiguity detection emits chips. We
+// craft a content set wider than the default fixture for this purpose. The
+// aliases.yaml here does not reference any concept artefacts so we do not
+// have to invent stub concepts purely for the validator's edge check.
+func TestQueryRefinementChips(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "taxonomy.yaml", seedTaxonomy)
+	writeFile(t, dir, "aliases.yaml", `
+aliases:
+  - alias: oauth
+    canonical:
+      - artefact: oauth2
+`)
+	writeFile(t, dir, "protocols/oauth2.md", `---
+id: oauth2
+name: OAuth 2.0
+use_cases: [user-login-via-own-idp]
+actors: [authorization-server]
+problem_domains: [authorization]
+---
+OAuth 2.0 authorization framework.
+`)
+	for _, useCase := range []string{"user-login-via-own-idp", "service-to-service-auth"} {
+		writeFile(t, dir, "flows/oauth2/"+useCase+".md", "---\nid: "+useCase+"\nname: "+useCase+"\nprotocol: oauth2\nuse_cases:\n  - "+useCase+"\nactors:\n  - public-client\nproblem_domains:\n  - authorization\n---\nAuthorization.\n")
+	}
+	for _, concept := range []string{"a-concept", "b-concept", "c-concept"} {
+		writeFile(t, dir, "concepts/"+concept+".md", "---\nid: "+concept+"\nname: "+concept+"\nuse_cases:\n  - service-to-service-auth\nactors:\n  - authorization-server\nproblem_domains:\n  - authorization\n---\nAuthorization.\n")
+	}
+	svc := queryServiceForTest(t, dir)
+
+	resp, err := svc.Query(context.Background(), Request{Q: "authorization"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatalf("expected results")
+	}
+	for _, chip := range resp.RefinementChips {
+		if !axisAllowed(chip.Axis) {
+			t.Errorf("refinement chip has bogus axis %q", chip.Axis)
+		}
+		if chip.Count <= 0 {
+			t.Errorf("refinement chip has zero count: %+v", chip)
+		}
+	}
+}
+
+// TestServiceClose is mainly a smoke test for shutdown.
+func TestServiceClose(t *testing.T) {
+	dir := seedContent(t)
+	out := filepath.Join(t.TempDir(), "palette.db")
+	if err := BuildIndex(dir, out); err != nil {
+		t.Fatalf("BuildIndex: %v", err)
+	}
+	svc, err := NewService(out)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if err := svc.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if err := svc.Close(); err != nil {
+		t.Errorf("double Close should be a no-op: %v", err)
+	}
+}
+
+// TestSanitiseToken locks the behaviour for FTS5-safety: only [a-zA-Z0-9]
+// and word-separator hyphen/underscore survive, and the first word-piece is
+// returned (so e.g. "openid-configuration" matches "openid*").
+func TestSanitiseToken(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"oauth2", "oauth2"},
+		{"openid-configuration", "openid"},
+		{"&*$", ""},
+		{"USER", "USER"},
+	}
+	for _, c := range cases {
+		if got := sanitiseToken(c.in); got != c.want {
+			t.Errorf("sanitiseToken(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseQueryDeterministic(t *testing.T) {
+	cat := catalog{aliases: map[string][]aliasRow{
+		"sso":  {{Canonical: "single-sign-on", Axis: AxisUseCases}},
+		"pkce": {{Canonical: "pkce", Axis: ""}, {Canonical: "pkce-bound", Axis: AxisPatterns}},
+	}}
+	p1 := parseQuery(Request{Q: "sso pkce"}, cat)
+	p2 := parseQuery(Request{Q: "sso pkce"}, cat)
+
+	sortResolved(p1.Resolved)
+	sortResolved(p2.Resolved)
+
+	r1, _ := json.Marshal(p1)
+	r2, _ := json.Marshal(p2)
+	if !bytes.Equal(r1, r2) {
+		t.Errorf("parseQuery is non-deterministic:\n%s\nvs\n%s", r1, r2)
+	}
+	if !strings.Contains(string(r1), "single-sign-on") {
+		t.Errorf("expected single-sign-on in resolution, got %s", r1)
+	}
+}
+
+func sortResolved(rs []ResolvedAlias) {
+	sort.SliceStable(rs, func(i, j int) bool {
+		if rs[i].MatchedToken != rs[j].MatchedToken {
+			return rs[i].MatchedToken < rs[j].MatchedToken
+		}
+		if rs[i].Axis != rs[j].Axis {
+			return rs[i].Axis < rs[j].Axis
+		}
+		return rs[i].Value+rs[i].Artefact < rs[j].Value+rs[j].Artefact
+	})
+}

--- a/backend/internal/palette/rank.go
+++ b/backend/internal/palette/rank.go
@@ -1,0 +1,426 @@
+package palette
+
+import (
+	"sort"
+)
+
+// scored is a candidate that has been through the ranker. It carries the
+// final score plus the chosen match reasons in display order.
+type scored struct {
+	cand    *candidate
+	payload ArtefactPayload
+	score   float64
+	reasons []MatchReason
+}
+
+// rankCandidates applies the deterministic scoring function, picks the top
+// reasons per row, and assembles the final result + refinement chip lists.
+func rankCandidates(cands map[string]*candidate, parsed ParsedQuery, cat catalog, weights Weights, limit int) ([]Result, []RefinementChip) {
+	var scoredAll []scored
+
+	for id, c := range cands {
+		payload, ok := cat.artefacts[id]
+		if !ok {
+			continue
+		}
+		if !passScope(payload, parsed) {
+			continue
+		}
+		if !passFilters(payload, parsed) {
+			continue
+		}
+
+		s := score(c, payload, parsed, weights)
+		scoredAll = append(scoredAll, s)
+	}
+
+	// Stable sort: by descending score, then by id ascending for
+	// determinism when scores tie.
+	sort.SliceStable(scoredAll, func(i, j int) bool {
+		if scoredAll[i].score != scoredAll[j].score {
+			return scoredAll[i].score > scoredAll[j].score
+		}
+		return scoredAll[i].cand.ID < scoredAll[j].cand.ID
+	})
+
+	if len(scoredAll) > limit {
+		scoredAll = scoredAll[:limit]
+	}
+
+	results := make([]Result, 0, len(scoredAll))
+	for _, s := range scoredAll {
+		results = append(results, toResult(s, cat, parsed))
+	}
+
+	chips := detectRefinementChips(scoredAll, parsed)
+	return results, chips
+}
+
+// passScope keeps only artefacts of the requested type, mapping the public
+// scope name to the artefact type used in the index.
+func passScope(p ArtefactPayload, parsed ParsedQuery) bool {
+	if parsed.Scope == "" {
+		return true
+	}
+	wantType, ok := scopeToType[parsed.Scope]
+	if !ok {
+		return true
+	}
+	return p.Type == wantType
+}
+
+func passFilters(p ArtefactPayload, parsed ParsedQuery) bool {
+	for _, f := range parsed.Filters {
+		if !payloadHasAxisValue(p, f.Axis, f.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+func payloadHasAxisValue(p ArtefactPayload, axis, value string) bool {
+	values := axisValues(p, axis)
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func axisValues(p ArtefactPayload, axis string) []string {
+	switch axis {
+	case AxisUseCases:
+		return p.UseCases
+	case AxisActors:
+		return p.Actors
+	case AxisPatterns:
+		return p.Patterns
+	case AxisProblemDomains:
+		return p.ProblemDomains
+	}
+	return nil
+}
+
+// score assigns a numeric score and selects up to two visible match reasons
+// for the row.
+//
+//	score = w_bm25 * bm25_norm
+//	      + w_axis * sum(axis weights of matched axis values)
+//	      + w_edge * edge_proximity
+//	      + w_runnable * runnable_boost (only when query is vague)
+//	      + w_alias_artefact * alias-artefact hit
+//	      + w_protocol_name * protocol-name hit
+//	      + w_status_live * status pref
+//
+// Use-case axis matches outweigh other axes by construction; protocol-name
+// alias hits land between use-case and pattern/actor.
+func score(c *candidate, payload ArtefactPayload, parsed ParsedQuery, weights Weights) scored {
+	var total float64
+	var reasons []MatchReason
+
+	if c.BM25 > 0 {
+		w := weights.BM25 * c.BM25
+		total += w
+		reasons = append(reasons, MatchReason{
+			Kind:          "fts",
+			MatchedPhrase: c.BM25Phrase,
+			Weight:        w,
+		})
+	}
+
+	axisSeen := make(map[string]struct{})
+	for _, hit := range c.axisHits {
+		key := hit.axis + "::" + hit.value
+		if _, dup := axisSeen[key]; dup {
+			continue
+		}
+		axisSeen[key] = struct{}{}
+		w := weightForAxis(weights, hit.axis)
+		total += w
+		reasons = append(reasons, MatchReason{
+			Kind:         "axis",
+			Axis:         hit.axis,
+			Value:        hit.value,
+			MatchedToken: hit.matchedToken,
+			Weight:       w,
+		})
+	}
+
+	if c.protocolHit != nil {
+		w := weights.ProtocolName
+		total += w
+		reasons = append(reasons, MatchReason{
+			Kind:         "protocol-name",
+			Artefact:     payload.ID,
+			MatchedToken: c.protocolHit.matchedToken,
+			Weight:       w,
+		})
+	}
+
+	aliasArtefactSeen := make(map[string]struct{})
+	for _, h := range c.aliasHits {
+		if h.artefact == "" {
+			continue
+		}
+		if _, dup := aliasArtefactSeen[h.artefact]; dup {
+			continue
+		}
+		aliasArtefactSeen[h.artefact] = struct{}{}
+		if h.artefact != payload.ID {
+			continue
+		}
+		w := weights.AliasArtefact
+		total += w
+		reasons = append(reasons, MatchReason{
+			Kind:         "alias",
+			Artefact:     h.artefact,
+			MatchedToken: h.matchedToken,
+			Weight:       w,
+		})
+	}
+
+	if len(c.edgeHits) > 0 {
+		w := weights.Edge * float64(len(c.edgeHits)) / float64(1+len(c.edgeHits))
+		total += w
+		reasons = append(reasons, MatchReason{
+			Kind:     "edge",
+			Artefact: c.edgeHits[0].via,
+			EdgeKind: c.edgeHits[0].kind,
+			Weight:   w,
+		})
+	}
+
+	if parsed.IsVague() && payload.Runnable {
+		w := weights.RunnableBoost
+		total += w
+		reasons = append(reasons, MatchReason{
+			Kind:   "runnable",
+			Weight: w,
+		})
+	}
+
+	if payload.Status == StatusLive {
+		total += weights.StatusLivePref
+	}
+
+	// Pick at most two visible reasons by weight, descending.
+	sort.SliceStable(reasons, func(i, j int) bool {
+		if reasons[i].Weight != reasons[j].Weight {
+			return reasons[i].Weight > reasons[j].Weight
+		}
+		// Tie-breaker so the choice is deterministic.
+		return reasonKey(reasons[i]) < reasonKey(reasons[j])
+	})
+	if len(reasons) > 2 {
+		reasons = reasons[:2]
+	}
+
+	return scored{cand: c, payload: payload, score: total, reasons: reasons}
+}
+
+func reasonKey(r MatchReason) string {
+	return r.Kind + "|" + r.Axis + "|" + r.Value + "|" + r.Artefact + "|" + r.MatchedToken + "|" + r.EdgeKind
+}
+
+func weightForAxis(w Weights, axis string) float64 {
+	switch axis {
+	case AxisUseCases:
+		return w.UseCase
+	case AxisProblemDomains:
+		return w.ProblemDomain
+	case AxisActors:
+		return w.Actor
+	case AxisPatterns:
+		return w.Pattern
+	}
+	return 0
+}
+
+// toResult turns a scored candidate into the externally-visible Result row.
+// AxisChips prioritises matched axis values (so they appear first) and then
+// fills with the artefact's remaining axis values.
+func toResult(s scored, cat catalog, parsed ParsedQuery) Result {
+	matched := make(map[string]struct{})
+	for _, r := range s.reasons {
+		if r.Axis == "" || r.Value == "" {
+			continue
+		}
+		matched[r.Axis+"::"+r.Value] = struct{}{}
+	}
+
+	var chips []AxisChip
+	addChip := func(axis, value string) {
+		chips = append(chips, AxisChip{Axis: axis, Value: value})
+	}
+
+	// Matched chips first, in axis order.
+	for _, axis := range AllAxes {
+		for _, v := range axisValues(s.payload, axis) {
+			if _, ok := matched[axis+"::"+v]; ok {
+				addChip(axis, v)
+			}
+		}
+	}
+	// Remaining axis values up to a sensible cap.
+	for _, axis := range AllAxes {
+		for _, v := range axisValues(s.payload, axis) {
+			if _, ok := matched[axis+"::"+v]; ok {
+				continue
+			}
+			if len(chips) >= 6 {
+				break
+			}
+			addChip(axis, v)
+		}
+		if len(chips) >= 6 {
+			break
+		}
+	}
+
+	result := Result{
+		ID:               s.payload.ID,
+		Type:             s.payload.Type,
+		Name:             s.payload.Name,
+		Summary:          s.payload.Summary,
+		Protocol:         s.payload.Protocol,
+		AxisChips:        chips,
+		MatchReasons:     s.reasons,
+		Runnable:         s.payload.Runnable,
+		Href:             s.payload.Href,
+		Score:            s.score,
+		Status:           s.payload.Status,
+		Body:             s.payload.Body,
+		BodyPreview:      s.payload.BodyPreview,
+		NormativeAnchors: s.payload.NormativeAnchors,
+		RelatedConcepts:  s.payload.RelatedConcepts,
+	}
+	if result.Runnable && s.payload.Type == ArtefactFlow {
+		result.RunURL = runURLFor(s.payload)
+	}
+	if s.payload.Type == ArtefactSpecAssertion {
+		result.SpecAssertion = &SpecAssertionDetails{
+			NormativeLevel: s.payload.NormativeLevel,
+			AssertionText:  s.payload.AssertionText,
+			Anchors:        s.payload.NormativeAnchors,
+		}
+	}
+	if snip := buildSnippet(s.payload.Body, snippetTokens(parsed)); snip != "" {
+		result.Snippet = snip
+	}
+	return result
+}
+
+// snippetTokens returns the union of tokens that should highlight in body
+// snippets: free tokens, alias-matched tokens (which would otherwise be
+// consumed out of FreeTokens), and explicit quoted phrases. Without alias
+// tokens, a query like "pkce" — which the parser resolves entirely as an
+// alias to the PKCE artefact — would produce zero free tokens and no
+// snippet highlighting in the rendered result.
+func snippetTokens(p ParsedQuery) []string {
+	out := make([]string, 0, len(p.FreeTokens)+len(p.Resolved)+len(p.PhraseMatches))
+	out = append(out, p.FreeTokens...)
+	seen := make(map[string]struct{}, len(out))
+	for _, t := range out {
+		seen[t] = struct{}{}
+	}
+	for _, r := range p.Resolved {
+		if r.MatchedToken == "" {
+			continue
+		}
+		if _, ok := seen[r.MatchedToken]; ok {
+			continue
+		}
+		seen[r.MatchedToken] = struct{}{}
+		out = append(out, r.MatchedToken)
+	}
+	for _, phr := range p.PhraseMatches {
+		if phr == "" {
+			continue
+		}
+		if _, ok := seen[phr]; ok {
+			continue
+		}
+		seen[phr] = struct{}{}
+		out = append(out, phr)
+	}
+	return out
+}
+
+// runURLFor returns the Looking Glass run URL for a runnable flow. The
+// frontend POSTs to /api/protocols/{protocol}/demo/{backend_id} via the
+// Looking Glass page; the URL itself is what the palette navigates to.
+func runURLFor(p ArtefactPayload) string {
+	protocol := p.Protocol
+	if protocol == "" && len(p.Protocols) == 1 {
+		protocol = p.Protocols[0]
+	}
+	backend := p.BackendID
+	if backend == "" {
+		backend = p.ID
+	}
+	if protocol == "" {
+		return ""
+	}
+	return "/looking-glass?protocol=" + protocol + "&flow=" + backend
+}
+
+// refinementChipMinDistinct sets how many distinct values an axis must show
+// across the top results before we surface refinement chips for it. Below
+// this threshold the axis is not interestingly ambiguous.
+const refinementChipMinDistinct = 3
+
+// detectRefinementChips counts distinct axis values across the top results
+// and emits chips for any axis whose distinct-value count meets the
+// threshold. The chips are ordered by descending count then ascending value
+// for determinism.
+func detectRefinementChips(top []scored, parsed ParsedQuery) []RefinementChip {
+	if len(top) == 0 {
+		return nil
+	}
+	counts := make(map[string]map[string]int)
+	for _, axis := range AllAxes {
+		counts[axis] = make(map[string]int)
+	}
+	for _, s := range top {
+		for _, axis := range AllAxes {
+			for _, v := range axisValues(s.payload, axis) {
+				counts[axis][v]++
+			}
+		}
+	}
+
+	existingFilters := make(map[string]struct{})
+	for _, f := range parsed.Filters {
+		existingFilters[f.Axis+"::"+f.Value] = struct{}{}
+	}
+
+	var chips []RefinementChip
+	for _, axis := range AllAxes {
+		if len(counts[axis]) < refinementChipMinDistinct {
+			continue
+		}
+		for value, n := range counts[axis] {
+			if _, applied := existingFilters[axis+"::"+value]; applied {
+				continue
+			}
+			chips = append(chips, RefinementChip{Axis: axis, Value: value, Count: n})
+		}
+	}
+
+	sort.SliceStable(chips, func(i, j int) bool {
+		if chips[i].Count != chips[j].Count {
+			return chips[i].Count > chips[j].Count
+		}
+		if chips[i].Axis != chips[j].Axis {
+			return chips[i].Axis < chips[j].Axis
+		}
+		return chips[i].Value < chips[j].Value
+	})
+
+	// Cap chip list. Too many chips just clutter the UI.
+	if len(chips) > 8 {
+		chips = chips[:8]
+	}
+	return chips
+}

--- a/backend/internal/palette/rank.go
+++ b/backend/internal/palette/rank.go
@@ -49,7 +49,7 @@ func rankCandidates(cands map[string]*candidate, parsed ParsedQuery, cat catalog
 
 	results := make([]Result, 0, len(scoredAll))
 	for _, s := range scoredAll {
-		results = append(results, toResult(s, cat, parsed))
+		results = append(results, toResult(s, parsed))
 	}
 
 	chips := detectRefinementChips(scoredAll, parsed)
@@ -240,7 +240,7 @@ func weightForAxis(w Weights, axis string) float64 {
 // toResult turns a scored candidate into the externally-visible Result row.
 // AxisChips prioritises matched axis values (so they appear first) and then
 // fills with the artefact's remaining axis values.
-func toResult(s scored, cat catalog, parsed ParsedQuery) Result {
+func toResult(s scored, parsed ParsedQuery) Result {
 	matched := make(map[string]struct{})
 	for _, r := range s.reasons {
 		if r.Axis == "" || r.Value == "" {

--- a/backend/internal/palette/run_url_test.go
+++ b/backend/internal/palette/run_url_test.go
@@ -1,0 +1,61 @@
+package palette
+
+import "testing"
+
+// TestRunURLForFlow_DeepLinkContract pins the wire shape of the Looking Glass deep-link URL emitted on PaletteResult.run_url.
+//
+// The shape `/looking-glass?protocol=X&flow=Y` is the contract that the frontend's `parseFlowDeepLink` (and the LookingGlass deep-link effect) depend on.
+// Changing the path or the parameter names here withoutpdating the frontend would silently break:
+//
+//   - Cmd+K palette dispatch to a runnable flow.
+//   - Shared/bookmarked /looking-glass URLs.
+//   - In-page palette re-dispatch while already on /looking-glass.
+//
+// This test makes that contract 'loud' rather than letting it drift.
+func TestRunURLForFlow_DeepLinkContract(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ArtefactPayload
+		want string
+	}{
+		{
+			name: "protocol + id, no backend_id",
+			in: ArtefactPayload{
+				ID:       "authorization-code",
+				Protocol: "oauth2",
+			},
+			want: "/looking-glass?protocol=oauth2&flow=authorization-code",
+		},
+		{
+			name: "backend_id overrides id when set",
+			in: ArtefactPayload{
+				ID:        "authorization-code-pkce",
+				Protocol:  "oauth2",
+				BackendID: "authorization_code_pkce",
+			},
+			want: "/looking-glass?protocol=oauth2&flow=authorization_code_pkce",
+		},
+		{
+			name: "single-element Protocols falls back when Protocol empty",
+			in: ArtefactPayload{
+				ID:        "issue-credential",
+				Protocols: []string{"oid4vci"},
+			},
+			want: "/looking-glass?protocol=oid4vci&flow=issue-credential",
+		},
+		{
+			name: "no protocol resolves to empty (frontend skips dispatch)",
+			in: ArtefactPayload{
+				ID: "orphan-flow",
+			},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runURLFor(tc.in); got != tc.want {
+				t.Errorf("runURLFor = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/palette/schema.go
+++ b/backend/internal/palette/schema.go
@@ -1,0 +1,84 @@
+package palette
+
+// schemaDDL is the complete schema for the palette index. It is intentionally
+// written as a single multi-statement script so the indexer can apply it as
+// one Exec call and so its hash uniquely identifies the on-disk format
+// version.
+//
+// The schema differs from the prose sketch in the prompt in one place: the
+// aliases table uses a composite primary key so an ambiguous alias can map to
+// multiple canonical targets (the prompt explicitly requires this behaviour;
+// the sketched single-key schema does not).
+const schemaDDL = `
+CREATE VIRTUAL TABLE artefacts_fts USING fts5(
+    id UNINDEXED,
+    type UNINDEXED,
+    name,
+    body,
+    aliases,
+    tokenize='porter unicode61'
+);
+
+CREATE TABLE artefacts (
+    id        TEXT PRIMARY KEY,
+    type      TEXT NOT NULL,
+    name      TEXT NOT NULL,
+    protocol  TEXT,
+    href      TEXT,
+    runnable  INTEGER NOT NULL DEFAULT 0,
+    status    TEXT NOT NULL,
+    summary   TEXT,
+    backend_id TEXT,
+    payload   TEXT NOT NULL
+);
+
+CREATE TABLE axis_values (
+    artefact_id TEXT NOT NULL,
+    axis        TEXT NOT NULL,
+    value       TEXT NOT NULL,
+    PRIMARY KEY (artefact_id, axis, value)
+) WITHOUT ROWID;
+CREATE INDEX idx_axis_values_value ON axis_values (axis, value);
+
+CREATE TABLE edges (
+    from_id TEXT NOT NULL,
+    to_id   TEXT NOT NULL,
+    kind    TEXT NOT NULL,
+    PRIMARY KEY (from_id, to_id, kind)
+) WITHOUT ROWID;
+CREATE INDEX idx_edges_to ON edges (to_id);
+
+CREATE TABLE aliases (
+    alias     TEXT NOT NULL COLLATE NOCASE,
+    canonical TEXT NOT NULL,
+    axis      TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (alias, canonical, axis)
+) WITHOUT ROWID;
+CREATE INDEX idx_aliases_alias ON aliases (alias COLLATE NOCASE);
+
+CREATE TABLE meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+) WITHOUT ROWID;
+`
+
+// EdgeKind is the closed set of edge relations stored in the edges table.
+type EdgeKind string
+
+const (
+	// EdgeRelatedTo is a symmetric concept-to-concept link. The indexer
+	// writes both directions so traversal does not need to consider order.
+	EdgeRelatedTo EdgeKind = "related-to"
+
+	// EdgePrerequisiteOf is a one-way link: the from artefact is a
+	// prerequisite for understanding the to artefact.
+	EdgePrerequisiteOf EdgeKind = "prerequisite-of"
+
+	// EdgeGoverns is a one-way link from a spec-assertion artefact to
+	// every artefact it normatively governs.
+	EdgeGoverns EdgeKind = "governs"
+
+	// EdgeProtocolOf is a one-way link from a flow to its protocol. It
+	// makes flow ↔ protocol traversal cheap during the candidates stage.
+	EdgeProtocolOf EdgeKind = "protocol-of"
+)

--- a/backend/internal/palette/snippet.go
+++ b/backend/internal/palette/snippet.go
@@ -1,0 +1,175 @@
+package palette
+
+import (
+	"strings"
+	"unicode"
+)
+
+// buildSnippet returns a query-aware excerpt of body containing the
+// first sentence (or two) that mention any of tokens. Matching tokens
+// are wrapped in <mark>...</mark> spans. The frontend renders these as
+// highlighted text — no other HTML is ever shipped from the backend so
+// the renderer can treat <mark> as the only special token.
+//
+// Returns an empty string when no token hits the body. Callers fall back
+// to the static BodyPreview in that case.
+//
+// Deterministic: same body + same tokens always produces the same snippet.
+func buildSnippet(body string, tokens []string) string {
+	if body == "" || len(tokens) == 0 {
+		return ""
+	}
+	// Normalise: lowercase tokens and keep only meaningful ones (>=3 chars).
+	clean := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if len(t) < 3 {
+			continue
+		}
+		clean = append(clean, t)
+	}
+	if len(clean) == 0 {
+		return ""
+	}
+
+	sentences := splitSentences(body)
+	if len(sentences) == 0 {
+		return ""
+	}
+
+	// Pick the first sentence that contains any token.
+	best := -1
+	for i, s := range sentences {
+		lower := strings.ToLower(s)
+		for _, tok := range clean {
+			if strings.Contains(lower, tok) {
+				best = i
+				break
+			}
+		}
+		if best >= 0 {
+			break
+		}
+	}
+	if best < 0 {
+		return ""
+	}
+
+	// Include one sentence of trailing context when available; the snippet
+	// then averages ~2 sentences which is what reads well in a result row.
+	end := best + 1
+	if end < len(sentences) {
+		end++
+	}
+	excerpt := strings.TrimSpace(strings.Join(sentences[best:end], " "))
+
+	// Cap the excerpt length so a runaway paragraph cannot inflate
+	// response payloads.
+	const maxLen = 360
+	if len(excerpt) > maxLen {
+		cut := excerpt[:maxLen]
+		if sp := strings.LastIndex(cut, " "); sp > maxLen/2 {
+			cut = cut[:sp]
+		}
+		excerpt = strings.TrimRight(cut, " ,.;:") + "..."
+	}
+
+	return highlightTokens(excerpt, clean)
+}
+
+// splitSentences slices a markdown body into rough sentences. The corpus
+// uses standard English punctuation; we split on '.', '!', '?' followed by
+// whitespace. We do not attempt to handle abbreviations because the corpus
+// does not need it; if that changes, add a small exception list here.
+func splitSentences(body string) []string {
+	body = strings.ReplaceAll(body, "\r", "")
+	// Treat blank-line paragraph breaks the same as sentence breaks so a
+	// preceding paragraph that ends mid-sentence (rare in our corpus) does
+	// not get glued to the next.
+	body = strings.ReplaceAll(body, "\n\n", ". ")
+	body = strings.ReplaceAll(body, "\n", " ")
+
+	var sentences []string
+	var b strings.Builder
+	runes := []rune(body)
+	for i, r := range runes {
+		b.WriteRune(r)
+		if r == '.' || r == '!' || r == '?' {
+			if i+1 >= len(runes) || unicode.IsSpace(runes[i+1]) {
+				s := strings.TrimSpace(b.String())
+				if s != "" {
+					sentences = append(sentences, s)
+				}
+				b.Reset()
+			}
+		}
+	}
+	if rem := strings.TrimSpace(b.String()); rem != "" {
+		sentences = append(sentences, rem)
+	}
+	return sentences
+}
+
+// highlightTokens wraps each case-insensitive occurrence of any token with
+// <mark>...</mark>. Token matches are case-insensitive but the original
+// casing in body is preserved. Existing literal "<mark>" / "</mark>" in
+// the body (none in the current corpus) would be passed through unchanged;
+// we accept that because we control the corpus.
+func highlightTokens(body string, tokens []string) string {
+	if len(tokens) == 0 {
+		return body
+	}
+	lower := strings.ToLower(body)
+	type match struct{ start, end int }
+	var matches []match
+	for _, tok := range tokens {
+		if tok == "" {
+			continue
+		}
+		from := 0
+		for {
+			idx := strings.Index(lower[from:], tok)
+			if idx < 0 {
+				break
+			}
+			start := from + idx
+			end := start + len(tok)
+			matches = append(matches, match{start, end})
+			from = end
+		}
+	}
+	if len(matches) == 0 {
+		return body
+	}
+
+	// Sort by start, then merge overlapping ranges so we never emit nested
+	// <mark> tags.
+	for i := 1; i < len(matches); i++ {
+		for j := i; j > 0 && matches[j-1].start > matches[j].start; j-- {
+			matches[j-1], matches[j] = matches[j], matches[j-1]
+		}
+	}
+	merged := matches[:0]
+	for _, m := range matches {
+		if len(merged) == 0 || m.start > merged[len(merged)-1].end {
+			merged = append(merged, m)
+			continue
+		}
+		if m.end > merged[len(merged)-1].end {
+			merged[len(merged)-1].end = m.end
+		}
+	}
+
+	var out strings.Builder
+	out.Grow(len(body) + len(merged)*15)
+	last := 0
+	for _, m := range merged {
+		out.WriteString(body[last:m.start])
+		out.WriteString("<mark>")
+		out.WriteString(body[m.start:m.end])
+		out.WriteString("</mark>")
+		last = m.end
+	}
+	out.WriteString(body[last:])
+	return out.String()
+}

--- a/backend/internal/palette/snippet_test.go
+++ b/backend/internal/palette/snippet_test.go
@@ -1,0 +1,187 @@
+package palette
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPlainTextPreviewStripsMarkdown(t *testing.T) {
+	a := Artefact{Body: "PKCE (Proof Key for Code Exchange, **RFC 7636**) protects the\nauthorization code grant against `code_verifier` capture.\n\nSecond paragraph not included."}
+	p := a.PlainTextPreview(120)
+	if strings.Contains(p, "**") || strings.Contains(p, "`") {
+		t.Errorf("expected markdown stripped, got %q", p)
+	}
+	if strings.Contains(p, "Second paragraph") {
+		t.Errorf("preview should stop at the first blank line, got %q", p)
+	}
+	if !strings.Contains(p, "RFC 7636") {
+		t.Errorf("expected RFC 7636 text retained, got %q", p)
+	}
+}
+
+func TestPlainTextPreviewTruncatesOnWordBoundary(t *testing.T) {
+	a := Artefact{Body: "The authorization server validates the code_verifier against the stored code_challenge before issuing tokens."}
+	p := a.PlainTextPreview(40)
+	if len(p) > 45 {
+		t.Errorf("expected preview <= ~40 chars, got %d: %q", len(p), p)
+	}
+	if !strings.HasSuffix(p, "...") {
+		t.Errorf("expected ellipsis suffix on truncation, got %q", p)
+	}
+	if strings.Contains(p, " v") && !strings.HasSuffix(p, "...") {
+		// Ensure we did not cut a word in half.
+		t.Errorf("preview cut mid-word: %q", p)
+	}
+}
+
+func TestBuildSnippetReturnsEmptyWhenNoTokenMatches(t *testing.T) {
+	body := "OAuth 2.0 is the authorization framework defined by RFC 6749."
+	if got := buildSnippet(body, []string{"saml", "xml"}); got != "" {
+		t.Errorf("expected empty snippet, got %q", got)
+	}
+}
+
+func TestBuildSnippetHighlightsMatchingTokens(t *testing.T) {
+	body := "OAuth 2.0 is the authorization framework defined by RFC 6749. It lets a client application obtain limited access to a resource server."
+	got := buildSnippet(body, []string{"authorization"})
+	if got == "" {
+		t.Fatal("expected snippet for 'authorization', got empty")
+	}
+	if !strings.Contains(got, "<mark>authorization</mark>") {
+		t.Errorf("expected <mark> wrapping around 'authorization', got %q", got)
+	}
+}
+
+func TestBuildSnippetIncludesTrailingContextSentence(t *testing.T) {
+	body := "PKCE protects against code interception. The client generates a high-entropy verifier. The verifier is presented at the token endpoint."
+	got := buildSnippet(body, []string{"pkce"})
+	if got == "" {
+		t.Fatal("expected snippet, got empty")
+	}
+	// Should include the matched sentence + one trailing context sentence.
+	if !strings.Contains(got, "client generates") {
+		t.Errorf("expected trailing context, got %q", got)
+	}
+}
+
+func TestBuildSnippetMergesOverlappingMatches(t *testing.T) {
+	// Two tokens that match the same word should not double-wrap.
+	body := "Authorization is hard."
+	got := buildSnippet(body, []string{"authorization", "authoriz"})
+	// At most one <mark>...</mark> wrapping per occurrence.
+	if strings.Count(got, "<mark>") != strings.Count(got, "</mark>") {
+		t.Errorf("unbalanced <mark> tags in %q", got)
+	}
+	if strings.Contains(got, "<mark><mark>") {
+		t.Errorf("nested <mark> tags in %q", got)
+	}
+}
+
+func TestBuildSnippetCapsLength(t *testing.T) {
+	// Construct a body longer than the maxLen so we can verify the cap.
+	long := strings.Repeat("authorization is the cornerstone of modern api access patterns. ", 20)
+	got := buildSnippet(long, []string{"authorization"})
+	if len(got) == 0 {
+		t.Fatal("expected snippet, got empty")
+	}
+	// 360 cap + <mark> tags around each occurrence; ceiling well under 1 KB.
+	if len(got) > 1024 {
+		t.Errorf("snippet too long: %d chars", len(got))
+	}
+}
+
+// TestSnippetTokensIncludeAliasMatches verifies that when a query is
+// resolved entirely through an alias (no free tokens left), the snippet
+// builder still receives the original matched token so highlights work.
+// Regression: live testing showed `q="pkce"` resolved to the pkce artefact
+// alias, leaving FreeTokens empty and producing an un-highlighted snippet.
+func TestSnippetTokensIncludeAliasMatches(t *testing.T) {
+	parsed := ParsedQuery{
+		FreeTokens: nil,
+		Resolved: []ResolvedAlias{
+			{MatchedToken: "pkce", Artefact: "pkce"},
+		},
+	}
+	got := snippetTokens(parsed)
+	if len(got) != 1 || got[0] != "pkce" {
+		t.Errorf("expected ['pkce'], got %v", got)
+	}
+}
+
+func TestSnippetTokensDeduplicatesAcrossSources(t *testing.T) {
+	parsed := ParsedQuery{
+		FreeTokens:    []string{"pkce", "verifier"},
+		Resolved:      []ResolvedAlias{{MatchedToken: "pkce"}},
+		PhraseMatches: []string{"verifier"},
+	}
+	got := snippetTokens(parsed)
+	if len(got) != 2 {
+		t.Errorf("expected dedup to 2 tokens, got %v", got)
+	}
+}
+
+func TestIndexerStoresBodyAndPreviewOnResult(t *testing.T) {
+	svc := queryServiceForTest(t, seedContent(t))
+	defer svc.Close()
+
+	// "authorization" hits the body of the seed PKCE concept
+	// ("Binds an authorization request to a per-request code_verifier").
+	resp, err := svc.Query(t.Context(), Request{Q: "authorization"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatal("expected results")
+	}
+
+	var found *Result
+	for i := range resp.Results {
+		if resp.Results[i].ID == "pkce" {
+			found = &resp.Results[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected pkce result in seed content")
+	}
+	if found.Body == "" {
+		t.Error("Result.Body empty; expected full markdown body")
+	}
+	if found.BodyPreview == "" {
+		t.Error("Result.BodyPreview empty; expected first-paragraph preview")
+	}
+	if found.Snippet == "" {
+		t.Error("Result.Snippet empty for query that matches body")
+	} else if !strings.Contains(found.Snippet, "<mark>") {
+		t.Errorf("expected highlighted snippet, got %q", found.Snippet)
+	}
+}
+
+// TestNormativeAnchorJSONFieldNames locks the wire shape of NormativeAnchor.
+// The frontend reads `rfc`/`sections` (lowercase); without explicit JSON
+// tags Go would emit `RFC`/`Sections` and the React row crashes on
+// `anchor.sections.length`. This test prevents that regression.
+func TestNormativeAnchorJSONFieldNames(t *testing.T) {
+	a := NormativeAnchor{RFC: "RFC 7636", Sections: []string{"4.1.3"}}
+	raw, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(raw)
+	want := `{"rfc":"RFC 7636","sections":["4.1.3"]}`
+	if got != want {
+		t.Errorf("NormativeAnchor JSON shape drift:\n got %s\nwant %s", got, want)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := decoded["rfc"]; !ok {
+		t.Error("decoded JSON missing lowercase `rfc`")
+	}
+	if _, ok := decoded["sections"]; !ok {
+		t.Error("decoded JSON missing lowercase `sections`")
+	}
+}

--- a/backend/internal/palette/taxonomy.go
+++ b/backend/internal/palette/taxonomy.go
@@ -1,0 +1,170 @@
+package palette
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TaxonomyEntry is one controlled-vocabulary value. The note is human-readable
+// guidance for authors and is surfaced in result chips for self-explanation.
+type TaxonomyEntry struct {
+	Note string `yaml:"note"`
+}
+
+// Taxonomy is the parsed taxonomy.yaml file. Each map is keyed by canonical
+// value; values are taxonomy entries.
+type Taxonomy struct {
+	UseCases       map[string]TaxonomyEntry `yaml:"use_cases"`
+	Actors         map[string]TaxonomyEntry `yaml:"actors"`
+	Patterns       map[string]TaxonomyEntry `yaml:"patterns"`
+	ProblemDomains map[string]TaxonomyEntry `yaml:"problem_domains"`
+}
+
+// Has reports whether the given (axis, value) pair is in the taxonomy.
+func (t Taxonomy) Has(axis, value string) bool {
+	switch axis {
+	case AxisUseCases:
+		_, ok := t.UseCases[value]
+		return ok
+	case AxisActors:
+		_, ok := t.Actors[value]
+		return ok
+	case AxisPatterns:
+		_, ok := t.Patterns[value]
+		return ok
+	case AxisProblemDomains:
+		_, ok := t.ProblemDomains[value]
+		return ok
+	}
+	return false
+}
+
+// Axis names. Kept in one place so taxonomy, aliases, and the query API all
+// agree on the spelling.
+const (
+	AxisUseCases       = "use_cases"
+	AxisActors         = "actors"
+	AxisPatterns       = "patterns"
+	AxisProblemDomains = "problem_domains"
+)
+
+// AllAxes is the closed set of retrieval axes.
+var AllAxes = []string{AxisUseCases, AxisActors, AxisPatterns, AxisProblemDomains}
+
+// LoadTaxonomy parses taxonomy.yaml from the given content root and validates
+// the file shape. It does not validate that the values are referenced; the
+// validator does that against the artefact set.
+func LoadTaxonomy(contentRoot string) (Taxonomy, error) {
+	raw, err := os.ReadFile(filepath.Join(contentRoot, "taxonomy.yaml"))
+	if err != nil {
+		return Taxonomy{}, fmt.Errorf("read taxonomy.yaml: %w", err)
+	}
+	var t Taxonomy
+	if err := yaml.Unmarshal(raw, &t); err != nil {
+		return Taxonomy{}, fmt.Errorf("parse taxonomy.yaml: %w", err)
+	}
+	if len(t.UseCases) == 0 {
+		return Taxonomy{}, fmt.Errorf("taxonomy.yaml: use_cases must not be empty")
+	}
+	if len(t.Actors) == 0 {
+		return Taxonomy{}, fmt.Errorf("taxonomy.yaml: actors must not be empty")
+	}
+	if len(t.Patterns) == 0 {
+		return Taxonomy{}, fmt.Errorf("taxonomy.yaml: patterns must not be empty")
+	}
+	if len(t.ProblemDomains) == 0 {
+		return Taxonomy{}, fmt.Errorf("taxonomy.yaml: problem_domains must not be empty")
+	}
+	for axis, m := range map[string]map[string]TaxonomyEntry{
+		AxisUseCases:       t.UseCases,
+		AxisActors:         t.Actors,
+		AxisPatterns:       t.Patterns,
+		AxisProblemDomains: t.ProblemDomains,
+	} {
+		for value, entry := range m {
+			if strings.TrimSpace(entry.Note) == "" {
+				return Taxonomy{}, fmt.Errorf("taxonomy.yaml: %s/%s missing a semantic note", axis, value)
+			}
+		}
+	}
+	return t, nil
+}
+
+// AliasCanonical is one canonical target referenced by an alias. Exactly one
+// of (Axis+Value) or (Artefact) must be set.
+type AliasCanonical struct {
+	Axis     string `yaml:"axis,omitempty"`
+	Value    string `yaml:"value,omitempty"`
+	Artefact string `yaml:"artefact,omitempty"`
+}
+
+// AliasEntry pairs a free-form alias with its canonical targets.
+type AliasEntry struct {
+	Alias     string           `yaml:"alias"`
+	Canonical []AliasCanonical `yaml:"canonical"`
+}
+
+// AliasesFile is the parsed aliases.yaml document.
+type AliasesFile struct {
+	Aliases []AliasEntry `yaml:"aliases"`
+}
+
+// LoadAliases parses aliases.yaml from the content root. Duplicate alias keys
+// are reported here so the indexer never has to deal with collisions.
+func LoadAliases(contentRoot string) (AliasesFile, error) {
+	raw, err := os.ReadFile(filepath.Join(contentRoot, "aliases.yaml"))
+	if err != nil {
+		return AliasesFile{}, fmt.Errorf("read aliases.yaml: %w", err)
+	}
+	var f AliasesFile
+	if err := yaml.Unmarshal(raw, &f); err != nil {
+		return AliasesFile{}, fmt.Errorf("parse aliases.yaml: %w", err)
+	}
+
+	seen := make(map[string]int)
+	var dups []string
+	for _, entry := range f.Aliases {
+		if strings.TrimSpace(entry.Alias) == "" {
+			return AliasesFile{}, fmt.Errorf("aliases.yaml: entry missing alias field")
+		}
+		if len(entry.Canonical) == 0 {
+			return AliasesFile{}, fmt.Errorf("aliases.yaml: alias %q has no canonical targets", entry.Alias)
+		}
+		key := strings.ToLower(strings.TrimSpace(entry.Alias))
+		seen[key]++
+		if seen[key] == 2 {
+			dups = append(dups, key)
+		}
+		for _, c := range entry.Canonical {
+			hasAxis := c.Axis != ""
+			hasArtefact := c.Artefact != ""
+			if hasAxis == hasArtefact {
+				return AliasesFile{}, fmt.Errorf("aliases.yaml: alias %q canonical entries must set exactly one of axis/value or artefact", entry.Alias)
+			}
+			if hasAxis && c.Value == "" {
+				return AliasesFile{}, fmt.Errorf("aliases.yaml: alias %q axis %q has no value", entry.Alias, c.Axis)
+			}
+		}
+	}
+	if len(dups) > 0 {
+		sort.Strings(dups)
+		return AliasesFile{}, fmt.Errorf("aliases.yaml: duplicate alias keys: %s", strings.Join(dups, ", "))
+	}
+	return f, nil
+}
+
+// Sorted returns the alias entries sorted by lower-cased alias. The indexer
+// relies on this ordering for byte-identical output across runs.
+func (f AliasesFile) Sorted() []AliasEntry {
+	out := make([]AliasEntry, len(f.Aliases))
+	copy(out, f.Aliases)
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Alias) < strings.ToLower(out[j].Alias)
+	})
+	return out
+}

--- a/backend/internal/palette/validate.go
+++ b/backend/internal/palette/validate.go
@@ -1,0 +1,261 @@
+package palette
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Issue is a single validation finding. Path is the artefact-relative path
+// (or "taxonomy.yaml"/"aliases.yaml" for catalog-level findings). Message is
+// a short, user-readable description with no terminating punctuation.
+type Issue struct {
+	Path    string
+	Message string
+}
+
+// Format renders an issue as "path: message" for CLI output.
+func (i Issue) Format() string {
+	if i.Path == "" {
+		return i.Message
+	}
+	return i.Path + ": " + i.Message
+}
+
+// ValidateContent runs every validation rule against the supplied tree and
+// returns the full list of issues sorted by (path, message). An empty slice
+// means the tree is clean. The function never returns a partial result: all
+// checks are run even when earlier checks fail, so a single CI run lists
+// every authoring problem at once.
+func ValidateContent(contentRoot string) ([]Artefact, Taxonomy, AliasesFile, []Issue, error) {
+	taxonomy, err := LoadTaxonomy(contentRoot)
+	if err != nil {
+		return nil, Taxonomy{}, AliasesFile{}, nil, err
+	}
+	aliases, err := LoadAliases(contentRoot)
+	if err != nil {
+		return nil, taxonomy, AliasesFile{}, nil, err
+	}
+
+	artefacts, err := ContentReader{Root: contentRoot}.Read()
+	if err != nil {
+		return nil, taxonomy, aliases, nil, err
+	}
+
+	var issues []Issue
+
+	known := make(map[string]Artefact, len(artefacts))
+	for i, a := range artefacts {
+		if existing, dup := known[a.ID]; dup {
+			issues = append(issues, Issue{
+				Path:    a.Path,
+				Message: fmt.Sprintf("duplicate artefact id %q (first defined in %s)", a.ID, existing.Path),
+			})
+			continue
+		}
+		known[a.ID] = artefacts[i]
+	}
+
+	for _, a := range artefacts {
+		issues = append(issues, validateArtefact(a, taxonomy, known)...)
+	}
+
+	issues = append(issues, validateAliasesAgainstCatalog(aliases, taxonomy, known)...)
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].Path != issues[j].Path {
+			return issues[i].Path < issues[j].Path
+		}
+		return issues[i].Message < issues[j].Message
+	})
+	return artefacts, taxonomy, aliases, issues, nil
+}
+
+// validateArtefact runs all per-artefact validation rules.
+func validateArtefact(a Artefact, t Taxonomy, known map[string]Artefact) []Issue {
+	var issues []Issue
+	add := func(format string, args ...any) {
+		issues = append(issues, Issue{Path: a.Path, Message: fmt.Sprintf(format, args...)})
+	}
+
+	expectedID := strings.TrimSuffix(filepath.Base(a.Path), ".md")
+	if a.ID == "" {
+		add("missing required field id")
+	} else if a.ID != expectedID {
+		add("id %q does not match filename stem %q", a.ID, expectedID)
+	}
+
+	if strings.TrimSpace(a.Name) == "" {
+		add("missing required field name")
+	}
+
+	if len(a.UseCases) == 0 {
+		add("missing required field use_cases (must list at least one)")
+	}
+	if len(a.Actors) == 0 {
+		add("missing required field actors (must list at least one)")
+	}
+	if len(a.ProblemDomains) == 0 {
+		add("missing required field problem_domains (must list at least one)")
+	}
+
+	checkAxisList := func(axis string, values []string) {
+		for _, v := range values {
+			if v == "" {
+				add("%s contains an empty value", axis)
+				continue
+			}
+			if !t.Has(axis, v) {
+				add("%s contains unknown value %q (not declared in taxonomy.yaml)", axis, v)
+			}
+		}
+		if dup := firstDuplicate(values); dup != "" {
+			add("%s contains duplicate value %q", axis, dup)
+		}
+	}
+	checkAxisList(AxisUseCases, a.UseCases)
+	checkAxisList(AxisActors, a.Actors)
+	checkAxisList(AxisPatterns, a.Patterns)
+	checkAxisList(AxisProblemDomains, a.ProblemDomains)
+
+	if a.Status != "" && a.Status != StatusLive && a.Status != StatusPlanned && a.Status != StatusDeprecated {
+		add("status %q is not one of live, planned, deprecated", a.Status)
+	}
+
+	if a.Protocol != "" && len(a.Protocols) > 0 {
+		add("protocol and protocols are mutually exclusive; set one only")
+	}
+
+	checkEdges := func(field string, ids []string) {
+		for _, ref := range ids {
+			if ref == "" {
+				add("%s contains an empty reference", field)
+				continue
+			}
+			if _, ok := known[ref]; !ok {
+				add("%s references unknown artefact id %q", field, ref)
+			}
+		}
+		if dup := firstDuplicate(ids); dup != "" {
+			add("%s contains duplicate reference %q", field, dup)
+		}
+	}
+	checkEdges("related_concepts", a.RelatedConcepts)
+	checkEdges("prerequisites", a.Prerequisites)
+
+	switch a.Type {
+	case ArtefactProtocol:
+		if a.Protocol != "" {
+			add("protocol artefacts must omit the protocol field (it is implied by id)")
+		}
+		if a.Runnable != nil && *a.Runnable {
+			add("protocol artefacts cannot be runnable")
+		}
+
+	case ArtefactFlow:
+		if a.Protocol == "" {
+			add("flow artefacts require a protocol field")
+		} else if a.ProtocolFromDir != "" && a.Protocol != a.ProtocolFromDir {
+			add("flow protocol %q does not match parent directory %q", a.Protocol, a.ProtocolFromDir)
+		}
+		if a.Protocol != "" {
+			if _, ok := known[a.Protocol]; !ok {
+				add("flow references unknown protocol %q (expected content/protocols/%s.md)", a.Protocol, a.Protocol)
+			}
+		}
+
+	case ArtefactConcept:
+		if a.Runnable != nil && *a.Runnable {
+			add("concept artefacts cannot be runnable")
+		}
+
+	case ArtefactWalkthrough:
+		if len(a.RelatedConcepts) == 0 && len(a.Prerequisites) == 0 {
+			add("walkthrough must reference at least one flow or concept via related_concepts or prerequisites")
+		}
+
+	case ArtefactSpecAssertion:
+		if len(a.NormativeAnchors) == 0 {
+			add("spec-assertion requires at least one normative_anchors entry")
+		}
+		if a.NormativeLevel == "" {
+			add("spec-assertion requires normative_level (MUST, SHOULD, MAY, MUST NOT, SHOULD NOT)")
+		} else if _, ok := NormativeLevels[a.NormativeLevel]; !ok {
+			add("normative_level %q is not one of MUST, SHOULD, MAY, MUST NOT, SHOULD NOT", a.NormativeLevel)
+		}
+		if strings.TrimSpace(a.AssertionText) == "" {
+			add("spec-assertion requires assertion_text describing the normative statement")
+		}
+	}
+
+	for _, ref := range a.Protocols {
+		if _, ok := known[ref]; !ok {
+			add("protocols references unknown artefact id %q", ref)
+		}
+	}
+
+	for _, anchor := range a.NormativeAnchors {
+		if strings.TrimSpace(anchor.RFC) == "" {
+			add("normative_anchors entry missing rfc")
+		}
+		if len(anchor.Sections) == 0 {
+			add("normative_anchors entry for %q has no sections", anchor.RFC)
+		}
+	}
+
+	return issues
+}
+
+// validateAliasesAgainstCatalog ensures every alias canonical target resolves
+// against the taxonomy and known artefact set.
+func validateAliasesAgainstCatalog(f AliasesFile, t Taxonomy, known map[string]Artefact) []Issue {
+	var issues []Issue
+	for _, entry := range f.Aliases {
+		for _, c := range entry.Canonical {
+			if c.Axis != "" {
+				if !axisAllowed(c.Axis) {
+					issues = append(issues, Issue{
+						Path:    "aliases.yaml",
+						Message: fmt.Sprintf("alias %q references unknown axis %q", entry.Alias, c.Axis),
+					})
+					continue
+				}
+				if !t.Has(c.Axis, c.Value) {
+					issues = append(issues, Issue{
+						Path:    "aliases.yaml",
+						Message: fmt.Sprintf("alias %q references unknown value %q on axis %s", entry.Alias, c.Value, c.Axis),
+					})
+				}
+				continue
+			}
+			if _, ok := known[c.Artefact]; !ok {
+				issues = append(issues, Issue{
+					Path:    "aliases.yaml",
+					Message: fmt.Sprintf("alias %q references unknown artefact %q", entry.Alias, c.Artefact),
+				})
+			}
+		}
+	}
+	return issues
+}
+
+func axisAllowed(axis string) bool {
+	for _, a := range AllAxes {
+		if a == axis {
+			return true
+		}
+	}
+	return false
+}
+
+func firstDuplicate(values []string) string {
+	seen := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			return v
+		}
+		seen[v] = struct{}{}
+	}
+	return ""
+}

--- a/backend/internal/palette/validate_test.go
+++ b/backend/internal/palette/validate_test.go
@@ -1,0 +1,296 @@
+package palette
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile is a test helper that writes contents under dir/path, creating
+// parents as needed. The path is relative to dir and uses forward slashes.
+func writeFile(t *testing.T, dir, rel, contents string) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", full, err)
+	}
+}
+
+const seedTaxonomy = `
+use_cases:
+  user-login-via-own-idp:
+    note: User signs into a relying party.
+  service-to-service-auth:
+    note: Service authenticates as itself.
+actors:
+  public-client:
+    note: SPA, mobile, or native client.
+  authorization-server:
+    note: OAuth AS.
+  resource-server:
+    note: API enforcing access tokens.
+patterns:
+  pkce-bound:
+    note: PKCE-bound authorization.
+  back-channel:
+    note: Server-to-server.
+problem_domains:
+  authorization:
+    note: Deciding what an authenticated party may do.
+  authentication:
+    note: Verifying who someone is.
+`
+
+const seedAliases = `
+aliases:
+  - alias: pkce
+    canonical:
+      - axis: patterns
+        value: pkce-bound
+      - artefact: pkce
+  - alias: m2m
+    canonical:
+      - axis: use_cases
+        value: service-to-service-auth
+`
+
+func seedContent(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, dir, "taxonomy.yaml", seedTaxonomy)
+	writeFile(t, dir, "aliases.yaml", seedAliases)
+	writeFile(t, dir, "protocols/oauth2.md", `---
+id: oauth2
+name: OAuth 2.0
+use_cases:
+  - service-to-service-auth
+  - user-login-via-own-idp
+actors:
+  - public-client
+  - authorization-server
+  - resource-server
+patterns:
+  - back-channel
+problem_domains:
+  - authorization
+---
+OAuth 2.0 is the authorization framework for delegated API access. It defines flows used by clients to obtain access tokens.
+`)
+	writeFile(t, dir, "flows/oauth2/authorization-code-pkce.md", `---
+id: authorization-code-pkce
+name: Authorization code + PKCE
+protocol: oauth2
+use_cases:
+  - user-login-via-own-idp
+actors:
+  - public-client
+  - authorization-server
+patterns:
+  - pkce-bound
+  - back-channel
+problem_domains:
+  - authorization
+runnable: true
+backend_id: authorization_code_pkce
+---
+Authorization code flow bound to a PKCE verifier. The canonical sign-in flow for public clients.
+`)
+	writeFile(t, dir, "concepts/pkce.md", `---
+id: pkce
+name: PKCE
+protocols:
+  - oauth2
+use_cases:
+  - user-login-via-own-idp
+actors:
+  - public-client
+patterns:
+  - pkce-bound
+problem_domains:
+  - authorization
+---
+Proof Key for Code Exchange. Binds an authorization request to a per-request code_verifier.
+`)
+	return dir
+}
+
+func TestValidateContentClean(t *testing.T) {
+	dir := seedContent(t)
+	artefacts, _, _, issues, err := ValidateContent(dir)
+	if err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected clean validation, got %d issues:\n%v", len(issues), issues)
+	}
+	if len(artefacts) != 3 {
+		t.Fatalf("expected 3 artefacts, got %d", len(artefacts))
+	}
+}
+
+func TestValidateContentUnknownAxisValue(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "concepts/bad-axis.md", `---
+id: bad-axis
+name: Bad axis
+use_cases:
+  - not-a-real-use-case
+actors:
+  - public-client
+problem_domains:
+  - authorization
+---
+`)
+	_, _, _, issues, err := ValidateContent(dir)
+	if err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+	if !containsIssue(issues, "concepts/bad-axis.md", "unknown value \"not-a-real-use-case\"") {
+		t.Fatalf("expected unknown-value issue, got: %v", issues)
+	}
+}
+
+func TestValidateContentMissingRequired(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "concepts/missing.md", `---
+id: missing
+name: Missing fields
+---
+`)
+	_, _, _, issues, err := ValidateContent(dir)
+	if err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+	wanted := []string{
+		"missing required field use_cases",
+		"missing required field actors",
+		"missing required field problem_domains",
+	}
+	for _, m := range wanted {
+		if !containsIssue(issues, "concepts/missing.md", m) {
+			t.Fatalf("expected issue containing %q, got: %v", m, issues)
+		}
+	}
+}
+
+func TestValidateContentDuplicateAlias(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "aliases.yaml", seedAliases+`
+  - alias: m2m
+    canonical:
+      - axis: actors
+        value: public-client
+`)
+	_, _, _, _, err := ValidateContent(dir)
+	if err == nil {
+		t.Fatalf("expected duplicate alias error")
+	}
+	if !strings.Contains(err.Error(), "duplicate alias keys") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateContentDanglingEdge(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "concepts/with-dangling.md", `---
+id: with-dangling
+name: Dangling reference
+use_cases:
+  - user-login-via-own-idp
+actors:
+  - public-client
+problem_domains:
+  - authorization
+related_concepts:
+  - does-not-exist
+---
+`)
+	_, _, _, issues, err := ValidateContent(dir)
+	if err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+	if !containsIssue(issues, "concepts/with-dangling.md", "related_concepts references unknown artefact id \"does-not-exist\"") {
+		t.Fatalf("expected dangling-edge issue, got: %v", issues)
+	}
+}
+
+func TestValidateContentFilenameMismatch(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "concepts/mismatch.md", `---
+id: not-mismatch
+name: Filename mismatch
+use_cases:
+  - user-login-via-own-idp
+actors:
+  - public-client
+problem_domains:
+  - authorization
+---
+`)
+	_, _, _, issues, err := ValidateContent(dir)
+	if err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+	if !containsIssue(issues, "concepts/mismatch.md", "does not match filename stem") {
+		t.Fatalf("expected filename mismatch issue, got: %v", issues)
+	}
+}
+
+func TestValidateContentUnknownTopLevelField(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "concepts/unknown-field.md", `---
+id: unknown-field
+name: Unknown
+use_cases:
+  - user-login-via-own-idp
+actors:
+  - public-client
+problem_domains:
+  - authorization
+mystery: 42
+---
+`)
+	_, _, _, _, err := ValidateContent(dir)
+	if err == nil {
+		t.Fatalf("expected unknown-field error")
+	}
+	if !strings.Contains(err.Error(), "unknown frontmatter fields: mystery") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateContentFlowProtocolMismatch(t *testing.T) {
+	dir := seedContent(t)
+	writeFile(t, dir, "flows/oauth2/wrong-protocol.md", `---
+id: wrong-protocol
+name: Mismatched protocol
+protocol: oidc
+use_cases:
+  - user-login-via-own-idp
+actors:
+  - public-client
+problem_domains:
+  - authorization
+---
+`)
+	_, _, _, issues, err := ValidateContent(dir)
+	if err != nil {
+		t.Fatalf("ValidateContent error: %v", err)
+	}
+	if !containsIssue(issues, "flows/oauth2/wrong-protocol.md", "flow protocol \"oidc\" does not match parent directory \"oauth2\"") {
+		t.Fatalf("expected protocol mismatch issue, got: %v", issues)
+	}
+}
+
+func containsIssue(issues []Issue, path, needle string) bool {
+	for _, i := range issues {
+		if i.Path == path && strings.Contains(i.Message, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/content/SCHEMA.md
+++ b/content/SCHEMA.md
@@ -1,0 +1,162 @@
+# Content frontmatter schema
+
+This file is the source of truth for the artefact frontmatter consumed by the
+palette content validator (`backend/cmd/content-validate`) and the indexer
+(`backend/cmd/palette-indexer`). The frontmatter is intentionally minimal and
+declarative. Behavioural prose belongs in the artefact body, not in fields.
+
+## File layout
+
+```
+content/
+  taxonomy.yaml          # controlled vocabulary for every axis
+  aliases.yaml           # synonym map
+  SCHEMA.md              # this file
+  protocols/             # one file per protocol catalog entry
+    {protocol-id}.md
+  flows/                 # one file per runnable flow definition
+    {protocol-id}/
+      {flow-id}.md
+  concepts/              # one file per cross-cutting concept page
+    {concept-id}.md
+  walkthroughs/          # one file per long-form walkthrough
+    {walkthrough-id}.md
+  assertions/            # one file per spec assertion (auto-generated later)
+    {assertion-id}.md
+```
+
+The validator discovers artefacts by walking `content/**/*.md`. The directory
+relative to `content/` determines the artefact `type`:
+
+| Directory       | Artefact type   |
+| --------------- | --------------- |
+| `protocols/`    | `protocol`      |
+| `flows/`        | `flow`          |
+| `concepts/`     | `concept`       |
+| `walkthroughs/` | `walkthrough`   |
+| `assertions/`   | `spec-assertion`|
+
+## Frontmatter contract
+
+Every artefact opens with a YAML document delimited by `---`. Unknown fields
+fail validation; this prevents drift over time.
+
+### Required fields
+
+| Field            | Type              | Notes |
+| ---------------- | ----------------- | ----- |
+| `id`             | string            | Stable artefact id, kebab-case. Must match the filename. |
+| `name`           | string            | Short human-readable name. |
+| `use_cases`      | list[string]      | Each value must exist in `taxonomy.yaml#use_cases`. |
+| `actors`         | list[string]      | Each value must exist in `taxonomy.yaml#actors`. |
+| `problem_domains`| list[string]      | Each value must exist in `taxonomy.yaml#problem_domains`. |
+
+### Recommended fields
+
+| Field              | Type              | Notes |
+| ------------------ | ----------------- | ----- |
+| `protocol`         | string            | Protocol id this artefact belongs to. Required for `flow` artefacts. |
+| `protocols`        | list[string]      | For cross-cutting concepts that span more than one protocol. Mutually exclusive with `protocol`. |
+| `patterns`         | list[string]      | Each value must exist in `taxonomy.yaml#patterns`. |
+| `related_concepts` | list[string]      | Concept artefact ids this artefact relates to. Each must resolve to an existing artefact. |
+| `prerequisites`    | list[string]      | Artefact ids that should be understood first. Each must resolve to an existing artefact. |
+
+### Optional fields
+
+| Field               | Type           | Notes |
+| ------------------- | -------------- | ----- |
+| `normative_anchors` | list[object]   | List of `{rfc: string, sections: list[string]}` references. |
+| `runnable`          | bool           | `true` for executable flows. Default `false`. |
+| `status`            | string         | `live` (default), `planned`, or `deprecated`. |
+| `href`              | string         | Canonical site URL. Defaults computed from `type` + `id`. **Ignored for inline-only types** (`concept`, `walkthrough`, `spec-assertion`); see "Inline-only artefacts" below. |
+| `summary`           | string         | One-line summary surfaced as a result subtitle. Keep declarative. |
+| `aliases`           | list[string]   | Free-form synonyms specific to this artefact, indexed in the FTS5 aliases column. |
+| `backend_id`        | string         | Flow id used by the backend `/api/protocols/.../demo/...` endpoint. Required for runnable flows whose backend id differs from `id`. |
+
+## Type-specific rules
+
+### `protocol`
+
+- File path: `content/protocols/{id}.md`
+- `protocol` field must be omitted (the artefact *is* the protocol). The
+  validator infers the protocol attribute from `id`.
+- `runnable` is forced to `false`.
+
+### `flow`
+
+- File path: `content/flows/{protocol-id}/{id}.md`
+- `protocol` is required and must equal the parent directory.
+- `runnable` defaults to `true`. Set to `false` for non-executable flow walks.
+- If `runnable` is `true` and the backend flow id differs from `id`, set
+  `backend_id`.
+
+### `concept`
+
+- File path: `content/concepts/{id}.md`
+- Either `protocol` or `protocols` may be set, depending on whether the
+  concept is single-protocol or cross-cutting.
+- `runnable` is forced to `false`.
+
+### `walkthrough`
+
+- File path: `content/walkthroughs/{id}.md`
+- Must reference at least one flow via `related_concepts` or `prerequisites`.
+
+### `spec-assertion`
+
+- File path: `content/assertions/{id}.md`
+- `normative_anchors` is required and must contain at least one entry.
+- Additional field `normative_level` (one of `MUST`, `SHOULD`, `MAY`,
+  `MUST NOT`, `SHOULD NOT`) is required.
+
+## Inline-only artefacts
+
+`concept`, `walkthrough`, and `spec-assertion` artefacts are **inline-only**:
+their canonical surface is the palette's expanded result row (full markdown
+body, normative anchors, related-concept chips) rather than a dedicated page
+route. The Next.js app intentionally does not serve `/concept/{id}`,
+`/walkthrough/{id}`, or `/assertion/{id}`.
+
+Consequences for content authors:
+
+- The `href` field is **ignored** for these types. The backend
+  (`palette.Artefact.DefaultHref`) returns an empty string regardless of
+  what frontmatter sets, so a phantom URL can never reach the surface.
+- Keep the body self-contained: it must answer the user's query on its own,
+  because the palette row is the final destination.
+- Cross-link via `related_concepts` (and free-text references inside the
+  body). Related-concept chips in the surface re-query the palette with
+  the linked concept's id — they do not navigate to a page.
+
+`protocol` and `flow` artefacts continue to have canonical pages
+(`/protocol/{id}` and `/protocol/{protocolId}/flow/{flowId}`) and their
+`href` field is honoured normally.
+
+## Validation failures
+
+The validator fails the build on any of:
+
+- Unknown axis value (i.e. not present in `taxonomy.yaml`).
+- Missing required field for the artefact type.
+- Duplicate alias key in `aliases.yaml`.
+- Edge reference to a non-existent artefact (via `related_concepts` or `prerequisites`).
+- `id` does not match the filename stem.
+- `flow` artefact whose `protocol` does not match the parent directory.
+- Unknown top-level frontmatter field.
+- Markdown file outside the recognised directories listed in **File layout**.
+
+Run locally with:
+
+```sh
+cd ProtocolLens/backend
+go run ./cmd/content-validate -content ../content
+```
+
+CI runs the same command on every PR that touches `content/**`.
+
+## Body
+
+The body that follows the frontmatter is plain markdown. It is indexed into
+the FTS5 `body` column and presented in result rows as a short summary. Keep
+it short, declarative, and free of marketing language. The first paragraph is
+treated as the result-card subtitle when `summary` is not set.

--- a/content/aliases.yaml
+++ b/content/aliases.yaml
@@ -1,0 +1,459 @@
+# ProtocolSoup palette aliases
+#
+# Synonym map. Each alias resolves to one or more canonical targets. An alias
+# may produce multiple canonical mappings (e.g. "auth" resolves to both
+# authentication and authorization); the indexer keeps all rows.
+#
+# Canonical entry shape:
+#   axis:  one of use_cases | actors | patterns | problem_domains  (optional)
+#   value: a value defined in taxonomy.yaml under that axis         (when axis is set)
+#   artefact: an artefact id (concept, protocol, flow, etc.)        (when axis is unset)
+#
+# Aliases are matched case-insensitively. Duplicate alias keys cause a
+# validator failure even when the canonical targets differ — collapse them
+# into one entry with multiple canonical targets.
+
+aliases:
+  # Protocol shortnames
+  - alias: oauth
+    canonical:
+      - artefact: oauth2
+  - alias: oauth2
+    canonical:
+      - artefact: oauth2
+  - alias: oauth 2.0
+    canonical:
+      - artefact: oauth2
+  - alias: oidc
+    canonical:
+      - artefact: oidc
+  - alias: openid connect
+    canonical:
+      - artefact: oidc
+  - alias: openid
+    canonical:
+      - artefact: oidc
+  - alias: saml
+    canonical:
+      - artefact: saml
+  - alias: scim
+    canonical:
+      - artefact: scim
+  - alias: ssf
+    canonical:
+      - artefact: ssf
+  - alias: spiffe
+    canonical:
+      - artefact: spiffe
+  - alias: spire
+    canonical:
+      - artefact: spiffe
+  - alias: oid4vci
+    canonical:
+      - artefact: oid4vci
+  - alias: oid4vp
+    canonical:
+      - artefact: oid4vp
+  - alias: openid4vci
+    canonical:
+      - artefact: oid4vci
+  - alias: openid4vp
+    canonical:
+      - artefact: oid4vp
+
+  # Concept aliases
+  - alias: pkce
+    canonical:
+      - artefact: pkce
+      - axis: patterns
+        value: pkce-bound
+  - alias: code verifier
+    canonical:
+      - artefact: pkce
+  - alias: code challenge
+    canonical:
+      - artefact: pkce
+  - alias: jwt
+    canonical:
+      - artefact: jwt
+  - alias: json web token
+    canonical:
+      - artefact: jwt
+  - alias: jwks
+    canonical:
+      - artefact: jwks
+  - alias: id token
+    canonical:
+      - artefact: id-token
+  - alias: id_token
+    canonical:
+      - artefact: id-token
+  - alias: access token
+    canonical:
+      - artefact: access-token
+  - alias: refresh token
+    canonical:
+      - axis: use_cases
+        value: token-refresh
+  - alias: bearer
+    canonical:
+      - axis: patterns
+        value: bearer
+  - alias: bearer token
+    canonical:
+      - axis: patterns
+        value: bearer
+  - alias: mtls
+    canonical:
+      - axis: patterns
+        value: mutual-tls
+  - alias: mutual tls
+    canonical:
+      - axis: patterns
+        value: mutual-tls
+  - alias: dpop
+    canonical:
+      - axis: patterns
+        value: key-bound
+  - alias: dcql
+    canonical:
+      - artefact: dcql
+  - alias: did:web
+    canonical:
+      - artefact: did-web
+  - alias: nonce
+    canonical:
+      - axis: patterns
+        value: nonce-bound
+
+  # Use-case aliases — sign in / login phrasings
+  - alias: sign in
+    canonical:
+      - axis: use_cases
+        value: user-login-via-own-idp
+      - axis: use_cases
+        value: single-page-app-login
+      - axis: use_cases
+        value: mobile-app-login
+  - alias: sign-in
+    canonical:
+      - axis: use_cases
+        value: user-login-via-own-idp
+      - axis: use_cases
+        value: single-page-app-login
+      - axis: use_cases
+        value: mobile-app-login
+  - alias: login
+    canonical:
+      - axis: use_cases
+        value: user-login-via-own-idp
+      - axis: use_cases
+        value: single-page-app-login
+      - axis: use_cases
+        value: mobile-app-login
+  - alias: log in
+    canonical:
+      - axis: use_cases
+        value: user-login-via-own-idp
+  - alias: signin
+    canonical:
+      - axis: use_cases
+        value: user-login-via-own-idp
+  - alias: sso
+    canonical:
+      - axis: use_cases
+        value: single-sign-on
+  - alias: single sign on
+    canonical:
+      - axis: use_cases
+        value: single-sign-on
+  - alias: single sign-on
+    canonical:
+      - axis: use_cases
+        value: single-sign-on
+  - alias: slo
+    canonical:
+      - axis: use_cases
+        value: single-logout
+  - alias: logout
+    canonical:
+      - axis: use_cases
+        value: single-logout
+  - alias: step up
+    canonical:
+      - axis: use_cases
+        value: step-up-authentication
+  - alias: step-up
+    canonical:
+      - axis: use_cases
+        value: step-up-authentication
+
+  # Service-to-service phrasings
+  - alias: machine to machine
+    canonical:
+      - axis: use_cases
+        value: service-to-service-auth
+  - alias: m2m
+    canonical:
+      - axis: use_cases
+        value: service-to-service-auth
+  - alias: service to service
+    canonical:
+      - axis: use_cases
+        value: service-to-service-auth
+  - alias: backend to backend
+    canonical:
+      - axis: use_cases
+        value: service-to-service-auth
+  - alias: api to api
+    canonical:
+      - axis: use_cases
+        value: service-to-service-auth
+
+  # Client form-factor phrasings
+  - alias: spa
+    canonical:
+      - axis: actors
+        value: public-client
+      - axis: use_cases
+        value: single-page-app-login
+  - alias: single page app
+    canonical:
+      - axis: use_cases
+        value: single-page-app-login
+  - alias: mobile app
+    canonical:
+      - axis: use_cases
+        value: mobile-app-login
+      - axis: actors
+        value: public-client
+  - alias: native app
+    canonical:
+      - axis: actors
+        value: public-client
+  - alias: mobile
+    canonical:
+      - axis: use_cases
+        value: mobile-app-login
+
+  # Actor phrasings
+  - alias: idp
+    canonical:
+      - axis: actors
+        value: identity-provider
+  - alias: identity provider
+    canonical:
+      - axis: actors
+        value: identity-provider
+  - alias: sp
+    canonical:
+      - axis: actors
+        value: service-provider
+  - alias: service provider
+    canonical:
+      - axis: actors
+        value: service-provider
+  - alias: rp
+    canonical:
+      - axis: actors
+        value: relying-party
+  - alias: relying party
+    canonical:
+      - axis: actors
+        value: relying-party
+  - alias: as
+    canonical:
+      - axis: actors
+        value: authorization-server
+  - alias: authorization server
+    canonical:
+      - axis: actors
+        value: authorization-server
+  - alias: resource server
+    canonical:
+      - axis: actors
+        value: resource-server
+  - alias: rs
+    canonical:
+      - axis: actors
+        value: resource-server
+  - alias: workload
+    canonical:
+      - axis: actors
+        value: workload
+      - axis: problem_domains
+        value: workload-identity
+
+  # Verifiable credentials phrasings
+  - alias: vc
+    canonical:
+      - axis: problem_domains
+        value: verifiable-credentials
+  - alias: vcs
+    canonical:
+      - axis: problem_domains
+        value: verifiable-credentials
+  - alias: verifiable credential
+    canonical:
+      - axis: problem_domains
+        value: verifiable-credentials
+  - alias: credential issuance
+    canonical:
+      - axis: use_cases
+        value: credential-issuance
+  - alias: credential presentation
+    canonical:
+      - axis: use_cases
+        value: credential-presentation
+  - alias: presentation
+    canonical:
+      - axis: use_cases
+        value: credential-presentation
+  - alias: issuance
+    canonical:
+      - axis: use_cases
+        value: credential-issuance
+  - alias: wallet
+    canonical:
+      - axis: actors
+        value: wallet
+  - alias: holder
+    canonical:
+      - axis: actors
+        value: holder
+  - alias: verifier
+    canonical:
+      - axis: actors
+        value: verifier
+  - alias: issuer
+    canonical:
+      - axis: actors
+        value: issuer
+
+  # Provisioning phrasings
+  - alias: user provisioning
+    canonical:
+      - axis: use_cases
+        value: user-provisioning
+  - alias: provisioning
+    canonical:
+      - axis: use_cases
+        value: user-provisioning
+      - axis: problem_domains
+        value: provisioning
+
+  # Federation phrasings
+  - alias: federate
+    canonical:
+      - axis: use_cases
+        value: federation-trust-establishment
+      - axis: problem_domains
+        value: federation
+  - alias: federation
+    canonical:
+      - axis: problem_domains
+        value: federation
+  - alias: federating
+    canonical:
+      - axis: use_cases
+        value: federation-trust-establishment
+
+  # Security events phrasings
+  - alias: caep
+    canonical:
+      - artefact: caep
+  - alias: risc
+    canonical:
+      - artefact: risc
+  - alias: security event
+    canonical:
+      - axis: problem_domains
+        value: security-events
+  - alias: continuous evaluation
+    canonical:
+      - axis: use_cases
+        value: continuous-evaluation
+  - alias: continuous access evaluation
+    canonical:
+      - axis: use_cases
+        value: continuous-evaluation
+
+  # Discovery phrasings
+  - alias: well known
+    canonical:
+      - axis: use_cases
+        value: discovery
+      - axis: patterns
+        value: metadata-discovery
+  - alias: ".well-known"
+    canonical:
+      - axis: use_cases
+        value: discovery
+      - axis: patterns
+        value: metadata-discovery
+  - alias: metadata
+    canonical:
+      - axis: patterns
+        value: metadata-discovery
+  - alias: discovery
+    canonical:
+      - axis: use_cases
+        value: discovery
+      - axis: problem_domains
+        value: discovery
+
+  # Ambiguous on purpose — both directions kept
+  - alias: auth
+    canonical:
+      - axis: problem_domains
+        value: authentication
+      - axis: problem_domains
+        value: authorization
+  - alias: authn
+    canonical:
+      - axis: problem_domains
+        value: authentication
+  - alias: authz
+    canonical:
+      - axis: problem_domains
+        value: authorization
+
+  # Token operations
+  - alias: introspection
+    canonical:
+      - axis: use_cases
+        value: token-introspection
+  - alias: introspect
+    canonical:
+      - axis: use_cases
+        value: token-introspection
+  - alias: revoke
+    canonical:
+      - axis: use_cases
+        value: token-revocation
+  - alias: revocation
+    canonical:
+      - axis: use_cases
+        value: token-revocation
+
+  # API access phrasings
+  - alias: call our api
+    canonical:
+      - axis: use_cases
+        value: delegated-api-access
+      - axis: use_cases
+        value: service-to-service-auth
+  - alias: call my api
+    canonical:
+      - axis: use_cases
+        value: delegated-api-access
+      - axis: use_cases
+        value: service-to-service-auth
+  - alias: api access
+    canonical:
+      - axis: use_cases
+        value: delegated-api-access
+  - alias: delegated access
+    canonical:
+      - axis: use_cases
+        value: delegated-api-access

--- a/content/concepts/access-token.md
+++ b/content/concepts/access-token.md
@@ -1,0 +1,38 @@
+---
+id: access-token
+name: Access Token
+protocols:
+  - oauth2
+  - oidc
+use_cases:
+  - delegated-api-access
+  - service-to-service-auth
+actors:
+  - client
+  - authorization-server
+  - resource-server
+patterns:
+  - bearer
+  - audience-restricted
+  - key-bound
+problem_domains:
+  - authorization
+related_concepts:
+  - jwt
+normative_anchors:
+  - rfc: RFC 6749
+    sections: ["1.4"]
+  - rfc: RFC 6750
+    sections: ["1.2", "2"]
+status: live
+summary: Credential a client presents to a resource server to access a protected resource.
+aliases:
+  - oauth access token
+  - bearer access token
+---
+
+An access token represents the authorization granted to a client. The
+resource server treats a presented access token (typically as a bearer
+credential per RFC 6750) as proof of authorization. Tokens can be opaque
+(validated via introspection, RFC 7662) or self-contained JWTs (validated
+against the issuer's JWKS).

--- a/content/concepts/caep.md
+++ b/content/concepts/caep.md
@@ -1,0 +1,29 @@
+---
+id: caep
+name: CAEP (Continuous Access Evaluation Profile)
+protocols:
+  - ssf
+use_cases:
+  - continuous-evaluation
+actors:
+  - transmitter
+  - receiver
+patterns:
+  - push-based
+  - polling
+  - signed-assertion
+problem_domains:
+  - security-events
+  - session-management
+normative_anchors:
+  - rfc: OpenID CAEP 1.0
+    sections: ["3", "4"]
+status: live
+summary: SSF profile for session-level security events.
+---
+
+CAEP (Continuous Access Evaluation Profile) is the SSF profile for
+distributing session and credential state events: session revoked, token
+claims changed, device compliance changed, credential level changed, and
+similar. CAEP events are SETs (RFC 8417) with CAEP-specific event types and
+subject identifiers.

--- a/content/concepts/dcql.md
+++ b/content/concepts/dcql.md
@@ -1,0 +1,29 @@
+---
+id: dcql
+name: DCQL (Digital Credentials Query Language)
+protocols:
+  - oid4vp
+use_cases:
+  - credential-presentation
+actors:
+  - verifier
+  - wallet
+  - holder
+patterns:
+  - signed-assertion
+problem_domains:
+  - verifiable-credentials
+normative_anchors:
+  - rfc: OpenID4VP 1.0
+    sections: ["6.1"]
+status: live
+summary: JSON query language verifiers use to request specific verifiable credentials.
+aliases:
+  - digital credentials query language
+---
+
+DCQL is the OID4VP query language verifiers use to express which verifiable
+credentials they want from a wallet and how to present them. A DCQL query
+declares credential sets, formats, and claim constraints; the wallet matches
+its store and produces a presentation per the request. DCQL replaces the
+earlier Presentation Exchange (PE) approach in OID4VP 1.0.

--- a/content/concepts/did-web.md
+++ b/content/concepts/did-web.md
@@ -1,0 +1,31 @@
+---
+id: did-web
+name: did:web
+protocols:
+  - oid4vp
+  - oid4vci
+use_cases:
+  - federation-trust-establishment
+  - credential-presentation
+actors:
+  - verifier
+  - issuer
+  - wallet
+patterns:
+  - metadata-discovery
+  - signed-assertion
+problem_domains:
+  - key-management
+  - federation
+  - verifiable-credentials
+normative_anchors:
+  - rfc: did:web Method Specification
+    sections: ["3"]
+status: live
+summary: DNS-backed DID method that publishes a DID Document via HTTPS.
+---
+
+did:web is a DID method that resolves to an HTTPS-hosted DID Document. The
+DNS name in the DID is converted to an HTTPS URL (with optional path) and the
+DID Document is fetched from there. Used in OID4VP for verifier and issuer
+identifiers when a wallet is configured with a did:web host allowlist.

--- a/content/concepts/id-token.md
+++ b/content/concepts/id-token.md
@@ -1,0 +1,35 @@
+---
+id: id-token
+name: ID Token
+protocols:
+  - oidc
+use_cases:
+  - user-login-via-own-idp
+  - single-sign-on
+  - step-up-authentication
+actors:
+  - identity-provider
+  - relying-party
+patterns:
+  - signed-assertion
+  - nonce-bound
+  - audience-restricted
+problem_domains:
+  - authentication
+related_concepts:
+  - jwt
+  - jwks
+normative_anchors:
+  - rfc: OpenID Connect Core 1.0
+    sections: ["2", "3.1.3.7"]
+status: live
+summary: JWT issued by an OIDC IdP asserting the end-user's identity to a relying party.
+aliases:
+  - oidc id token
+---
+
+The ID Token is a JWT issued by an OpenID Provider that asserts the
+authentication event and identity of an end-user to a relying party. The
+mandatory claims are `iss`, `sub`, `aud`, `exp`, `iat`, and (when the
+authorization request carried one) `nonce`. RP validation includes signature
+verification against the issuer's JWKS, audience check, and nonce check.

--- a/content/concepts/jwks.md
+++ b/content/concepts/jwks.md
@@ -1,0 +1,36 @@
+---
+id: jwks
+name: JSON Web Key Set (JWKS)
+protocols:
+  - oauth2
+  - oidc
+  - oid4vci
+  - oid4vp
+  - ssf
+use_cases:
+  - discovery
+actors:
+  - authorization-server
+  - identity-provider
+  - resource-server
+  - relying-party
+patterns:
+  - metadata-discovery
+problem_domains:
+  - key-management
+  - discovery
+normative_anchors:
+  - rfc: RFC 7517
+    sections: ["3", "4"]
+status: live
+summary: Published set of public keys used to verify JWT signatures.
+aliases:
+  - jwks_uri
+  - rfc 7517
+---
+
+A JWKS (JSON Web Key Set, RFC 7517) is a JSON document containing one or more
+public keys an issuer uses to sign JWTs. Relying parties fetch the document
+from the issuer's `jwks_uri` and use the matching `kid` to verify
+signatures. Rotation is performed by publishing new keys ahead of switching
+the signing key.

--- a/content/concepts/jwt.md
+++ b/content/concepts/jwt.md
@@ -1,0 +1,48 @@
+---
+id: jwt
+name: JSON Web Token (JWT)
+protocols:
+  - oauth2
+  - oidc
+  - oid4vci
+  - oid4vp
+  - ssf
+  - spiffe
+use_cases:
+  - delegated-api-access
+  - user-login-via-own-idp
+  - service-to-service-auth
+  - workload-attestation
+  - continuous-evaluation
+actors:
+  - authorization-server
+  - identity-provider
+  - resource-server
+  - workload
+patterns:
+  - signed-assertion
+  - audience-restricted
+  - bearer
+  - key-bound
+problem_domains:
+  - authentication
+  - authorization
+  - key-management
+normative_anchors:
+  - rfc: RFC 7519
+    sections: ["3", "4"]
+  - rfc: RFC 7515
+    sections: ["3", "4"]
+  - rfc: RFC 7518
+    sections: ["3"]
+status: live
+summary: Compact, URL-safe, signed JSON claims envelope.
+aliases:
+  - json web tokens
+  - rfc 7519
+---
+
+A JSON Web Token (RFC 7519) is a compact, URL-safe envelope of JSON claims,
+typically signed using JWS (RFC 7515). JWTs are the wire format for OIDC
+ID Tokens, OAuth 2.0 access tokens (when self-contained), SETs, JWT-SVIDs,
+and many VC formats.

--- a/content/concepts/pkce.md
+++ b/content/concepts/pkce.md
@@ -1,0 +1,39 @@
+---
+id: pkce
+name: PKCE (Proof Key for Code Exchange)
+protocols:
+  - oauth2
+  - oidc
+  - oid4vci
+use_cases:
+  - pkce-protection
+  - single-page-app-login
+  - mobile-app-login
+actors:
+  - public-client
+  - confidential-client
+  - authorization-server
+patterns:
+  - pkce-bound
+  - front-channel-redirect
+  - back-channel
+problem_domains:
+  - authorization
+normative_anchors:
+  - rfc: RFC 7636
+    sections: ["4"]
+  - rfc: RFC 9700
+    sections: ["2.1.1"]
+status: live
+summary: Binds an authorization request to a per-request code_verifier.
+aliases:
+  - proof key for code exchange
+  - rfc 7636
+---
+
+PKCE (Proof Key for Code Exchange, RFC 7636) protects the authorization code
+grant against code interception. The client generates a high-entropy random
+`code_verifier`, hashes it into a `code_challenge`, and sends the challenge
+with the authorization request. The verifier is presented at the token
+endpoint; the AS hashes it and compares against the stored challenge. RFC
+9700 §2.1.1 requires PKCE for all clients, public or confidential.

--- a/content/concepts/risc.md
+++ b/content/concepts/risc.md
@@ -1,0 +1,26 @@
+---
+id: risc
+name: RISC (Risk Incident Sharing and Coordination)
+protocols:
+  - ssf
+use_cases:
+  - continuous-evaluation
+actors:
+  - transmitter
+  - receiver
+patterns:
+  - push-based
+  - signed-assertion
+problem_domains:
+  - security-events
+normative_anchors:
+  - rfc: OpenID RISC 1.0
+    sections: ["3", "4"]
+status: live
+summary: SSF profile for account-level risk events such as compromise and disablement.
+---
+
+RISC (Risk Incident Sharing and Coordination) is the SSF profile for
+distributing account-level risk events: account disabled, account purged,
+credential compromise, identifier change, and account credential change.
+RISC events are SETs (RFC 8417) with RISC-specific event types.

--- a/content/flows/oauth2/authorization-code-pkce.md
+++ b/content/flows/oauth2/authorization-code-pkce.md
@@ -1,0 +1,48 @@
+---
+id: authorization-code-pkce
+name: OAuth 2.0 authorization code with PKCE
+protocol: oauth2
+use_cases:
+  - user-login-via-own-idp
+  - single-page-app-login
+  - mobile-app-login
+  - delegated-api-access
+  - pkce-protection
+actors:
+  - public-client
+  - authorization-server
+  - resource-server
+  - user-agent
+patterns:
+  - front-channel-redirect
+  - back-channel
+  - bearer
+  - pkce-bound
+problem_domains:
+  - authorization
+  - authentication
+related_concepts:
+  - pkce
+  - access-token
+normative_anchors:
+  - rfc: RFC 6749
+    sections: ["4.1"]
+  - rfc: RFC 7636
+    sections: ["4"]
+  - rfc: RFC 9700
+    sections: ["2.1.1"]
+runnable: true
+backend_id: authorization_code_pkce
+status: live
+href: /protocol/oauth2/flow/authorization-code-pkce
+summary: Authorization code flow bound to a PKCE verifier; required for public clients.
+aliases:
+  - auth code pkce
+  - authorization code + pkce
+---
+
+PKCE (RFC 7636) binds the authorization request to a code_verifier known only
+to the client. The authorization server stores the code_challenge alongside
+the issued code; the verifier is presented at the token endpoint and checked
+against the challenge. RFC 9700 requires PKCE for all OAuth clients, not just
+public ones.

--- a/content/flows/oauth2/authorization-code.md
+++ b/content/flows/oauth2/authorization-code.md
@@ -1,0 +1,39 @@
+---
+id: authorization-code
+name: OAuth 2.0 authorization code grant
+protocol: oauth2
+use_cases:
+  - user-login-via-own-idp
+  - delegated-api-access
+actors:
+  - confidential-client
+  - authorization-server
+  - resource-server
+  - user-agent
+patterns:
+  - front-channel-redirect
+  - back-channel
+  - bearer
+problem_domains:
+  - authorization
+  - authentication
+related_concepts:
+  - access-token
+  - jwt
+normative_anchors:
+  - rfc: RFC 6749
+    sections: ["4.1"]
+  - rfc: RFC 9700
+    sections: ["2.1"]
+runnable: true
+backend_id: authorization_code
+status: live
+href: /protocol/oauth2/flow/authorization-code
+summary: Server-side web app obtains tokens through a browser-mediated code exchange.
+---
+
+The authorization code grant is the canonical OAuth 2.0 flow for confidential
+clients. The user agent is redirected to the authorization server to consent,
+and the resulting authorization code is exchanged at the token endpoint over
+the back channel using the client's secret. The code is single-use and short-
+lived.

--- a/content/flows/oauth2/client-credentials.md
+++ b/content/flows/oauth2/client-credentials.md
@@ -1,0 +1,36 @@
+---
+id: client-credentials
+name: OAuth 2.0 client credentials grant
+protocol: oauth2
+use_cases:
+  - service-to-service-auth
+actors:
+  - confidential-client
+  - authorization-server
+  - resource-server
+patterns:
+  - back-channel
+  - bearer
+problem_domains:
+  - authorization
+related_concepts:
+  - access-token
+normative_anchors:
+  - rfc: RFC 6749
+    sections: ["4.4"]
+  - rfc: RFC 9700
+    sections: ["2.5"]
+runnable: true
+backend_id: client_credentials
+status: live
+href: /protocol/oauth2/flow/client-credentials
+summary: Confidential client authenticates as itself; no user context.
+aliases:
+  - m2m token
+  - machine-to-machine
+---
+
+The client credentials grant is used when a confidential client acts as
+itself, not on behalf of a user. The client authenticates directly at the
+token endpoint and receives an access token scoped to its own permissions.
+This is the canonical flow for service-to-service back-channel calls.

--- a/content/flows/oauth2/refresh-token.md
+++ b/content/flows/oauth2/refresh-token.md
@@ -1,0 +1,33 @@
+---
+id: refresh-token
+name: OAuth 2.0 refresh token exchange
+protocol: oauth2
+use_cases:
+  - token-refresh
+actors:
+  - client
+  - authorization-server
+patterns:
+  - back-channel
+  - bearer
+problem_domains:
+  - authorization
+  - session-management
+related_concepts:
+  - access-token
+normative_anchors:
+  - rfc: RFC 6749
+    sections: ["6"]
+  - rfc: RFC 9700
+    sections: ["4.14"]
+runnable: true
+backend_id: refresh_token
+status: live
+href: /protocol/oauth2/flow/refresh-token
+summary: Exchanges a refresh token for a fresh access token; supports rotation.
+---
+
+The refresh token grant exchanges a previously issued refresh token for a new
+access token (and optionally a rotated refresh token) without user
+interaction. RFC 9700 §4.14 mandates refresh token rotation and binding to
+the original client for public clients to mitigate token theft.

--- a/content/flows/oauth2/token-introspection.md
+++ b/content/flows/oauth2/token-introspection.md
@@ -1,0 +1,33 @@
+---
+id: token-introspection
+name: OAuth 2.0 token introspection
+protocol: oauth2
+use_cases:
+  - token-introspection
+actors:
+  - resource-server
+  - authorization-server
+patterns:
+  - back-channel
+  - bearer
+problem_domains:
+  - authorization
+  - session-management
+related_concepts:
+  - access-token
+normative_anchors:
+  - rfc: RFC 7662
+    sections: ["2", "4"]
+runnable: true
+backend_id: token_introspection
+status: live
+href: /protocol/oauth2/flow/token-introspection
+summary: Resource server asks the issuer whether a token is active and what it represents.
+aliases:
+  - introspect endpoint
+---
+
+Token introspection (RFC 7662) lets a protected resource ask the
+authorization server whether a presented token is active, who it was issued
+to, what scopes it carries, and when it expires. It is the canonical way to
+validate opaque access tokens that cannot be self-validated.

--- a/content/flows/oauth2/token-revocation.md
+++ b/content/flows/oauth2/token-revocation.md
@@ -1,0 +1,33 @@
+---
+id: token-revocation
+name: OAuth 2.0 token revocation
+protocol: oauth2
+use_cases:
+  - token-revocation
+actors:
+  - client
+  - authorization-server
+patterns:
+  - back-channel
+  - bearer
+problem_domains:
+  - authorization
+  - session-management
+related_concepts:
+  - access-token
+normative_anchors:
+  - rfc: RFC 7009
+    sections: ["2", "5"]
+runnable: true
+backend_id: token_revocation
+status: live
+href: /protocol/oauth2/flow/token-revocation
+summary: Client asks the issuer to invalidate a previously issued access or refresh token.
+aliases:
+  - revoke endpoint
+---
+
+Token revocation (RFC 7009) lets a client invalidate an access or refresh
+token at the authorization server, for example on user logout. The server
+treats the token (and any tokens derived from it, such as access tokens
+issued by exchanging a refresh token) as invalid after the call returns 200.

--- a/content/flows/oidc/discovery.md
+++ b/content/flows/oidc/discovery.md
@@ -1,0 +1,35 @@
+---
+id: discovery
+name: OIDC Discovery
+protocol: oidc
+use_cases:
+  - discovery
+actors:
+  - relying-party
+  - identity-provider
+patterns:
+  - back-channel
+  - metadata-discovery
+problem_domains:
+  - discovery
+  - key-management
+related_concepts:
+  - jwks
+normative_anchors:
+  - rfc: OpenID Connect Discovery 1.0
+    sections: ["3", "4", "7"]
+runnable: true
+backend_id: oidc_discovery
+status: live
+href: /protocol/oidc/flow/discovery
+summary: RP locates endpoints, supported features, and JWKS via .well-known.
+aliases:
+  - openid-configuration
+  - well-known/openid-configuration
+---
+
+OpenID Connect Discovery defines a `.well-known/openid-configuration`
+document published by the issuer. It carries endpoint URLs, supported scopes,
+response types, signing algorithms, and a `jwks_uri` pointing at the issuer's
+public keys. The RP fetches it once at startup (or on key rollover) to
+self-configure.

--- a/content/flows/oidc/hybrid.md
+++ b/content/flows/oidc/hybrid.md
@@ -1,0 +1,37 @@
+---
+id: hybrid
+name: OIDC hybrid flow
+protocol: oidc
+use_cases:
+  - user-login-via-own-idp
+  - delegated-api-access
+actors:
+  - relying-party
+  - identity-provider
+  - authorization-server
+  - user-agent
+patterns:
+  - front-channel-redirect
+  - back-channel
+  - signed-assertion
+  - nonce-bound
+problem_domains:
+  - authentication
+  - authorization
+related_concepts:
+  - id-token
+  - access-token
+normative_anchors:
+  - rfc: OpenID Connect Core 1.0
+    sections: ["3.3", "3.3.2", "3.3.3"]
+runnable: true
+backend_id: oidc_hybrid
+status: live
+href: /protocol/oidc/flow/hybrid
+summary: Returns ID Token on front channel and code for back-channel exchange.
+---
+
+The hybrid flow returns part of the response (typically an ID Token and an
+authorization code) on the front channel, while the access token is obtained
+via back-channel code exchange. The `at_hash` and `c_hash` claims in the
+returned ID Token bind it to the access token and code respectively.

--- a/content/flows/oidc/oidc-authorization-code.md
+++ b/content/flows/oidc/oidc-authorization-code.md
@@ -1,0 +1,46 @@
+---
+id: oidc-authorization-code
+name: OIDC authorization code flow
+protocol: oidc
+use_cases:
+  - user-login-via-own-idp
+  - single-sign-on
+  - delegated-api-access
+actors:
+  - relying-party
+  - identity-provider
+  - authorization-server
+  - user-agent
+patterns:
+  - front-channel-redirect
+  - back-channel
+  - signed-assertion
+  - nonce-bound
+  - bearer
+problem_domains:
+  - authentication
+  - authorization
+  - session-management
+related_concepts:
+  - id-token
+  - jwt
+  - access-token
+  - pkce
+normative_anchors:
+  - rfc: OpenID Connect Core 1.0
+    sections: ["3.1", "3.1.2.1", "3.1.3.7"]
+runnable: true
+backend_id: oidc_authorization_code
+status: live
+href: /protocol/oidc/flow/oidc-authorization-code
+summary: Authorization Code Flow with ID Token; canonical OIDC sign-in.
+aliases:
+  - oidc auth code
+  - openid connect login
+---
+
+The Authorization Code Flow with `openid` scope is the recommended OpenID
+Connect flow. The relying party receives both an ID Token (asserting the
+user's identity) and an access token (for any additional API calls), with the
+ID Token bound to a request-provided `nonce`. RFC 9700-aligned deployments
+also bind the request with PKCE.

--- a/content/flows/oidc/oidc-implicit.md
+++ b/content/flows/oidc/oidc-implicit.md
@@ -1,0 +1,36 @@
+---
+id: oidc-implicit
+name: OIDC implicit flow (legacy)
+protocol: oidc
+use_cases:
+  - user-login-via-own-idp
+  - single-page-app-login
+actors:
+  - relying-party
+  - identity-provider
+  - user-agent
+patterns:
+  - front-channel-redirect
+  - signed-assertion
+  - nonce-bound
+problem_domains:
+  - authentication
+related_concepts:
+  - id-token
+normative_anchors:
+  - rfc: OpenID Connect Core 1.0
+    sections: ["3.2"]
+  - rfc: RFC 9700
+    sections: ["2.1.2"]
+runnable: true
+backend_id: oidc_implicit
+status: deprecated
+href: /protocol/oidc/flow/oidc-implicit
+summary: Tokens returned directly via the front channel; superseded by code+PKCE.
+---
+
+The implicit flow returns the ID Token (and optionally an access token)
+directly in the authorization response fragment, with no back-channel token
+exchange. RFC 9700 §2.1.2 explicitly states the implicit grant SHOULD NOT be
+used; prefer Authorization Code + PKCE. Kept in the catalog for educational
+contrast.

--- a/content/flows/oidc/userinfo.md
+++ b/content/flows/oidc/userinfo.md
@@ -1,0 +1,31 @@
+---
+id: userinfo
+name: OIDC UserInfo endpoint
+protocol: oidc
+use_cases:
+  - delegated-api-access
+actors:
+  - relying-party
+  - identity-provider
+patterns:
+  - back-channel
+  - bearer
+problem_domains:
+  - authentication
+related_concepts:
+  - access-token
+  - id-token
+normative_anchors:
+  - rfc: OpenID Connect Core 1.0
+    sections: ["5.3", "16.11"]
+runnable: true
+backend_id: oidc_userinfo
+status: live
+href: /protocol/oidc/flow/userinfo
+summary: RP fetches additional user claims from the IdP using an access token.
+---
+
+The UserInfo endpoint returns claims about the authenticated end-user when
+presented with a valid access token issued for the `openid` scope. The
+`sub` claim returned MUST match the `sub` claim in the ID Token to prevent
+token substitution (OIDC Core §16.11).

--- a/content/protocols/oauth2.md
+++ b/content/protocols/oauth2.md
@@ -1,0 +1,54 @@
+---
+id: oauth2
+name: OAuth 2.0
+use_cases:
+  - delegated-api-access
+  - service-to-service-auth
+  - single-page-app-login
+  - mobile-app-login
+  - token-refresh
+  - token-introspection
+  - token-revocation
+actors:
+  - client
+  - public-client
+  - confidential-client
+  - authorization-server
+  - resource-server
+  - user-agent
+patterns:
+  - front-channel-redirect
+  - back-channel
+  - bearer
+  - pkce-bound
+  - metadata-discovery
+problem_domains:
+  - authorization
+  - authentication
+  - session-management
+  - key-management
+related_concepts:
+  - pkce
+  - jwt
+  - jwks
+  - access-token
+normative_anchors:
+  - rfc: RFC 6749
+    sections: ["1.1", "1.4", "4", "5", "6", "10"]
+  - rfc: RFC 6750
+    sections: ["1", "2"]
+  - rfc: RFC 9700
+    sections: ["2.1", "2.5"]
+status: live
+href: /protocol/oauth2
+summary: Industry-standard authorization framework for delegated API access.
+aliases:
+  - rfc 6749
+  - oauth 2
+  - oauth2.0
+---
+
+OAuth 2.0 is the authorization framework defined by RFC 6749. It lets a client
+application obtain limited access to a resource server on behalf of a resource
+owner without exposing credentials. Modern deployments follow RFC 9700, the
+OAuth 2.0 Security Best Current Practice (BCP 240).

--- a/content/protocols/oid4vci.md
+++ b/content/protocols/oid4vci.md
@@ -1,0 +1,41 @@
+---
+id: oid4vci
+name: OpenID for Verifiable Credential Issuance
+use_cases:
+  - credential-issuance
+  - discovery
+actors:
+  - issuer
+  - holder
+  - wallet
+  - authorization-server
+patterns:
+  - back-channel
+  - pre-authorized
+  - qr-code-handoff
+  - signed-assertion
+  - key-bound
+  - metadata-discovery
+problem_domains:
+  - verifiable-credentials
+  - authorization
+  - key-management
+related_concepts:
+  - jwt
+  - jwks
+normative_anchors:
+  - rfc: OpenID4VCI 1.0
+    sections: ["3", "4", "6", "8", "9", "13"]
+status: live
+href: /protocol/oid4vci
+summary: Issues verifiable credentials to a wallet via OpenID-based flows.
+aliases:
+  - vci
+  - credential offer
+---
+
+OpenID for Verifiable Credential Issuance (OID4VCI) profiles OAuth 2.0 so an
+authorised issuer can deliver a verifiable credential to a holder's wallet. It
+supports authorisation code and pre-authorised code grants, credential offers
+delivered out-of-band (typically by QR), nonce-bound proof of key possession,
+and deferred issuance for credentials that require manual approval.

--- a/content/protocols/oid4vp.md
+++ b/content/protocols/oid4vp.md
@@ -1,0 +1,39 @@
+---
+id: oid4vp
+name: OpenID for Verifiable Presentations
+use_cases:
+  - credential-presentation
+  - user-login-via-own-idp
+actors:
+  - verifier
+  - holder
+  - wallet
+patterns:
+  - front-channel-redirect
+  - out-of-band
+  - signed-assertion
+  - nonce-bound
+  - qr-code-handoff
+  - attestation-bound
+problem_domains:
+  - verifiable-credentials
+  - authentication
+related_concepts:
+  - dcql
+  - did-web
+  - jwt
+normative_anchors:
+  - rfc: OpenID4VP 1.0
+    sections: ["5", "6.1", "8.2", "8.3", "14"]
+status: live
+href: /protocol/oid4vp
+summary: Requests and verifies verifiable presentations from a wallet.
+aliases:
+  - vp
+---
+
+OpenID for Verifiable Presentations (OID4VP) defines how a verifier requests
+a presentation from a holder's wallet using DCQL (Digital Credentials Query
+Language) and receives the presentation via direct_post or direct_post.jwt.
+Trust between verifier and wallet is established via client_id_scheme values
+including redirect_uri, verifier_attestation, and x509_san_dns.

--- a/content/protocols/oidc.md
+++ b/content/protocols/oidc.md
@@ -1,0 +1,55 @@
+---
+id: oidc
+name: OpenID Connect
+use_cases:
+  - user-login-via-own-idp
+  - user-login-via-social
+  - single-sign-on
+  - single-page-app-login
+  - mobile-app-login
+  - discovery
+  - step-up-authentication
+actors:
+  - relying-party
+  - identity-provider
+  - authorization-server
+  - user-agent
+  - public-client
+  - confidential-client
+patterns:
+  - front-channel-redirect
+  - back-channel
+  - signed-assertion
+  - nonce-bound
+  - metadata-discovery
+  - bearer
+problem_domains:
+  - authentication
+  - federation
+  - session-management
+  - key-management
+  - discovery
+related_concepts:
+  - jwt
+  - jwks
+  - id-token
+  - access-token
+  - pkce
+normative_anchors:
+  - rfc: OpenID Connect Core 1.0
+    sections: ["3.1", "3.3", "5.3", "15", "16"]
+  - rfc: OpenID Connect Discovery 1.0
+    sections: ["3", "7"]
+status: live
+href: /protocol/oidc
+summary: Identity layer over OAuth 2.0 that adds verified authentication.
+aliases:
+  - openid 1.0
+  - oidc core
+  - openid connect core
+---
+
+OpenID Connect adds a verified authentication layer on top of OAuth 2.0. The
+relying party receives a signed ID Token that asserts the user's identity, in
+addition to (or instead of) an access token. Discovery and JWKS endpoints let
+clients self-configure without prior coordination.

--- a/content/protocols/saml.md
+++ b/content/protocols/saml.md
@@ -1,0 +1,38 @@
+---
+id: saml
+name: SAML 2.0
+use_cases:
+  - user-login-via-own-idp
+  - single-sign-on
+  - single-logout
+  - federation-trust-establishment
+actors:
+  - identity-provider
+  - service-provider
+  - user-agent
+patterns:
+  - front-channel-redirect
+  - signed-assertion
+  - xml-signed
+  - metadata-discovery
+problem_domains:
+  - authentication
+  - federation
+  - session-management
+normative_anchors:
+  - rfc: SAML 2.0 Core
+    sections: ["2", "3"]
+  - rfc: SAML 2.0 Bindings
+    sections: ["3", "4"]
+  - rfc: SAML 2.0 Profiles
+    sections: ["4.1", "4.4"]
+status: live
+href: /protocol/saml
+summary: XML-based enterprise SSO via signed assertions between IdP and SP.
+---
+
+SAML 2.0 (Security Assertion Markup Language) is the OASIS standard for
+exchanging authentication and authorization data between an identity provider
+and a service provider. Assertions are XML documents, signed with XMLDsig, and
+typically delivered to the SP via HTTP-POST or HTTP-Redirect bindings through
+the user's browser.

--- a/content/protocols/scim.md
+++ b/content/protocols/scim.md
@@ -1,0 +1,34 @@
+---
+id: scim
+name: SCIM 2.0
+use_cases:
+  - user-provisioning
+  - discovery
+actors:
+  - scim-client
+  - scim-service-provider
+  - identity-provider
+patterns:
+  - back-channel
+  - bearer
+  - metadata-discovery
+problem_domains:
+  - provisioning
+  - discovery
+normative_anchors:
+  - rfc: RFC 7642
+    sections: ["3"]
+  - rfc: RFC 7643
+    sections: ["4"]
+  - rfc: RFC 7644
+    sections: ["3"]
+status: live
+href: /protocol/scim
+summary: Cross-domain identity provisioning protocol for users and groups.
+---
+
+SCIM 2.0 (System for Cross-domain Identity Management) is the IETF standard
+for automating user account lifecycle across systems. Defined across RFC 7642
+(definitions), RFC 7643 (core schema), and RFC 7644 (protocol), it lets an
+identity provider create, read, update, and deactivate accounts on downstream
+service providers.

--- a/content/protocols/spiffe.md
+++ b/content/protocols/spiffe.md
@@ -1,0 +1,36 @@
+---
+id: spiffe
+name: SPIFFE/SPIRE
+use_cases:
+  - workload-attestation
+  - service-to-service-auth
+actors:
+  - workload
+patterns:
+  - mutual-tls
+  - certificate-bound
+  - key-bound
+  - attestation-bound
+  - signed-assertion
+problem_domains:
+  - workload-identity
+  - authentication
+  - key-management
+normative_anchors:
+  - rfc: SPIFFE-ID
+    sections: ["2"]
+  - rfc: X509-SVID
+    sections: ["2", "4"]
+  - rfc: JWT-SVID
+    sections: ["2", "3"]
+  - rfc: Workload API
+    sections: ["3", "5"]
+status: live
+href: /protocol/spiffe
+summary: Cryptographic identity for workloads via X.509-SVID and JWT-SVID.
+---
+
+SPIFFE (Secure Production Identity Framework For Everyone) defines a uniform
+identity for workloads that is attested by infrastructure rather than carried
+in static credentials. SPIRE is the reference implementation. Identities are
+expressed as X.509-SVIDs or JWT-SVIDs scoped by a trust domain.

--- a/content/protocols/ssf.md
+++ b/content/protocols/ssf.md
@@ -1,0 +1,36 @@
+---
+id: ssf
+name: Shared Signals Framework
+use_cases:
+  - continuous-evaluation
+  - discovery
+actors:
+  - transmitter
+  - receiver
+patterns:
+  - push-based
+  - polling
+  - signed-assertion
+  - bearer
+  - metadata-discovery
+problem_domains:
+  - security-events
+  - session-management
+normative_anchors:
+  - rfc: RFC 8417
+    sections: ["1", "2"]
+  - rfc: RFC 8935
+    sections: ["1", "2"]
+  - rfc: RFC 8936
+    sections: ["1", "2"]
+  - rfc: OpenID SSF 1.0
+    sections: ["3", "5"]
+status: live
+href: /protocol/ssf
+summary: Real-time security event sharing across identity-consuming systems.
+---
+
+The Shared Signals Framework (SSF) defines how identity-consuming systems
+share Security Event Tokens (SETs, RFC 8417) to coordinate session, account,
+and credential state in real time. CAEP and RISC are the two principal
+profiles. Push delivery uses RFC 8935; poll delivery uses RFC 8936.

--- a/content/taxonomy.yaml
+++ b/content/taxonomy.yaml
@@ -1,0 +1,153 @@
+# ProtocolSoup palette taxonomy
+#
+# Controlled vocabulary for every retrieval axis. Validator fails on any
+# artefact frontmatter that uses a value not present here.
+#
+# Each value carries a one-line semantic note explaining what it covers.
+# Notes are declarative; do not turn them into marketing copy.
+#
+# Axes:
+#   use_cases       — intent-level outcomes the user is trying to achieve
+#   actors          — protocol participants involved in the artefact
+#   patterns        — how the protocol mechanically operates
+#   problem_domains — high-level problem space the artefact addresses
+
+use_cases:
+  user-login-via-own-idp:
+    note: User signs into a relying party using credentials held by their own identity provider.
+  user-login-via-social:
+    note: User signs into a relying party via a third-party social identity provider.
+  service-to-service-auth:
+    note: One backend service authenticates as itself to another backend service.
+  step-up-authentication:
+    note: Demanding stronger or fresher authentication mid-session.
+  credential-issuance:
+    note: Issuer mints a verifiable credential to a holder wallet.
+  credential-presentation:
+    note: Holder wallet presents a verifiable credential to a verifier.
+  continuous-evaluation:
+    note: Producing or consuming security events that change live session state.
+  workload-attestation:
+    note: Workload obtains a cryptographic identity that proves what it is.
+  user-provisioning:
+    note: Synchronising user accounts and groups across identity systems.
+  single-sign-on:
+    note: One authentication grants access to multiple federated applications.
+  single-logout:
+    note: One logout terminates sessions across multiple federated applications.
+  token-introspection:
+    note: Resource server validates an opaque token at the authoritative issuer.
+  token-revocation:
+    note: Invalidating a previously issued token at the issuer.
+  delegated-api-access:
+    note: Application calls an API on behalf of a user with scoped permissions.
+  mobile-app-login:
+    note: User signs into a native mobile application.
+  single-page-app-login:
+    note: User signs into a browser SPA without a backend client secret.
+  federation-trust-establishment:
+    note: Two identity systems publish metadata and establish bilateral trust.
+  discovery:
+    note: Locating endpoints, keys, and capabilities of a protocol participant.
+  token-refresh:
+    note: Exchanging a refresh token for a new access token without user interaction.
+  pkce-protection:
+    note: Binding an authorization request to a code_verifier to prevent code interception.
+
+actors:
+  public-client:
+    note: OAuth client that cannot keep secrets confidential (SPA, mobile, native).
+  confidential-client:
+    note: OAuth client that can keep secrets confidential (backend service).
+  client:
+    note: OAuth client application requesting tokens, public or confidential.
+  authorization-server:
+    note: OAuth 2.0 entity that issues access and refresh tokens.
+  resource-server:
+    note: OAuth 2.0 entity that hosts protected resources and accepts access tokens.
+  identity-provider:
+    note: SAML or OIDC IdP responsible for authenticating users.
+  service-provider:
+    note: SAML SP relying on assertions issued by an IdP.
+  relying-party:
+    note: OIDC RP relying on identity claims issued by an OP.
+  wallet:
+    note: VC holder application that stores and presents credentials.
+  verifier:
+    note: VC verifier requesting presentations from a wallet.
+  issuer:
+    note: VC issuer issuing credentials to a wallet.
+  holder:
+    note: Subject controlling a wallet that holds credentials.
+  workload:
+    note: Service identity attested by SPIFFE infrastructure.
+  user-agent:
+    note: Browser or mobile OS mediating between user and protocol participants.
+  transmitter:
+    note: SSF transmitter publishing security event tokens.
+  receiver:
+    note: SSF receiver consuming security event tokens.
+  scim-client:
+    note: SCIM client (typically an IdP) issuing provisioning requests.
+  scim-service-provider:
+    note: SCIM-protected resource accepting provisioning requests.
+
+patterns:
+  front-channel-redirect:
+    note: Protocol message delivered through the user agent via HTTP redirects.
+  back-channel:
+    note: Protocol message delivered server-to-server without user-agent involvement.
+  out-of-band:
+    note: Protocol step delivered outside the primary HTTP exchange.
+  certificate-bound:
+    note: Token or session bound to a TLS client certificate.
+  key-bound:
+    note: Token bound to a cryptographic proof-of-possession key.
+  push-based:
+    note: Sender initiates delivery as events occur.
+  polling:
+    note: Receiver asks for new data on a schedule or trigger.
+  signed-assertion:
+    note: Identity statement carried in a cryptographically signed envelope.
+  pre-authorized:
+    note: Authorization granted before the protocol exchange begins.
+  pkce-bound:
+    note: Authorization request bound to a PKCE code_verifier and code_challenge.
+  nonce-bound:
+    note: Response bound to a request-provided nonce to prevent replay.
+  xml-signed:
+    note: Assertion signed using XMLDsig.
+  qr-code-handoff:
+    note: Handoff between two devices via QR code.
+  metadata-discovery:
+    note: Endpoints and keys located via a published metadata document.
+  audience-restricted:
+    note: Token or assertion scoped to a specific recipient via audience claim.
+  attestation-bound:
+    note: Identity bound to platform or workload attestation.
+  mutual-tls:
+    note: Both parties present X.509 certificates during TLS handshake.
+  bearer:
+    note: Token presented as proof of authorization, valid for whoever holds it.
+
+problem_domains:
+  authentication:
+    note: Verifying who someone is.
+  authorization:
+    note: Deciding what an authenticated party may do.
+  federation:
+    note: Trust relationships and identity flow between organisations.
+  provisioning:
+    note: Creating, updating, and deactivating user accounts across systems.
+  verifiable-credentials:
+    note: Issuance, holding, and presentation of cryptographically verifiable claims.
+  security-events:
+    note: Sharing real-time signals about identities, sessions, and credentials.
+  workload-identity:
+    note: Cryptographic identity for non-human services.
+  session-management:
+    note: Establishing, refreshing, and terminating user sessions.
+  key-management:
+    note: Distribution, rotation, and trust of cryptographic keys.
+  discovery:
+    note: Locating endpoints, keys, and supported features.

--- a/docs/starlight/src/content/docs/developers/development-setup.mdx
+++ b/docs/starlight/src/content/docs/developers/development-setup.mdx
@@ -78,5 +78,9 @@ Run the smallest set that covers your change before requesting review.
 | OpenAPI contracts | `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1` |
 | Docker or service topology | `cd docker && docker compose config` |
 | OID4VCI/OID4VP conformance | `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1` |
+| Palette content (`content/**`) | `cd backend && go run ./cmd/content-validate -content ../content && go test ./internal/palette/...` |
+| Palette indexer or query service | `cd backend && go test ./internal/palette/... && go run ./cmd/palette-indexer -content ../content -out ../frontend/public/palette.db` |
+
+The canonical contract for palette artefacts lives in [`content/SCHEMA.md`](https://github.com/ParleSec/ProtocolSoup/blob/master/content/SCHEMA.md). New axis values must be added to `content/taxonomy.yaml`, and synonyms to `content/aliases.yaml`. Both files are validated in CI by `cmd/content-validate`.
 
 Security scans may be limited on forked pull requests because repository secrets are not available to untrusted code. Maintainers can rerun or review those checks after triage.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -79,6 +79,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -292,6 +293,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -505,6 +507,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -527,6 +530,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -549,6 +553,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -565,6 +570,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -581,6 +587,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -597,6 +604,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -613,6 +621,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -629,6 +638,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -645,6 +655,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -661,6 +672,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -677,6 +689,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -693,6 +706,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -709,6 +723,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -731,6 +746,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -753,6 +769,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -775,6 +792,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -797,6 +815,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -819,6 +838,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -841,6 +861,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -863,6 +884,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -885,6 +907,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -904,6 +927,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -923,6 +947,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -942,6 +967,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1370,27 +1396,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -1531,6 +1536,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1590,6 +1596,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1794,6 +1801,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1944,6 +1952,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2157,6 +2166,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3199,6 +3209,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3234,6 +3245,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3292,6 +3304,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3301,6 +3314,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3560,6 +3574,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3805,6 +3820,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Layout } from '@/components/common/Layout'
+import { CmdKPalette } from '@/components/palette/CmdKPalette'
 import { SITE_CONFIG } from '@/config/seo'
 import { SITE_ORIGIN, absoluteUrl } from '@/lib/seo'
 import { generateOrganizationSchema, generateWebsiteSchema } from '@/utils/schema'
@@ -85,6 +86,7 @@ export default function RootLayout({
           />
         ))}
         <Layout>{children}</Layout>
+        <CmdKPalette />
       </body>
     </html>
   )

--- a/frontend/src/components/common/LayoutHeader.client.tsx
+++ b/frontend/src/components/common/LayoutHeader.client.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Eye, Home, ExternalLink, BookOpen, Menu, X, Radio, FileText } from 'lucide-react'
+import { Eye, Home, ExternalLink, BookOpen, Menu, X, Radio, FileText, Search } from 'lucide-react'
+
+import { usePlatformShortcutLabel } from '@/components/palette/usePaletteQuery'
 
 function Github({ className }: { className?: string }) {
   return (
@@ -20,14 +22,24 @@ const navItems = [
   { path: '/protocols', icon: BookOpen, label: 'Protocols' },
 ]
 
+function openPalette() {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('palette:open'))
+}
+
 export function LayoutHeader() {
   const pathname = usePathname()
   const currentPath = pathname || '/'
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const shortcutLabel = usePlatformShortcutLabel()
 
   useEffect(() => {
     setIsMobileMenuOpen(false)
   }, [currentPath])
+
+  // The homepage carries its own prominent search input; suppressing the
+  // header chip there avoids two competing call-to-action surfaces.
+  const showSearchChip = currentPath !== '/'
 
   useEffect(() => {
     if (isMobileMenuOpen) {
@@ -51,6 +63,23 @@ export function LayoutHeader() {
             </Link>
 
             <nav className="hidden lg:flex items-center gap-1">
+              {showSearchChip && (
+                <button
+                  type="button"
+                  onClick={openPalette}
+                  aria-haspopup="dialog"
+                  aria-label="Open search palette"
+                  className="flex items-center gap-2 px-3 py-1.5 rounded-md transition-colors text-sm text-surface-400 hover:text-white hover:bg-white/5 mr-1"
+                >
+                  <Search className="w-4 h-4" />
+                  <span>Search</span>
+                  {shortcutLabel && (
+                    <kbd className="ml-1 hidden xl:inline-flex items-center rounded border border-white/10 bg-surface-800/60 px-1.5 py-0.5 text-[10px] font-mono text-surface-300">
+                      {shortcutLabel}
+                    </kbd>
+                  )}
+                </button>
+              )}
               {navItems.map((item) => {
                 const isActive = currentPath === item.path ||
                   (item.path !== '/' && currentPath.startsWith(item.path))
@@ -137,6 +166,19 @@ export function LayoutHeader() {
               </div>
 
               <div className="flex-1 overflow-y-auto p-4 space-y-1">
+                {showSearchChip && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsMobileMenuOpen(false)
+                      openPalette()
+                    }}
+                    className="flex w-full items-center gap-3 px-4 py-3 rounded-xl text-surface-400 hover:text-white hover:bg-white/5 transition-colors"
+                  >
+                    <Search className="w-5 h-5" />
+                    <span className="font-medium">Search</span>
+                  </button>
+                )}
                 {navItems.map((item) => {
                   const isActive = currentPath === item.path ||
                     (item.path !== '/' && currentPath.startsWith(item.path))

--- a/frontend/src/components/palette/CmdKPalette.tsx
+++ b/frontend/src/components/palette/CmdKPalette.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { usePathname } from 'next/navigation'
+
+import { Palette } from './Palette'
+
+/**
+ * CmdKPalette mounts the shared Palette as a global keyboard-driven overlay.
+ *
+ * Bindings:
+ * - Cmd/Ctrl+K toggles the overlay.
+ * - "/" opens the overlay when focus is outside an editable element.
+ * - Esc closes it (handled inside Palette for the cmdk variant).
+ *
+ * The overlay is suppressed on the homepage because the homepage already
+ * carries a prominent input. Suppressing avoids two visible palette inputs
+ * fighting for the same focus.
+ */
+export function CmdKPalette() {
+  const pathname = usePathname()
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLElement | null>(null)
+
+  const isHomepage = pathname === '/' || pathname === ''
+
+  const close = useCallback(() => {
+    setOpen(false)
+    triggerRef.current?.focus()
+    triggerRef.current = null
+  }, [])
+
+  useEffect(() => {
+    if (isHomepage) return
+
+    function onKey(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null
+      const isEditable =
+        !!target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        triggerRef.current = (document.activeElement as HTMLElement) ?? null
+        setOpen((v) => !v)
+        return
+      }
+
+      if (event.key === '/' && !isEditable && !open) {
+        event.preventDefault()
+        triggerRef.current = (document.activeElement as HTMLElement) ?? null
+        setOpen(true)
+      }
+    }
+
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isHomepage, open])
+
+  // Close the overlay automatically when the route changes.
+  useEffect(() => {
+    if (!open) return
+    setOpen(false)
+    triggerRef.current = null
+  }, [pathname]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!open) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [open])
+
+  if (isHomepage || !open) {
+    return null
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search palette"
+      className="fixed inset-0 z-[200] flex items-start justify-center pt-[12vh] px-3 sm:px-4"
+    >
+      <button
+        type="button"
+        aria-label="Close palette"
+        onClick={close}
+        className="absolute inset-0 bg-surface-950/80 backdrop-blur-sm"
+      />
+      <div className="relative z-10 w-full max-w-2xl rounded-xl border border-white/10 bg-surface-900/95 shadow-2xl p-3 sm:p-4 max-h-[78vh] overflow-y-auto">
+        <Palette variant="cmdk" autoFocus onClose={close} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/palette/CmdKPalette.tsx
+++ b/frontend/src/components/palette/CmdKPalette.tsx
@@ -9,9 +9,13 @@ import { Palette } from './Palette'
  * CmdKPalette mounts the shared Palette as a global keyboard-driven overlay.
  *
  * Bindings:
- * - Cmd/Ctrl+K toggles the overlay.
+ * - Cmd/Ctrl+K toggles the overlay on non-home pages; on `/` it focuses the
+ *   homepage palette input via `palette:focus-home`.
  * - "/" opens the overlay when focus is outside an editable element.
  * - Esc closes it (handled inside Palette for the cmdk variant).
+ * - `window.dispatchEvent(new CustomEvent('palette:open'))` from any other
+ *   component (e.g. the site header Search chip) opens the overlay; the
+ *   header stays decoupled from the modal implementation.
  *
  * The overlay is suppressed on the homepage because the homepage already
  * carries a prominent input. Suppressing avoids two visible palette inputs
@@ -31,8 +35,6 @@ export function CmdKPalette() {
   }, [])
 
   useEffect(() => {
-    if (isHomepage) return
-
     function onKey(event: KeyboardEvent) {
       const target = event.target as HTMLElement | null
       const isEditable =
@@ -43,10 +45,16 @@ export function CmdKPalette() {
 
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault()
+        if (isHomepage) {
+          window.dispatchEvent(new CustomEvent('palette:focus-home'))
+          return
+        }
         triggerRef.current = (document.activeElement as HTMLElement) ?? null
         setOpen((v) => !v)
         return
       }
+
+      if (isHomepage) return
 
       if (event.key === '/' && !isEditable && !open) {
         event.preventDefault()
@@ -55,8 +63,18 @@ export function CmdKPalette() {
       }
     }
 
+    function onPaletteOpen() {
+      if (isHomepage) return
+      triggerRef.current = (document.activeElement as HTMLElement) ?? null
+      setOpen(true)
+    }
+
     window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    window.addEventListener('palette:open', onPaletteOpen)
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('palette:open', onPaletteOpen)
+    }
   }, [isHomepage, open])
 
   // Close the overlay automatically when the route changes.
@@ -92,9 +110,33 @@ export function CmdKPalette() {
         onClick={close}
         className="absolute inset-0 bg-surface-950/80 backdrop-blur-sm"
       />
-      <div className="relative z-10 w-full max-w-2xl rounded-xl border border-white/10 bg-surface-900/95 shadow-2xl p-3 sm:p-4 max-h-[78vh] overflow-y-auto">
-        <Palette variant="cmdk" autoFocus onClose={close} />
+      <div className="relative z-10 flex w-full max-w-2xl flex-col rounded-xl border border-white/10 bg-surface-900/95 shadow-2xl max-h-[78vh] overflow-hidden">
+        <div className="flex min-h-0 flex-1 flex-col p-3 sm:p-4">
+          <Palette variant="cmdk" autoFocus onClose={close} />
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-white/5 bg-surface-900/95 px-3 py-2 text-[10px] text-surface-500 sm:px-4">
+          <ShortcutHint keys={['\u2191', '\u2193']} label="navigate" />
+          <ShortcutHint keys={['Enter']} label="open" />
+          <ShortcutHint keys={['Tab']} label="narrow" />
+          <ShortcutHint keys={['Esc']} label="close" />
+        </div>
       </div>
     </div>
+  )
+}
+
+function ShortcutHint({ keys, label }: { keys: string[]; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {keys.map((k, i) => (
+        <kbd
+          key={`${k}-${i}`}
+          className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded border border-white/10 bg-surface-800/60 px-1 font-mono text-[10px] text-surface-300"
+        >
+          {k}
+        </kbd>
+      ))}
+      <span className="text-surface-500">{label}</span>
+    </span>
   )
 }

--- a/frontend/src/components/palette/HomepagePalette.tsx
+++ b/frontend/src/components/palette/HomepagePalette.tsx
@@ -1,16 +1,43 @@
 'use client'
 
-import { Palette } from './Palette'
+import { Suspense } from 'react'
+
+import { Palette } from '@/components/palette/Palette'
+
+const shellClass =
+  'p-0 sm:rounded-xl sm:border sm:border-white/10 sm:bg-surface-900/30 sm:p-5'
+
+function HomepagePaletteInner() {
+  return (
+    <section className={shellClass}>
+      <Palette variant="homepage" autoFocus={false} />
+    </section>
+  )
+}
 
 /**
  * HomepagePalette wraps the shared Palette component for the homepage mount
- * point. Renders below the tagline as the single prominent retrieval surface
- * for protocolsoup.com — no separate hero search, no separate "browse" link.
+ * point.
+ *
+ * On mobile the outer card chrome is omitted so the input reads as part of
+ * the hero, not a second boxed panel stacked under the tagline.
+ *
+ * Suspense is required because Palette reads `useSearchParams()` for URL
+ * persistence on the homepage.
  */
 export function HomepagePalette() {
   return (
-    <section className="rounded-xl border border-white/10 bg-surface-900/30 p-3.5 sm:p-5">
-      <Palette variant="homepage" autoFocus={false} />
-    </section>
+    <Suspense
+      fallback={
+        <section className={shellClass}>
+          <div
+            className="h-11 animate-pulse rounded-lg border border-white/10 bg-surface-900/60 sm:h-14"
+            aria-hidden="true"
+          />
+        </section>
+      }
+    >
+      <HomepagePaletteInner />
+    </Suspense>
   )
 }

--- a/frontend/src/components/palette/HomepagePalette.tsx
+++ b/frontend/src/components/palette/HomepagePalette.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { Palette } from './Palette'
+
+/**
+ * HomepagePalette wraps the shared Palette component for the homepage mount
+ * point. Renders below the tagline as the single prominent retrieval surface
+ * for protocolsoup.com — no separate hero search, no separate "browse" link.
+ */
+export function HomepagePalette() {
+  return (
+    <section className="rounded-xl border border-white/10 bg-surface-900/30 p-3.5 sm:p-5">
+      <Palette variant="homepage" autoFocus={false} />
+    </section>
+  )
+}

--- a/frontend/src/components/palette/MarkdownLite.tsx
+++ b/frontend/src/components/palette/MarkdownLite.tsx
@@ -1,0 +1,257 @@
+'use client'
+
+import { Fragment } from 'react'
+
+/**
+ * MarkdownLite renders the small subset of markdown used in ProtocolSoup
+ * artefact bodies — paragraphs, inline `code`, **bold**, *italic*, links,
+ * and bullet/numbered lists. It deliberately does NOT support raw HTML
+ * (with one exception: `<mark>` spans coming from the backend snippet
+ * builder are recognised and rendered as highlighted spans).
+ *
+ * The point is to keep the dependency surface zero — the project prompt
+ * forbids new UI library dependencies — while still rendering the corpus
+ * faithfully. If the corpus ever grows to need tables, code blocks, or
+ * nested lists, swap this for a real markdown library.
+ */
+interface MarkdownLiteProps {
+  source: string
+  /** When true, the source is the query-aware snippet that may contain
+   *  literal `<mark>...</mark>` spans from the backend. */
+  allowMark?: boolean
+  className?: string
+}
+
+export function MarkdownLite({ source, allowMark, className }: MarkdownLiteProps) {
+  if (!source) return null
+  const blocks = splitBlocks(source)
+  return (
+    <div className={className ?? 'space-y-2 text-[13px] leading-relaxed text-surface-200'}>
+      {blocks.map((block, i) => renderBlock(block, i, !!allowMark))}
+    </div>
+  )
+}
+
+type Block =
+  | { kind: 'paragraph'; text: string }
+  | { kind: 'heading'; level: number; text: string }
+  | { kind: 'ul'; items: string[] }
+  | { kind: 'ol'; items: string[] }
+
+function splitBlocks(source: string): Block[] {
+  const lines = source.replace(/\r\n/g, '\n').split('\n')
+  const blocks: Block[] = []
+  let buffer: string[] = []
+
+  const flushParagraph = () => {
+    const text = buffer.join(' ').trim()
+    if (text) blocks.push({ kind: 'paragraph', text })
+    buffer = []
+  }
+
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]
+
+    if (line.trim() === '') {
+      flushParagraph()
+      i++
+      continue
+    }
+
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line)
+    if (heading) {
+      flushParagraph()
+      blocks.push({ kind: 'heading', level: heading[1].length, text: heading[2].trim() })
+      i++
+      continue
+    }
+
+    if (/^\s*[-*+]\s+/.test(line)) {
+      flushParagraph()
+      const items: string[] = []
+      while (i < lines.length && /^\s*[-*+]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*[-*+]\s+/, ''))
+        i++
+      }
+      blocks.push({ kind: 'ul', items })
+      continue
+    }
+
+    if (/^\s*\d+\.\s+/.test(line)) {
+      flushParagraph()
+      const items: string[] = []
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*\d+\.\s+/, ''))
+        i++
+      }
+      blocks.push({ kind: 'ol', items })
+      continue
+    }
+
+    buffer.push(line)
+    i++
+  }
+  flushParagraph()
+  return blocks
+}
+
+function renderBlock(block: Block, key: number, allowMark: boolean) {
+  switch (block.kind) {
+    case 'paragraph':
+      return (
+        <p key={key} className="text-surface-200">
+          {renderInline(block.text, allowMark)}
+        </p>
+      )
+    case 'heading': {
+      const sizes = ['text-base', 'text-base', 'text-sm', 'text-sm', 'text-xs', 'text-xs']
+      const size = sizes[Math.min(block.level - 1, sizes.length - 1)]
+      return (
+        <p key={key} className={`font-semibold text-white ${size} mt-1`}>
+          {renderInline(block.text, allowMark)}
+        </p>
+      )
+    }
+    case 'ul':
+      return (
+        <ul key={key} className="list-disc pl-5 space-y-0.5 text-surface-200">
+          {block.items.map((item, j) => (
+            <li key={j}>{renderInline(item, allowMark)}</li>
+          ))}
+        </ul>
+      )
+    case 'ol':
+      return (
+        <ol key={key} className="list-decimal pl-5 space-y-0.5 text-surface-200">
+          {block.items.map((item, j) => (
+            <li key={j}>{renderInline(item, allowMark)}</li>
+          ))}
+        </ol>
+      )
+  }
+}
+
+/**
+ * Inline tokeniser. Walks the string once, splitting on the smallest set of
+ * inline markers we support: `<mark>`, backticks, `**`, `*`, and link
+ * syntax `[text](url)`. Each segment is rendered with the right tag. No
+ * raw HTML is ever passed through except the `<mark>` open/close tags
+ * recognised here.
+ */
+function renderInline(text: string, allowMark: boolean): React.ReactNode {
+  const nodes: React.ReactNode[] = []
+  let i = 0
+  let key = 0
+  let plain = ''
+
+  const flushPlain = () => {
+    if (plain) {
+      nodes.push(plain)
+      plain = ''
+    }
+  }
+
+  while (i < text.length) {
+    if (allowMark && text.startsWith('<mark>', i)) {
+      const end = text.indexOf('</mark>', i + 6)
+      if (end >= 0) {
+        flushPlain()
+        nodes.push(
+          <mark
+            key={`m-${key++}`}
+            className="bg-amber-400/20 text-amber-100 rounded px-0.5 py-px"
+          >
+            {text.slice(i + 6, end)}
+          </mark>,
+        )
+        i = end + 7
+        continue
+      }
+    }
+
+    const ch = text[i]
+
+    if (ch === '`') {
+      const end = text.indexOf('`', i + 1)
+      if (end > i) {
+        flushPlain()
+        nodes.push(
+          <code
+            key={`c-${key++}`}
+            className="rounded bg-surface-800/80 border border-white/5 px-1 py-px font-mono text-[12px] text-surface-100"
+          >
+            {text.slice(i + 1, end)}
+          </code>,
+        )
+        i = end + 1
+        continue
+      }
+    }
+
+    if (text.startsWith('**', i)) {
+      const end = text.indexOf('**', i + 2)
+      if (end > i + 1) {
+        flushPlain()
+        nodes.push(
+          <strong key={`b-${key++}`} className="font-semibold text-white">
+            {text.slice(i + 2, end)}
+          </strong>,
+        )
+        i = end + 2
+        continue
+      }
+    }
+
+    if (ch === '*' && text[i + 1] !== ' ') {
+      const end = text.indexOf('*', i + 1)
+      if (end > i) {
+        flushPlain()
+        nodes.push(
+          <em key={`i-${key++}`} className="italic">
+            {text.slice(i + 1, end)}
+          </em>,
+        )
+        i = end + 1
+        continue
+      }
+    }
+
+    if (ch === '[') {
+      const close = text.indexOf(']', i + 1)
+      if (close > i && text[close + 1] === '(') {
+        const urlEnd = text.indexOf(')', close + 2)
+        if (urlEnd > close + 1) {
+          flushPlain()
+          const linkText = text.slice(i + 1, close)
+          const url = text.slice(close + 2, urlEnd)
+          nodes.push(
+            <a
+              key={`a-${key++}`}
+              href={url}
+              target={url.startsWith('http') ? '_blank' : undefined}
+              rel={url.startsWith('http') ? 'noopener noreferrer' : undefined}
+              className="text-amber-300 underline-offset-2 hover:underline"
+            >
+              {linkText}
+            </a>,
+          )
+          i = urlEnd + 1
+          continue
+        }
+      }
+    }
+
+    plain += ch
+    i++
+  }
+
+  flushPlain()
+  return (
+    <Fragment>
+      {nodes.map((n, idx) => (
+        <Fragment key={idx}>{n}</Fragment>
+      ))}
+    </Fragment>
+  )
+}

--- a/frontend/src/components/palette/Palette.tsx
+++ b/frontend/src/components/palette/Palette.tsx
@@ -8,19 +8,29 @@ import {
   useRef,
   useState,
 } from 'react'
-import { useRouter } from 'next/navigation'
-import { Search, Loader2, X } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Search, Loader2, X, ChevronDown, ChevronUp, Clock } from 'lucide-react'
 
-import { AXIS_LABEL, axisValueLabel } from './labels'
-import { resolveFlowHandoff } from './runDispatch'
-import { usePaletteQuery } from './usePaletteQuery'
-import { PaletteResultRow } from './PaletteResultRow'
+import { AXIS_LABEL, axisValueLabel } from '@/components/palette/labels'
+import {
+  aliasSearchTarget,
+  buildPalettePathname,
+  parsePaletteUrlState,
+} from '@/components/palette/paletteUrlState'
+import { resolveFlowHandoff } from '@/components/palette/runDispatch'
+import {
+  usePaletteQuery,
+  usePlatformShortcutLabel,
+  useRecentSearches,
+} from '@/components/palette/usePaletteQuery'
+import { PaletteResultRow } from '@/components/palette/PaletteResultRow'
 import type {
   PaletteFilter,
   PaletteRefinementChip,
+  PaletteResolvedAlias,
   PaletteResult,
   PaletteScope,
-} from './types'
+} from '@/components/palette/types'
 
 const HOMEPAGE_PLACEHOLDERS = [
   'Show me an OAuth flow',
@@ -62,16 +72,50 @@ interface PaletteProps {
  */
 export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLUListElement>(null)
   const headingId = useId()
   const listboxId = useId()
 
-  const [q, setQ] = useState('')
-  const [scope, setScope] = useState<PaletteScope | undefined>(undefined)
-  const [filters, setFilters] = useState<PaletteFilter[]>([])
+  // URL persistence is enabled for the homepage variant only.
+  const urlPersist = variant === 'homepage'
+
+  // Hydrate initial state from URL once on mount.
+  const initial = useMemo(() => {
+    if (!urlPersist || !searchParams) return null
+    return parsePaletteUrlState(searchParams)
+    // We intentionally only compute this once on mount; subsequent URL updates are driven by state changes
+  }, [])
+
+  const [q, setQ] = useState(() => initial?.q ?? '')
+  const [scope, setScope] = useState<PaletteScope | undefined>(
+    () => initial?.scope,
+  )
+  const [filters, setFilters] = useState<PaletteFilter[]>(
+    () => initial?.filters ?? [],
+  )
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [placeholderIndex, setPlaceholderIndex] = useState(0)
+  const [statusMessage, setStatusMessage] = useState('')
+  // Results-list visibility cap. Default 5 keeps the surface short
+  const DEFAULT_VISIBLE = 5
+  const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE)
+
+  const shortcutLabel = usePlatformShortcutLabel()
+
+  // localStorage-backed recent searches. Only used in the empty state.
+  const { recent: recentSearches, push: pushRecent, clear: clearRecent } =
+    useRecentSearches()
+
+  const resetPalette = useCallback(() => {
+    setQ('')
+    setScope(undefined)
+    setFilters([])
+    setSelectedIndex(0)
+    setVisibleCount(DEFAULT_VISIBLE)
+    inputRef.current?.focus()
+  }, [])
 
   const placeholderPool = variant === 'homepage' ? HOMEPAGE_PLACEHOLDERS : CMDK_PLACEHOLDERS
 
@@ -79,6 +123,17 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
     if (!autoFocus) return
     inputRef.current?.focus()
   }, [autoFocus])
+
+  // Homepage: cmd+K / Ctrl+K focuses the prominent input instead of opening modal
+  useEffect(() => {
+    if (variant !== 'homepage') return
+    function onFocusHome() {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+    window.addEventListener('palette:focus-home', onFocusHome)
+    return () => window.removeEventListener('palette:focus-home', onFocusHome)
+  }, [variant])
 
   // Cycle the placeholder. Stops cycling as soon as the user types.
   useEffect(() => {
@@ -99,10 +154,56 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
   const results = useMemo(() => data?.results ?? [], [data])
   const refinement = useMemo(() => data?.refinement_chips ?? [], [data])
   const resolved = useMemo(() => data?.resolved_aliases ?? [], [data])
+  const isEmptyQuery = q.trim().length === 0 && filters.length === 0
 
   useEffect(() => {
     setSelectedIndex(0)
+    setVisibleCount(DEFAULT_VISIBLE)
   }, [q, scope, filters])
+
+  useEffect(() => {
+    if (!urlPersist) return
+    if (typeof window === 'undefined') return
+    const next = buildPalettePathname(window.location.pathname, { q, scope, filters })
+    if (next === window.location.pathname + window.location.search) return
+    router.replace(next, { scroll: false })
+  }, [urlPersist, q, scope, filters, router])
+
+  const resultCount = data?.results.length ?? 0
+  useEffect(() => {
+    const trimmed = q.trim()
+    if (trimmed.length < 2) return
+    if (loading) return
+    if (resultCount === 0) return
+    const handle = window.setTimeout(() => {
+      pushRecent(trimmed)
+    }, 1500)
+    return () => window.clearTimeout(handle)
+  }, [q, resultCount, loading, pushRecent])
+
+  // Screen-reader status: announce result counts once a query settles.
+  useEffect(() => {
+    if (isEmptyQuery) {
+      setStatusMessage('')
+      return
+    }
+    if (loading) {
+      setStatusMessage('Searching…')
+      return
+    }
+    if (error) {
+      setStatusMessage(error)
+      return
+    }
+    if (!data) return
+    if (resultCount === 0) {
+      setStatusMessage('No results found.')
+      return
+    }
+    setStatusMessage(
+      `${resultCount} result${resultCount === 1 ? '' : 's'} found.`,
+    )
+  }, [isEmptyQuery, loading, error, data, resultCount])
 
   const activeResult: PaletteResult | undefined = results[selectedIndex]
 
@@ -158,7 +259,13 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
-        setSelectedIndex((i) => Math.min(i + 1, Math.max(results.length - 1, 0)))
+        setSelectedIndex((i) => {
+          const next = Math.min(i + 1, Math.max(results.length - 1, 0))
+          // Power users: arrow past the visible cap auto-expands the list
+          // so the highlighted row is always rendered and scrollable.
+          if (next >= visibleCount) setVisibleCount(results.length)
+          return next
+        })
         return
       }
       if (event.key === 'ArrowUp') {
@@ -184,11 +291,14 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
         if (variant === 'cmdk') {
           event.preventDefault()
           onClose?.()
+        } else if (!isEmptyQuery) {
+          event.preventDefault()
+          resetPalette()
         }
         return
       }
     },
-    [activate, activeResult, applyFirstRefinement, onClose, refinement.length, results.length, variant],
+    [activate, activeResult, applyFirstRefinement, isEmptyQuery, onClose, refinement.length, resetPalette, results.length, variant, visibleCount],
   )
 
   useEffect(() => {
@@ -206,17 +316,50 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
     inputRef.current?.focus()
   }, [])
 
-  const isEmptyQuery = q.trim().length === 0 && filters.length === 0
+  const applyAliasSuggestion = useCallback((alias: PaletteResolvedAlias) => {
+    const target = aliasSearchTarget(alias)
+    if (!target) return
+    setQ(target)
+    setFilters([])
+    setSelectedIndex(0)
+    inputRef.current?.focus()
+  }, [])
 
-  return (
-    <div className={variant === 'homepage' ? 'w-full' : 'w-full max-w-2xl'} role="search" aria-labelledby={headingId}>
-      <h2 id={headingId} className="sr-only">Palette search</h2>
+  const listExpanded = !isEmptyQuery && (loading || results.length > 0 || Boolean(data))
 
+  const showResolvedHint = !isEmptyQuery && results.length > 0 && resolved.length > 0
+  const showZeroResultAliases =
+    !isEmptyQuery && !loading && results.length === 0 && !error && data && resolved.length > 0
+
+  const inputTrailing = loading ? (
+    <Loader2 className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-surface-500" />
+  ) : q.length > 0 ? (
+    <button
+      type="button"
+      onClick={resetPalette}
+      aria-label="Clear search"
+      title="Clear search"
+      className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1.5 text-surface-500 hover:text-surface-200 hover:bg-white/10 focus:outline-none focus:ring-1 focus:ring-amber-400/40 transition-colors"
+    >
+      <X className="h-3.5 w-3.5" />
+    </button>
+  ) : variant === 'homepage' && shortcutLabel ? (
+    <kbd
+      aria-hidden="true"
+      className="pointer-events-none absolute right-3 top-1/2 hidden -translate-y-1/2 rounded border border-white/10 bg-surface-800/60 px-1.5 py-0.5 font-mono text-[10px] text-surface-400 sm:inline-flex"
+    >
+      {shortcutLabel}
+    </kbd>
+  ) : null
+
+  const controls = (
+    <>
       <div className="relative">
         <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500" />
         <input
           ref={inputRef}
           type="text"
+          role="combobox"
           value={q}
           onChange={(e) => setQ(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -224,36 +367,60 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
           autoComplete="off"
           spellCheck={false}
           aria-autocomplete="list"
+          aria-expanded={listExpanded}
+          aria-haspopup="listbox"
           aria-controls={listboxId}
           aria-activedescendant={
             activeResult ? `${listboxId}-${activeResult.id}` : undefined
           }
-          className={`w-full rounded-lg border border-white/10 bg-surface-900/60 pl-9 pr-3 text-white placeholder-surface-500 focus:outline-none focus:border-amber-400/60 focus:ring-1 focus:ring-amber-400/30 transition ${
+          className={`w-full rounded-lg border border-white/10 bg-surface-900/60 pl-9 text-white placeholder-surface-500 focus:outline-none focus:border-amber-400/60 focus:ring-1 focus:ring-amber-400/30 transition ${
+            q.length > 0 || (variant === 'homepage' && shortcutLabel)
+              ? 'pr-9'
+              : 'pr-3'
+          } ${
             variant === 'homepage'
-              ? 'py-3.5 text-base sm:py-4 sm:text-lg'
+              ? 'py-2.5 text-sm sm:py-4 sm:text-lg'
               : 'py-2.5 text-sm sm:text-base'
           }`}
         />
-        {loading && (
-          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-surface-500" />
-        )}
+        {inputTrailing}
       </div>
 
+      {!isEmptyQuery && (
+        <ScopeRail scope={scope} onChange={setScope} />
+      )}
+
       {filters.length > 0 && (
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          <span className="text-[11px] text-surface-500">Filters:</span>
-          {filters.map((f) => (
-            <button
-              key={`${f.axis}-${f.value}`}
-              type="button"
-              onClick={() => removeFilter(f)}
-              className="inline-flex items-center gap-1 rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-0.5 text-[11px] text-amber-200 hover:bg-amber-400/20 transition-colors"
-            >
-              <span className="text-amber-300/80">{AXIS_LABEL[f.axis]}:</span>
-              <span>{axisValueLabel(f.value)}</span>
-              <X className="h-3 w-3" />
-            </button>
-          ))}
+        <div className="mt-2 max-w-full overflow-hidden">
+          <div className="overflow-x-auto overscroll-x-contain pb-0.5 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:overflow-visible">
+            <div className="flex w-max min-w-full flex-nowrap items-center gap-1.5 sm:w-auto sm:flex-wrap">
+            <span className="shrink-0 text-[11px] text-surface-500">Filters:</span>
+            {filters.map((f) => (
+              <button
+                key={`${f.axis}-${f.value}`}
+                type="button"
+                onClick={() => removeFilter(f)}
+                className="inline-flex shrink-0 min-h-9 items-center gap-1 rounded-full border border-amber-400/40 bg-amber-400/10 px-2.5 py-1.5 text-[11px] text-amber-200 hover:bg-amber-400/20 transition-colors sm:min-h-0 sm:px-2 sm:py-0.5"
+              >
+                <span className="text-amber-300/80">{AXIS_LABEL[f.axis]}:</span>
+                <span>{axisValueLabel(f.value)}</span>
+                <X className="h-3 w-3" />
+              </button>
+            ))}
+            {filters.length >= 2 && (
+              <button
+                type="button"
+                onClick={() => setFilters([])}
+                className="inline-flex shrink-0 min-h-9 items-center gap-1 rounded-full border border-white/10 bg-surface-800/60 px-2.5 py-1.5 text-[11px] text-surface-400 hover:border-amber-400/40 hover:text-amber-200 transition-colors sm:min-h-0 sm:px-2 sm:py-0.5"
+                aria-label="Clear all filters"
+                title="Clear all filters"
+              >
+                Clear all
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            </div>
+          </div>
         </div>
       )}
 
@@ -265,30 +432,47 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
         />
       )}
 
-      {!isEmptyQuery && resolved.length > 0 && (
-        <p className="mt-2 text-[11px] text-surface-500">
+      {showResolvedHint && (
+        <p className="mt-2 hidden text-[11px] text-surface-500 sm:block">
           Resolved: {resolved.map((r) => `"${r.matched_token}" → ${r.value || r.artefact}`).join('; ')}
         </p>
       )}
 
-      <div className="mt-3" aria-live="polite">
-        {error && (
-          <p className="text-xs text-amber-300">
-            {error}
-          </p>
-        )}
+      {showZeroResultAliases && (
+        <ZeroResultAliases resolved={resolved} onApply={applyAliasSuggestion} />
+      )}
+    </>
+  )
 
-        {!isEmptyQuery && !loading && results.length === 0 && !error && data && (
-          <p className="text-xs text-surface-400">
-            No results. Try removing a filter or broadening the query.
-          </p>
-        )}
+  const resultsPanel = (
+    <>
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {statusMessage}
+      </p>
 
-        {isEmptyQuery && (
-          <EmptyState variant={variant} onPick={setEntryChip} />
-        )}
+      {error && (
+        <p className="text-xs text-amber-300" role="alert">
+          {error}
+        </p>
+      )}
 
-        {results.length > 0 && (
+      {!isEmptyQuery && !loading && results.length === 0 && !error && data && !showZeroResultAliases && (
+        <p className="text-xs text-surface-400">
+          No results. Try removing a filter or broadening the query.
+        </p>
+      )}
+
+      {isEmptyQuery && (
+        <EmptyState
+          variant={variant}
+          onPick={setEntryChip}
+          recent={recentSearches}
+          onClearRecent={clearRecent}
+        />
+      )}
+
+      {results.length > 0 && (
+        <>
           <ul
             ref={listRef}
             id={listboxId}
@@ -296,30 +480,85 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
             aria-label="Palette results"
             className="mt-2 space-y-1.5"
           >
-            {results.map((result, idx) => (
-              <div key={result.id} data-index={idx} id={`${listboxId}-${result.id}`}>
-                <PaletteResultRow
-                  result={result}
-                  selected={idx === selectedIndex}
-                  onSelect={() => setSelectedIndex(idx)}
-                  onActivate={() => activate(result)}
-                  onRelatedConceptClick={goToConcept}
-                />
-              </div>
+            {results.slice(0, visibleCount).map((result, idx) => (
+              <PaletteResultRow
+                key={result.id}
+                id={`${listboxId}-${result.id}`}
+                dataIndex={idx}
+                result={result}
+                selected={idx === selectedIndex}
+                onSelect={() => setSelectedIndex(idx)}
+                onActivate={() => activate(result)}
+                onRelatedConceptClick={goToConcept}
+              />
             ))}
           </ul>
-        )}
 
-        {data && results.length > 0 && (
-          <p className="mt-2 text-[10px] text-surface-600">
-            {data.results.length} of {data.total_candidates} candidate
-            {data.total_candidates === 1 ? '' : 's'} — {(data.elapsed_micros / 1000).toFixed(1)} ms server time
-          </p>
-        )}
-      </div>
+          {results.length > DEFAULT_VISIBLE && (
+            <button
+              type="button"
+              onClick={() =>
+                setVisibleCount((v) => (v >= results.length ? DEFAULT_VISIBLE : results.length))
+              }
+              className="mt-2 inline-flex min-h-10 w-full items-center justify-center gap-1.5 rounded-md border border-white/10 bg-surface-900/40 px-3 py-2 text-xs text-surface-300 hover:border-amber-400/40 hover:text-amber-200 transition-colors sm:min-h-0 sm:py-1.5"
+              aria-expanded={visibleCount >= results.length}
+              aria-controls={listboxId}
+            >
+              {visibleCount >= results.length ? (
+                <>
+                  <ChevronUp className="h-3.5 w-3.5" />
+                  Show top {DEFAULT_VISIBLE}
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-3.5 w-3.5" />
+                  Show all {results.length} results
+                </>
+              )}
+            </button>
+          )}
+        </>
+      )}
 
-      {!isEmptyQuery && results.length > 0 && (
-        <ScopeRail scope={scope} onChange={setScope} />
+      {data && results.length > 0 && (
+        <p className="mt-2 text-[10px] text-surface-600" aria-hidden="true">
+          Showing {Math.min(visibleCount, results.length)} of {results.length} ranked result
+          {results.length === 1 ? '' : 's'}
+          <span className="hidden sm:inline">
+            {' '}({data.total_candidates} candidate
+            {data.total_candidates === 1 ? '' : 's'} scored in {(data.elapsed_micros / 1000).toFixed(1)} ms)
+          </span>
+        </p>
+      )}
+    </>
+  )
+
+  const shellClass =
+    variant === 'homepage'
+      ? 'w-full'
+      : 'flex min-h-0 w-full max-w-2xl flex-1 flex-col'
+
+  return (
+    <div className={shellClass} role="search" aria-labelledby={headingId}>
+      <h2 id={headingId} className="sr-only">Palette search</h2>
+
+      {variant === 'cmdk' ? (
+        <>
+          <div className="shrink-0">{controls}</div>
+          <div
+            className="mt-3 min-h-0 flex-1 overflow-y-auto"
+            aria-busy={loading}
+          >
+            {resultsPanel}
+          </div>
+        </>
+      ) : (
+        <>
+          {controls}
+          <div className="mt-3" aria-busy={loading}>
+            {resultsPanel}
+          </div>
+        </>
       )}
     </div>
   )
@@ -335,29 +574,56 @@ function RefinementChipBar({
   existingFilters: PaletteFilter[]
   onApply: (chip: PaletteRefinementChip) => void
 }) {
+  const [open, setOpen] = useState(false)
+
+  const chipButtons = chips.slice(0, 6).map((chip) => {
+    const already = existingFilters.some(
+      (f) => f.axis === chip.axis && f.value === chip.value,
+    )
+    return (
+      <button
+        key={`${chip.axis}-${chip.value}`}
+        type="button"
+        onClick={() => !already && onApply(chip)}
+        disabled={already}
+        className="inline-flex shrink-0 min-h-9 items-center gap-1 rounded-full border border-white/15 bg-surface-800/60 px-2.5 py-1.5 text-[11px] text-surface-200 hover:border-amber-400/40 hover:bg-amber-400/5 disabled:opacity-40 disabled:cursor-not-allowed transition-colors sm:min-h-0 sm:px-2 sm:py-0.5"
+      >
+        <span className="text-surface-500">{AXIS_LABEL[chip.axis]}:</span>
+        <span>{axisValueLabel(chip.value)}</span>
+        <span className="text-surface-500">·</span>
+        <span className="text-surface-500">{chip.count}</span>
+      </button>
+    )
+  })
+
   return (
-    <div className="mt-2 flex flex-wrap items-center gap-1.5">
-      <span className="text-[11px] text-surface-500">Narrow by:</span>
-      {chips.slice(0, 6).map((chip) => {
-        const already = existingFilters.some(
-          (f) => f.axis === chip.axis && f.value === chip.value,
-        )
-        return (
-          <button
-            key={`${chip.axis}-${chip.value}`}
-            type="button"
-            onClick={() => !already && onApply(chip)}
-            disabled={already}
-            className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-surface-800/60 px-2 py-0.5 text-[11px] text-surface-200 hover:border-amber-400/40 hover:bg-amber-400/5 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            <span className="text-surface-500">{AXIS_LABEL[chip.axis]}:</span>
-            <span>{axisValueLabel(chip.value)}</span>
-            <span className="text-surface-500">·</span>
-            <span className="text-surface-500">{chip.count}</span>
-          </button>
-        )
-      })}
-    </div>
+    <>
+      {/* Mobile: collapsed by default so results stay above the fold. */}
+      <div className="mt-2 sm:hidden">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="inline-flex min-h-9 w-full items-center justify-between gap-2 rounded-md border border-white/10 bg-surface-900/40 px-3 py-2 text-xs text-surface-300 hover:border-amber-400/40 hover:text-amber-200 transition-colors"
+        >
+          <span>Narrow by ({chips.length})</span>
+          <ChevronDown className={`h-3.5 w-3.5 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
+        </button>
+        {open && (
+          <div className="mt-1.5 max-w-full overflow-hidden">
+            <div className="overflow-x-auto overscroll-x-contain pb-0.5 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+              <div className="flex w-max gap-1.5">{chipButtons}</div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Desktop: always visible, wraps naturally. */}
+      <div className="mt-2 hidden flex-wrap items-center gap-1.5 sm:flex">
+        <span className="text-[11px] text-surface-500">Narrow by:</span>
+        {chipButtons}
+      </div>
+    </>
   )
 }
 
@@ -374,13 +640,12 @@ function ScopeRail({
     { id: 'concept', label: 'Concepts' },
     { id: 'spec', label: 'Spec' },
   ]
-  return (
-    <div className="mt-3 flex flex-wrap items-center gap-1.5">
-      <span className="text-[11px] text-surface-500">Filter to:</span>
+  const scopeButtons = (
+    <>
       <button
         type="button"
         onClick={() => onChange(undefined)}
-        className={`rounded-full border px-2 py-0.5 text-[11px] transition-colors ${
+        className={`shrink-0 min-h-9 rounded-full border px-2.5 py-1.5 text-[11px] transition-colors sm:min-h-0 sm:px-2 sm:py-0.5 ${
           scope === undefined
             ? 'border-amber-400/50 bg-amber-400/10 text-amber-200'
             : 'border-white/10 bg-surface-800/60 text-surface-300 hover:border-white/20'
@@ -393,7 +658,7 @@ function ScopeRail({
           key={s.id}
           type="button"
           onClick={() => onChange(s.id === scope ? undefined : s.id)}
-          className={`rounded-full border px-2 py-0.5 text-[11px] transition-colors ${
+          className={`shrink-0 min-h-9 rounded-full border px-2.5 py-1.5 text-[11px] transition-colors sm:min-h-0 sm:px-2 sm:py-0.5 ${
             scope === s.id
               ? 'border-amber-400/50 bg-amber-400/10 text-amber-200'
               : 'border-white/10 bg-surface-800/60 text-surface-300 hover:border-white/20'
@@ -402,6 +667,49 @@ function ScopeRail({
           {s.label}
         </button>
       ))}
+    </>
+  )
+
+  return (
+    <div className="mt-2 max-w-full overflow-hidden">
+      <div className="overflow-x-auto overscroll-x-contain pb-0.5 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:overflow-visible">
+        <div className="flex w-max min-w-full flex-nowrap items-center gap-1.5 sm:w-auto sm:flex-wrap">
+          <span className="shrink-0 text-[11px] text-surface-500">Show:</span>
+          {scopeButtons}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ZeroResultAliases({
+  resolved,
+  onApply,
+}: {
+  resolved: PaletteResolvedAlias[]
+  onApply: (alias: PaletteResolvedAlias) => void
+}) {
+  const suggestions = resolved
+    .map((alias) => ({ alias, target: aliasSearchTarget(alias) }))
+    .filter((entry): entry is { alias: PaletteResolvedAlias; target: string } => entry.target !== null)
+
+  if (suggestions.length === 0) return null
+
+  return (
+    <div className="mt-2">
+      <p className="text-xs text-surface-400">No exact matches.</p>
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
+        {suggestions.map(({ alias, target }) => (
+          <button
+            key={`${alias.matched_token}-${target}`}
+            type="button"
+            onClick={() => onApply(alias)}
+            className="inline-flex min-h-9 items-center rounded-full border border-amber-400/30 bg-amber-400/5 px-3 py-1.5 text-[12px] text-amber-200 hover:border-amber-400/50 hover:bg-amber-400/10 transition-colors sm:min-h-0 sm:px-2.5 sm:py-1"
+          >
+            Did you mean &ldquo;{target}&rdquo;?
+          </button>
+        ))}
+      </div>
     </div>
   )
 }
@@ -409,27 +717,80 @@ function ScopeRail({
 function EmptyState({
   variant,
   onPick,
+  recent,
+  onClearRecent,
 }: {
   variant: 'homepage' | 'cmdk'
   onPick: (q: string) => void
+  recent: string[]
+  onClearRecent: () => void
 }) {
+  const chipClass =
+    'inline-flex max-w-[14rem] shrink-0 items-center truncate rounded-full border border-white/10 bg-surface-800/60 px-2.5 py-1 text-[11px] text-surface-200 hover:border-amber-400/40 hover:bg-amber-400/5 transition-colors sm:max-w-none sm:px-3 sm:py-1.5 sm:text-[12px]'
+  const recentChipClass =
+    'inline-flex max-w-[12rem] shrink-0 items-center gap-1 truncate rounded-full border border-amber-400/25 bg-amber-400/5 px-2.5 py-1 text-[11px] text-amber-100 hover:border-amber-400/40 hover:bg-amber-400/10 transition-colors sm:max-w-none sm:px-3 sm:py-1.5 sm:text-[12px]'
+
+  const starterLabel =
+    variant === 'homepage'
+      ? recent.length > 0
+        ? 'Try'
+        : 'Try:'
+      : recent.length > 0
+        ? 'Curated'
+        : 'Curated entry points'
+
   return (
-    <div className="mt-2">
-      <p className="text-[11px] text-surface-500 mb-1.5">
-        {variant === 'homepage' ? "Don't know where to start?" : 'Curated entry points'}
-      </p>
-      <div className="flex flex-wrap gap-1.5">
-        {ENTRY_CHIPS.map((chip) => (
-          <button
-            key={chip.label}
-            type="button"
-            onClick={() => onPick(chip.q)}
-            className="rounded-full border border-white/10 bg-surface-800/60 px-2.5 py-1 text-[12px] text-surface-200 hover:border-amber-400/40 hover:bg-amber-400/5 transition-colors"
-          >
-            {chip.label}
-          </button>
-        ))}
+    <div className="mt-1.5 max-w-full overflow-hidden sm:mt-2">
+      <div className="overflow-x-auto overscroll-x-contain [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:overflow-visible">
+        <div className="flex w-max max-w-full items-center gap-1.5 sm:w-auto sm:flex-wrap">
+          {recent.map((entry) => (
+            <button
+              key={entry}
+              type="button"
+              onClick={() => onPick(entry)}
+              className={recentChipClass}
+              title={entry}
+            >
+              <Clock className="h-3 w-3 shrink-0 text-amber-300/70" aria-hidden="true" />
+              <span className="truncate">{entry}</span>
+            </button>
+          ))}
+
+          {recent.length > 0 && (
+            <span
+              className="h-4 w-px shrink-0 bg-white/10 sm:hidden"
+              aria-hidden="true"
+            />
+          )}
+
+          <span className="shrink-0 text-[10px] text-surface-500 sm:text-[11px]">
+            {starterLabel}
+          </span>
+
+          {ENTRY_CHIPS.map((chip) => (
+            <button
+              key={chip.label}
+              type="button"
+              onClick={() => onPick(chip.q)}
+              className={chipClass}
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
       </div>
+
+      {recent.length > 0 && (
+        <button
+          type="button"
+          onClick={onClearRecent}
+          className="mt-1 text-[10px] text-surface-600 hover:text-surface-400 transition-colors sm:text-[11px]"
+          aria-label="Clear recent searches"
+        >
+          Clear recent
+        </button>
+      )}
+
       {variant === 'cmdk' && (
         <p className="mt-3 text-[11px] text-surface-500">
           Tip: prefix a query with{' '}

--- a/frontend/src/components/palette/Palette.tsx
+++ b/frontend/src/components/palette/Palette.tsx
@@ -81,20 +81,19 @@ export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
   // URL persistence is enabled for the homepage variant only.
   const urlPersist = variant === 'homepage'
 
-  // Hydrate initial state from URL once on mount.
-  const initial = useMemo(() => {
-    if (!urlPersist || !searchParams) return null
-    return parsePaletteUrlState(searchParams)
-    // We intentionally only compute this once on mount; subsequent URL updates are driven by state changes
-  }, [])
-
-  const [q, setQ] = useState(() => initial?.q ?? '')
-  const [scope, setScope] = useState<PaletteScope | undefined>(
-    () => initial?.scope,
-  )
-  const [filters, setFilters] = useState<PaletteFilter[]>(
-    () => initial?.filters ?? [],
-  )
+  // Hydrate initial state from URL once on mount (lazy useState initializers).
+  const [q, setQ] = useState(() => {
+    if (!urlPersist || !searchParams) return ''
+    return parsePaletteUrlState(searchParams).q
+  })
+  const [scope, setScope] = useState<PaletteScope | undefined>(() => {
+    if (!urlPersist || !searchParams) return undefined
+    return parsePaletteUrlState(searchParams).scope
+  })
+  const [filters, setFilters] = useState<PaletteFilter[]>(() => {
+    if (!urlPersist || !searchParams) return []
+    return parsePaletteUrlState(searchParams).filters
+  })
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [placeholderIndex, setPlaceholderIndex] = useState(0)
   const [statusMessage, setStatusMessage] = useState('')

--- a/frontend/src/components/palette/Palette.tsx
+++ b/frontend/src/components/palette/Palette.tsx
@@ -1,0 +1,444 @@
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { useRouter } from 'next/navigation'
+import { Search, Loader2, X } from 'lucide-react'
+
+import { AXIS_LABEL, axisValueLabel } from './labels'
+import { resolveFlowHandoff } from './runDispatch'
+import { usePaletteQuery } from './usePaletteQuery'
+import { PaletteResultRow } from './PaletteResultRow'
+import type {
+  PaletteFilter,
+  PaletteRefinementChip,
+  PaletteResult,
+  PaletteScope,
+} from './types'
+
+const HOMEPAGE_PLACEHOLDERS = [
+  'Show me an OAuth flow',
+  'What does PKCE require',
+  'Federating with another IdP',
+  'Let users sign in to my app',
+  'Mobile app needs to call our API',
+  'Issuing verifiable credentials',
+]
+
+const CMDK_PLACEHOLDERS = [
+  'Type a protocol, concept, or use case',
+  'Search "PKCE"',
+  'Try "step-up authentication"',
+]
+
+const ENTRY_CHIPS: { label: string; q: string }[] = [
+  { label: "I'm building a mobile app", q: 'mobile app' },
+  { label: 'Federating with another IdP', q: 'federation' },
+  { label: 'Issuing verifiable credentials', q: 'credential issuance' },
+  { label: 'Just exploring', q: '' },
+]
+
+interface PaletteProps {
+  variant: 'homepage' | 'cmdk'
+  onClose?: () => void
+  autoFocus?: boolean
+}
+
+/**
+ * Palette renders the shared multi-axis content retrieval surface used on
+ * the homepage and inside the global cmd+K portal.
+ *
+ * The component is fully keyboard-operable:
+ * - ArrowUp / ArrowDown navigate result rows.
+ * - Enter opens the row (or dispatches a runnable flow into Looking Glass).
+ * - Tab applies the first refinement chip as an additional filter.
+ * - Esc closes the cmd+K variant (no-op for the homepage variant).
+ */
+export function Palette({ variant, onClose, autoFocus }: PaletteProps) {
+  const router = useRouter()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+  const headingId = useId()
+  const listboxId = useId()
+
+  const [q, setQ] = useState('')
+  const [scope, setScope] = useState<PaletteScope | undefined>(undefined)
+  const [filters, setFilters] = useState<PaletteFilter[]>([])
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [placeholderIndex, setPlaceholderIndex] = useState(0)
+
+  const placeholderPool = variant === 'homepage' ? HOMEPAGE_PLACEHOLDERS : CMDK_PLACEHOLDERS
+
+  useEffect(() => {
+    if (!autoFocus) return
+    inputRef.current?.focus()
+  }, [autoFocus])
+
+  // Cycle the placeholder. Stops cycling as soon as the user types.
+  useEffect(() => {
+    if (q.length > 0) return
+    const handle = window.setInterval(() => {
+      setPlaceholderIndex((i) => (i + 1) % placeholderPool.length)
+    }, 3200)
+    return () => window.clearInterval(handle)
+  }, [q.length, placeholderPool.length])
+
+  const { data, loading, error } = usePaletteQuery({
+    q,
+    scope,
+    filters,
+    enabled: q.trim().length > 0 || filters.length > 0,
+  })
+
+  const results = useMemo(() => data?.results ?? [], [data])
+  const refinement = useMemo(() => data?.refinement_chips ?? [], [data])
+  const resolved = useMemo(() => data?.resolved_aliases ?? [], [data])
+
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [q, scope, filters])
+
+  const activeResult: PaletteResult | undefined = results[selectedIndex]
+
+  const activate = useCallback(
+    (result: PaletteResult) => {
+      const handoff = resolveFlowHandoff(result)
+      if (handoff) {
+        router.push(handoff.lookingGlassPath)
+        onClose?.()
+        return
+      }
+      // Inline-only artefact types (concept, walkthrough, spec-assertion)
+      // have no canonical page; the backend marks them by leaving `href`
+      // empty (see palette.Artefact.DefaultHref). Activating them just
+      // confirms inline expansion — never `router.push('')`, which would
+      // silently send the user back to the homepage.
+      if (!result.href) {
+        return
+      }
+      router.push(result.href)
+      onClose?.()
+    },
+    [router, onClose],
+  )
+
+  // Called when a user clicks a related-concept chip inside an expanded
+  // result row. Re-queries the palette with the concept's ID so the chip
+  // navigates *within the palette* instead of trying to open a
+  // /concept/{id} page that does not exist.
+  const goToConcept = useCallback((conceptId: string) => {
+    setQ(conceptId)
+    setFilters([])
+    setSelectedIndex(0)
+    inputRef.current?.focus()
+  }, [])
+
+  const applyRefinement = useCallback((chip: PaletteRefinementChip) => {
+    setFilters((prev) => {
+      if (prev.some((f) => f.axis === chip.axis && f.value === chip.value)) {
+        return prev
+      }
+      return [...prev, { axis: chip.axis, value: chip.value }]
+    })
+  }, [])
+
+  const applyFirstRefinement = useCallback(() => {
+    const chip = refinement[0]
+    if (!chip) return
+    applyRefinement(chip)
+  }, [refinement, applyRefinement])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setSelectedIndex((i) => Math.min(i + 1, Math.max(results.length - 1, 0)))
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setSelectedIndex((i) => Math.max(i - 1, 0))
+        return
+      }
+      if (event.key === 'Enter') {
+        if (activeResult) {
+          event.preventDefault()
+          activate(activeResult)
+        }
+        return
+      }
+      if (event.key === 'Tab' && !event.shiftKey) {
+        if (refinement.length > 0) {
+          event.preventDefault()
+          applyFirstRefinement()
+        }
+        return
+      }
+      if (event.key === 'Escape') {
+        if (variant === 'cmdk') {
+          event.preventDefault()
+          onClose?.()
+        }
+        return
+      }
+    },
+    [activate, activeResult, applyFirstRefinement, onClose, refinement.length, results.length, variant],
+  )
+
+  useEffect(() => {
+    const li = listRef.current?.querySelector<HTMLLIElement>(`[data-index="${selectedIndex}"]`)
+    if (!li) return
+    li.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const removeFilter = useCallback((target: PaletteFilter) => {
+    setFilters((prev) => prev.filter((f) => !(f.axis === target.axis && f.value === target.value)))
+  }, [])
+
+  const setEntryChip = useCallback((chipQ: string) => {
+    setQ(chipQ)
+    inputRef.current?.focus()
+  }, [])
+
+  const isEmptyQuery = q.trim().length === 0 && filters.length === 0
+
+  return (
+    <div className={variant === 'homepage' ? 'w-full' : 'w-full max-w-2xl'} role="search" aria-labelledby={headingId}>
+      <h2 id={headingId} className="sr-only">Palette search</h2>
+
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholderPool[placeholderIndex]}
+          autoComplete="off"
+          spellCheck={false}
+          aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-activedescendant={
+            activeResult ? `${listboxId}-${activeResult.id}` : undefined
+          }
+          className={`w-full rounded-lg border border-white/10 bg-surface-900/60 pl-9 pr-3 text-white placeholder-surface-500 focus:outline-none focus:border-amber-400/60 focus:ring-1 focus:ring-amber-400/30 transition ${
+            variant === 'homepage'
+              ? 'py-3.5 text-base sm:py-4 sm:text-lg'
+              : 'py-2.5 text-sm sm:text-base'
+          }`}
+        />
+        {loading && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-surface-500" />
+        )}
+      </div>
+
+      {filters.length > 0 && (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <span className="text-[11px] text-surface-500">Filters:</span>
+          {filters.map((f) => (
+            <button
+              key={`${f.axis}-${f.value}`}
+              type="button"
+              onClick={() => removeFilter(f)}
+              className="inline-flex items-center gap-1 rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-0.5 text-[11px] text-amber-200 hover:bg-amber-400/20 transition-colors"
+            >
+              <span className="text-amber-300/80">{AXIS_LABEL[f.axis]}:</span>
+              <span>{axisValueLabel(f.value)}</span>
+              <X className="h-3 w-3" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {!isEmptyQuery && refinement.length > 0 && (
+        <RefinementChipBar
+          chips={refinement}
+          existingFilters={filters}
+          onApply={applyRefinement}
+        />
+      )}
+
+      {!isEmptyQuery && resolved.length > 0 && (
+        <p className="mt-2 text-[11px] text-surface-500">
+          Resolved: {resolved.map((r) => `"${r.matched_token}" → ${r.value || r.artefact}`).join('; ')}
+        </p>
+      )}
+
+      <div className="mt-3" aria-live="polite">
+        {error && (
+          <p className="text-xs text-amber-300">
+            {error}
+          </p>
+        )}
+
+        {!isEmptyQuery && !loading && results.length === 0 && !error && data && (
+          <p className="text-xs text-surface-400">
+            No results. Try removing a filter or broadening the query.
+          </p>
+        )}
+
+        {isEmptyQuery && (
+          <EmptyState variant={variant} onPick={setEntryChip} />
+        )}
+
+        {results.length > 0 && (
+          <ul
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            aria-label="Palette results"
+            className="mt-2 space-y-1.5"
+          >
+            {results.map((result, idx) => (
+              <div key={result.id} data-index={idx} id={`${listboxId}-${result.id}`}>
+                <PaletteResultRow
+                  result={result}
+                  selected={idx === selectedIndex}
+                  onSelect={() => setSelectedIndex(idx)}
+                  onActivate={() => activate(result)}
+                  onRelatedConceptClick={goToConcept}
+                />
+              </div>
+            ))}
+          </ul>
+        )}
+
+        {data && results.length > 0 && (
+          <p className="mt-2 text-[10px] text-surface-600">
+            {data.results.length} of {data.total_candidates} candidate
+            {data.total_candidates === 1 ? '' : 's'} — {(data.elapsed_micros / 1000).toFixed(1)} ms server time
+          </p>
+        )}
+      </div>
+
+      {!isEmptyQuery && results.length > 0 && (
+        <ScopeRail scope={scope} onChange={setScope} />
+      )}
+    </div>
+  )
+}
+
+
+function RefinementChipBar({
+  chips,
+  existingFilters,
+  onApply,
+}: {
+  chips: PaletteRefinementChip[]
+  existingFilters: PaletteFilter[]
+  onApply: (chip: PaletteRefinementChip) => void
+}) {
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+      <span className="text-[11px] text-surface-500">Narrow by:</span>
+      {chips.slice(0, 6).map((chip) => {
+        const already = existingFilters.some(
+          (f) => f.axis === chip.axis && f.value === chip.value,
+        )
+        return (
+          <button
+            key={`${chip.axis}-${chip.value}`}
+            type="button"
+            onClick={() => !already && onApply(chip)}
+            disabled={already}
+            className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-surface-800/60 px-2 py-0.5 text-[11px] text-surface-200 hover:border-amber-400/40 hover:bg-amber-400/5 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <span className="text-surface-500">{AXIS_LABEL[chip.axis]}:</span>
+            <span>{axisValueLabel(chip.value)}</span>
+            <span className="text-surface-500">·</span>
+            <span className="text-surface-500">{chip.count}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function ScopeRail({
+  scope,
+  onChange,
+}: {
+  scope: PaletteScope | undefined
+  onChange: (s: PaletteScope | undefined) => void
+}) {
+  const scopes: { id: PaletteScope; label: string }[] = [
+    { id: 'protocol', label: 'Protocols' },
+    { id: 'flow', label: 'Flows' },
+    { id: 'concept', label: 'Concepts' },
+    { id: 'spec', label: 'Spec' },
+  ]
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+      <span className="text-[11px] text-surface-500">Filter to:</span>
+      <button
+        type="button"
+        onClick={() => onChange(undefined)}
+        className={`rounded-full border px-2 py-0.5 text-[11px] transition-colors ${
+          scope === undefined
+            ? 'border-amber-400/50 bg-amber-400/10 text-amber-200'
+            : 'border-white/10 bg-surface-800/60 text-surface-300 hover:border-white/20'
+        }`}
+      >
+        All
+      </button>
+      {scopes.map((s) => (
+        <button
+          key={s.id}
+          type="button"
+          onClick={() => onChange(s.id === scope ? undefined : s.id)}
+          className={`rounded-full border px-2 py-0.5 text-[11px] transition-colors ${
+            scope === s.id
+              ? 'border-amber-400/50 bg-amber-400/10 text-amber-200'
+              : 'border-white/10 bg-surface-800/60 text-surface-300 hover:border-white/20'
+          }`}
+        >
+          {s.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState({
+  variant,
+  onPick,
+}: {
+  variant: 'homepage' | 'cmdk'
+  onPick: (q: string) => void
+}) {
+  return (
+    <div className="mt-2">
+      <p className="text-[11px] text-surface-500 mb-1.5">
+        {variant === 'homepage' ? "Don't know where to start?" : 'Curated entry points'}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {ENTRY_CHIPS.map((chip) => (
+          <button
+            key={chip.label}
+            type="button"
+            onClick={() => onPick(chip.q)}
+            className="rounded-full border border-white/10 bg-surface-800/60 px-2.5 py-1 text-[12px] text-surface-200 hover:border-amber-400/40 hover:bg-amber-400/5 transition-colors"
+          >
+            {chip.label}
+          </button>
+        ))}
+      </div>
+      {variant === 'cmdk' && (
+        <p className="mt-3 text-[11px] text-surface-500">
+          Tip: prefix a query with{' '}
+          <code className="rounded bg-surface-800/80 px-1 py-0.5 text-surface-300">flow:</code>,{' '}
+          <code className="rounded bg-surface-800/80 px-1 py-0.5 text-surface-300">protocol:</code>, or{' '}
+          <code className="rounded bg-surface-800/80 px-1 py-0.5 text-surface-300">concept:</code>{' '}
+          to limit results.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/palette/PaletteResultRow.tsx
+++ b/frontend/src/components/palette/PaletteResultRow.tsx
@@ -1,0 +1,373 @@
+'use client'
+
+import { forwardRef } from 'react'
+import {
+  Beaker,
+  BookOpen,
+  Box,
+  ChevronRight,
+  Compass,
+  ExternalLink,
+  FileBadge,
+  Play,
+  Workflow,
+} from 'lucide-react'
+
+import {
+  artefactTypeLabel,
+  AXIS_LABEL,
+  axisValueLabel,
+} from './labels'
+import { MarkdownLite } from './MarkdownLite'
+import type {
+  PaletteAxisChip,
+  PaletteMatchReason,
+  PaletteResult,
+} from './types'
+
+const TYPE_ICON: Record<string, React.ComponentType<{ className?: string }>> = {
+  protocol: Box,
+  flow: Workflow,
+  concept: Compass,
+  walkthrough: BookOpen,
+  'spec-assertion': FileBadge,
+}
+
+const NORMATIVE_LEVEL_STYLE: Record<string, string> = {
+  'MUST': 'bg-red-500/10 border-red-500/40 text-red-300',
+  'MUST NOT': 'bg-red-500/10 border-red-500/40 text-red-300',
+  'SHOULD': 'bg-amber-500/10 border-amber-500/40 text-amber-300',
+  'SHOULD NOT': 'bg-amber-500/10 border-amber-500/40 text-amber-300',
+  'MAY': 'bg-blue-500/10 border-blue-500/40 text-blue-300',
+}
+
+interface PaletteResultRowProps {
+  result: PaletteResult
+  selected: boolean
+  onSelect: () => void
+  onActivate: () => void
+  /**
+   * Called when the user clicks a related-concept chip inside the
+   * expanded body. The palette re-queries with the concept ID so the
+   * chip navigates *within the palette* rather than to /concept/{id},
+   * which does not exist as a Next.js route (concepts are inline-only;
+   * their full body, anchors, and chips render in the expanded row).
+   */
+  onRelatedConceptClick?: (conceptId: string) => void
+}
+
+/**
+ * PaletteResultRow renders one result, switching presentation on artefact
+ * type. Every row carries at least one match-reason chip — the backend
+ * guarantees this (see `Service.Query`).
+ */
+export const PaletteResultRow = forwardRef<HTMLLIElement, PaletteResultRowProps>(
+  function PaletteResultRow(
+    { result, selected, onSelect, onActivate, onRelatedConceptClick },
+    ref,
+  ) {
+    const Icon = TYPE_ICON[result.type] ?? Beaker
+    // An empty href means the artefact has no canonical page (inline-only
+    // type). The chevron and "Open page" affordance lie when href is empty,
+    // so we hide them and rely on the inline expansion as the answer.
+    const hasPage = Boolean(result.href)
+
+    const handleClick = () => {
+      onSelect()
+      onActivate()
+    }
+
+    const outerClasses = [
+      'group relative rounded-lg border transition-colors',
+      selected
+        ? 'border-amber-400/60 bg-amber-500/[0.06]'
+        : 'border-white/5 bg-surface-900/40 hover:border-white/15',
+    ].join(' ')
+
+    return (
+      <li ref={ref} className={`list-none ${outerClasses}`}>
+        <button
+          type="button"
+          onClick={handleClick}
+          onMouseEnter={onSelect}
+          onFocus={onSelect}
+          className="flex w-full items-stretch gap-3 rounded-lg px-3 py-2.5 sm:px-3.5 sm:py-3 text-left"
+          aria-current={selected}
+          data-result-id={result.id}
+        >
+          <span className="flex-shrink-0 mt-0.5">
+            <span className="flex h-8 w-8 items-center justify-center rounded-md bg-surface-800/80 border border-white/10">
+              <Icon className="h-4 w-4 text-surface-300" />
+            </span>
+          </span>
+
+          <span className="flex-1 min-w-0">
+            <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="text-[10px] uppercase tracking-wider text-surface-500">
+                {artefactTypeLabel(result.type)}
+                {result.protocol ? ` · ${result.protocol}` : ''}
+              </span>
+              {result.runnable && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-green-500/10 border border-green-500/30 px-1.5 py-0.5 text-[10px] font-medium text-green-300">
+                  <Play className="h-2.5 w-2.5" /> Runnable
+                </span>
+              )}
+              {result.status && result.status !== 'live' && (
+                <span className="rounded-full bg-amber-500/10 border border-amber-500/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-300">
+                  {result.status}
+                </span>
+              )}
+            </span>
+            <div className="mt-0.5 flex items-baseline gap-2">
+              <span className="text-sm sm:text-base font-medium text-white truncate">
+                {result.name}
+              </span>
+            </div>
+
+            {result.type !== 'spec-assertion' && (
+              <ResultSummaryLine result={result} expanded={selected} />
+            )}
+
+            {result.spec_assertion && (
+              <div className="mt-2 space-y-1">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span
+                    className={`rounded border px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-wider ${
+                      NORMATIVE_LEVEL_STYLE[result.spec_assertion.normative_level] ??
+                      'border-white/15 text-surface-300'
+                    }`}
+                  >
+                    {result.spec_assertion.normative_level}
+                  </span>
+                  {result.spec_assertion.anchors.map((anchor) => (
+                    <span
+                      key={`${anchor.rfc}-${anchor.sections.join('.')}`}
+                      className="rounded bg-surface-800/80 border border-white/10 px-1.5 py-0.5 text-[10px] font-mono text-surface-300"
+                    >
+                      {anchor.rfc} §{anchor.sections.join(', ')}
+                    </span>
+                  ))}
+                </div>
+                <p className="text-xs sm:text-[13px] text-surface-200 leading-relaxed">
+                  {result.spec_assertion.assertion_text}
+                </p>
+              </div>
+            )}
+
+            <div className="mt-2 flex flex-wrap items-center gap-1">
+              {result.axis_chips.slice(0, 4).map((chip) => (
+                <AxisChipTag key={`${chip.axis}-${chip.value}`} chip={chip} />
+              ))}
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center gap-1">
+              {result.match_reasons.map((reason, idx) => (
+                <MatchReasonChip key={`${reason.kind}-${idx}`} reason={reason} />
+              ))}
+            </div>
+          </span>
+
+          {hasPage && (
+            <span className="self-center text-surface-500 group-hover:text-surface-300 transition-colors">
+              <ChevronRight className="h-4 w-4" />
+            </span>
+          )}
+        </button>
+
+        {selected && result.type !== 'spec-assertion' && result.body && (
+          <div className="px-3 pb-3 sm:px-3.5">
+            <ExpandedBody result={result} onRelatedConceptClick={onRelatedConceptClick} />
+          </div>
+        )}
+      </li>
+    )
+  },
+)
+
+/**
+ * ResultSummaryLine renders the always-visible row excerpt. When a
+ * query-aware snippet is available it wins (with `<mark>` highlights);
+ * otherwise we fall back to the static `body_preview`; otherwise to the
+ * frontmatter `summary`.
+ */
+function ResultSummaryLine({
+  result,
+  expanded,
+}: {
+  result: PaletteResult
+  expanded: boolean
+}) {
+  if (result.snippet) {
+    return (
+      <div className={`mt-1 text-xs sm:text-[13px] text-surface-300 ${expanded ? '' : 'line-clamp-2'}`}>
+        <MarkdownLite
+          source={result.snippet}
+          allowMark
+          className="inline text-xs sm:text-[13px] text-surface-300"
+        />
+      </div>
+    )
+  }
+  const text = result.body_preview || result.summary
+  if (!text) return null
+  return (
+    <p className={`mt-1 text-xs sm:text-[13px] text-surface-400 ${expanded ? '' : 'line-clamp-2'}`}>
+      {text}
+    </p>
+  )
+}
+
+/**
+ * ExpandedBody renders the full markdown body of the selected row plus
+ * structured metadata — normative anchors and related-concept chips.
+ *
+ * For artefact types with a canonical page (protocol, flow), an "Open
+ * page" link appears under the body. For inline-only types (concept,
+ * walkthrough, spec-assertion) the panel itself *is* the canonical
+ * surface, so no link is shown.
+ *
+ * Related-concept chips dispatch through onRelatedConceptClick so they
+ * navigate within the palette (re-querying with the concept's ID) rather
+ * than to a phantom /concept/{id} route.
+ */
+function ExpandedBody({
+  result,
+  onRelatedConceptClick,
+}: {
+  result: PaletteResult
+  onRelatedConceptClick?: (conceptId: string) => void
+}) {
+  return (
+    <div className="mt-3 rounded-md border border-white/5 bg-surface-950/40 p-3">
+      <MarkdownLite source={result.body ?? ''} />
+
+      {result.normative_anchors && result.normative_anchors.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-1">
+          <span className="text-[10px] uppercase tracking-wider text-surface-500 pr-1">
+            Anchors
+          </span>
+          {result.normative_anchors.map((anchor) => {
+            // `sections` is required by the schema and the backend validator
+            // refuses anchors with zero sections, but defend against an
+            // upstream regression (e.g. a stale index from a previous build)
+            // because rendering crashes here take the whole homepage down.
+            const sections = Array.isArray(anchor.sections) ? anchor.sections : []
+            return (
+              <span
+                key={`${anchor.rfc}-${sections.join('.')}`}
+                className="rounded bg-surface-800/80 border border-white/10 px-1.5 py-0.5 text-[10px] font-mono text-surface-200"
+              >
+                {anchor.rfc}
+                {sections.length > 0 ? ` §${sections.join(', ')}` : ''}
+              </span>
+            )
+          })}
+        </div>
+      )}
+
+      {result.related_concepts && result.related_concepts.length > 0 && (
+        <div className="mt-2 flex flex-wrap items-center gap-1">
+          <span className="text-[10px] uppercase tracking-wider text-surface-500 pr-1">
+            Related
+          </span>
+          {result.related_concepts.map((id) => (
+            <button
+              key={id}
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onRelatedConceptClick?.(id)
+              }}
+              className="rounded-full border border-white/10 bg-surface-800/60 px-2 py-0.5 text-[10px] text-surface-200 hover:border-amber-400/40"
+              title={`Open ${id} in the palette`}
+            >
+              {id}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {(result.href || (result.runnable && result.type === 'flow')) && (
+        <div className="mt-3 flex items-center gap-3 text-[11px]">
+          {result.href && (
+            <a
+              href={result.href}
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex items-center gap-1 text-amber-300 hover:text-amber-200"
+            >
+              Open page <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+          {result.runnable && result.type === 'flow' && (
+            <span className="inline-flex items-center gap-1 text-green-300">
+              <Play className="h-3 w-3" /> Press Enter to run in Looking Glass
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AxisChipTag({ chip }: { chip: PaletteAxisChip }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-surface-800/60 px-2 py-0.5 text-[10px] text-surface-300"
+      title={AXIS_LABEL[chip.axis]}
+    >
+      <span className="text-surface-500">{AXIS_LABEL[chip.axis]}:</span>
+      <span>{axisValueLabel(chip.value)}</span>
+    </span>
+  )
+}
+
+function MatchReasonChip({ reason }: { reason: PaletteMatchReason }) {
+  let label = ''
+  let tone = 'border-cyan-500/30 bg-cyan-500/5 text-cyan-200'
+
+  switch (reason.kind) {
+    case 'axis':
+      label = reason.axis
+        ? `Matched on ${AXIS_LABEL[reason.axis].toLowerCase()}: ${axisValueLabel(reason.value || '')}`
+        : 'Matched on axis'
+      tone = 'border-amber-500/30 bg-amber-500/5 text-amber-200'
+      break
+    case 'alias':
+      label = reason.matched_token
+        ? `Alias: "${reason.matched_token}"`
+        : 'Alias match'
+      tone = 'border-purple-500/30 bg-purple-500/5 text-purple-200'
+      break
+    case 'fts':
+      label = reason.matched_phrase
+        ? `Text match`
+        : 'Text match'
+      tone = 'border-blue-500/30 bg-blue-500/5 text-blue-200'
+      break
+    case 'edge':
+      label = reason.artefact
+        ? `Related to ${reason.artefact}`
+        : 'Related'
+      tone = 'border-emerald-500/30 bg-emerald-500/5 text-emerald-200'
+      break
+    case 'runnable':
+      label = 'Runnable boost'
+      tone = 'border-green-500/30 bg-green-500/5 text-green-200'
+      break
+    case 'protocol-name':
+      label = reason.matched_token
+        ? `Protocol "${reason.matched_token}"`
+        : 'Protocol name'
+      tone = 'border-orange-500/30 bg-orange-500/5 text-orange-200'
+      break
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] ${tone}`}
+      title={`weight ${reason.weight.toFixed(2)}`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/frontend/src/components/palette/PaletteResultRow.tsx
+++ b/frontend/src/components/palette/PaletteResultRow.tsx
@@ -44,6 +44,8 @@ const NORMATIVE_LEVEL_STYLE: Record<string, string> = {
 interface PaletteResultRowProps {
   result: PaletteResult
   selected: boolean
+  id: string
+  dataIndex: number
   onSelect: () => void
   onActivate: () => void
   /**
@@ -63,7 +65,7 @@ interface PaletteResultRowProps {
  */
 export const PaletteResultRow = forwardRef<HTMLLIElement, PaletteResultRowProps>(
   function PaletteResultRow(
-    { result, selected, onSelect, onActivate, onRelatedConceptClick },
+    { result, selected, id, dataIndex, onSelect, onActivate, onRelatedConceptClick },
     ref,
   ) {
     const Icon = TYPE_ICON[result.type] ?? Beaker
@@ -85,14 +87,20 @@ export const PaletteResultRow = forwardRef<HTMLLIElement, PaletteResultRowProps>
     ].join(' ')
 
     return (
-      <li ref={ref} className={`list-none ${outerClasses}`}>
+      <li
+        ref={ref}
+        id={id}
+        data-index={dataIndex}
+        role="option"
+        aria-selected={selected}
+        className={`list-none ${outerClasses}`}
+      >
         <button
           type="button"
           onClick={handleClick}
           onMouseEnter={onSelect}
           onFocus={onSelect}
           className="flex w-full items-stretch gap-3 rounded-lg px-3 py-2.5 sm:px-3.5 sm:py-3 text-left"
-          aria-current={selected}
           data-result-id={result.id}
         >
           <span className="flex-shrink-0 mt-0.5">
@@ -119,7 +127,7 @@ export const PaletteResultRow = forwardRef<HTMLLIElement, PaletteResultRowProps>
               )}
             </span>
             <div className="mt-0.5 flex items-baseline gap-2">
-              <span className="text-sm sm:text-base font-medium text-white truncate">
+              <span className="text-sm sm:text-base font-medium text-white line-clamp-2 sm:truncate">
                 {result.name}
               </span>
             </div>
@@ -154,16 +162,21 @@ export const PaletteResultRow = forwardRef<HTMLLIElement, PaletteResultRowProps>
               </div>
             )}
 
-            <div className="mt-2 flex flex-wrap items-center gap-1">
-              {result.axis_chips.slice(0, 4).map((chip) => (
+            <div className={`mt-2 flex flex-wrap items-center gap-1 ${selected ? '' : 'hidden sm:flex'}`}>
+              {result.axis_chips.slice(0, selected ? 4 : 2).map((chip) => (
                 <AxisChipTag key={`${chip.axis}-${chip.value}`} chip={chip} />
               ))}
             </div>
 
             <div className="mt-2 flex flex-wrap items-center gap-1">
-              {result.match_reasons.map((reason, idx) => (
+              {(selected ? result.match_reasons : result.match_reasons.slice(0, 2)).map((reason, idx) => (
                 <MatchReasonChip key={`${reason.kind}-${idx}`} reason={reason} />
               ))}
+              {!selected && result.match_reasons.length > 2 && (
+                <span className="text-[10px] text-surface-500 sm:hidden">
+                  +{result.match_reasons.length - 2} more
+                </span>
+              )}
             </div>
           </span>
 
@@ -238,7 +251,7 @@ function ExpandedBody({
   onRelatedConceptClick?: (conceptId: string) => void
 }) {
   return (
-    <div className="mt-3 rounded-md border border-white/5 bg-surface-950/40 p-3">
+    <div className="mt-3 max-h-64 overflow-y-auto rounded-md border border-white/5 bg-surface-950/40 p-3 sm:max-h-72">
       <MarkdownLite source={result.body ?? ''} />
 
       {result.normative_anchors && result.normative_anchors.length > 0 && (

--- a/frontend/src/components/palette/labels.ts
+++ b/frontend/src/components/palette/labels.ts
@@ -1,0 +1,108 @@
+/**
+ * Human-readable labels for axis values and axis names.
+ *
+ * These exist so the palette UI can render the controlled vocabulary in
+ * sentence-case without each result row inventing its own translation. The
+ * source of truth for the vocabulary lives in `content/taxonomy.yaml`; this
+ * file is a presentation-only mirror for the values currently in use.
+ */
+
+import type { PaletteAxis } from './types'
+
+export const AXIS_LABEL: Record<PaletteAxis, string> = {
+  use_cases: 'Use case',
+  actors: 'Actor',
+  patterns: 'Pattern',
+  problem_domains: 'Domain',
+}
+
+const VALUE_LABEL_OVERRIDES: Record<string, string> = {
+  // Use cases
+  'user-login-via-own-idp': 'User login (own IdP)',
+  'user-login-via-social': 'Social login',
+  'service-to-service-auth': 'Service-to-service',
+  'step-up-authentication': 'Step-up auth',
+  'credential-issuance': 'Credential issuance',
+  'credential-presentation': 'Credential presentation',
+  'continuous-evaluation': 'Continuous evaluation',
+  'workload-attestation': 'Workload attestation',
+  'user-provisioning': 'User provisioning',
+  'single-sign-on': 'SSO',
+  'single-logout': 'SLO',
+  'token-introspection': 'Token introspection',
+  'token-revocation': 'Token revocation',
+  'token-refresh': 'Token refresh',
+  'delegated-api-access': 'Delegated API access',
+  'mobile-app-login': 'Mobile login',
+  'single-page-app-login': 'SPA login',
+  'federation-trust-establishment': 'Federation trust',
+  'pkce-protection': 'PKCE',
+  'discovery': 'Discovery',
+
+  // Actors
+  'public-client': 'Public client',
+  'confidential-client': 'Confidential client',
+  'authorization-server': 'Authorization server',
+  'resource-server': 'Resource server',
+  'identity-provider': 'IdP',
+  'service-provider': 'SP',
+  'relying-party': 'RP',
+  'wallet': 'Wallet',
+  'verifier': 'Verifier',
+  'issuer': 'Issuer',
+  'holder': 'Holder',
+  'workload': 'Workload',
+  'user-agent': 'User agent',
+  'transmitter': 'Transmitter',
+  'receiver': 'Receiver',
+  'scim-client': 'SCIM client',
+  'scim-service-provider': 'SCIM SP',
+  'client': 'Client',
+
+  // Patterns
+  'front-channel-redirect': 'Front channel',
+  'back-channel': 'Back channel',
+  'out-of-band': 'Out of band',
+  'certificate-bound': 'Cert-bound',
+  'key-bound': 'Key-bound',
+  'push-based': 'Push',
+  'polling': 'Poll',
+  'signed-assertion': 'Signed assertion',
+  'pre-authorized': 'Pre-authorized',
+  'pkce-bound': 'PKCE-bound',
+  'nonce-bound': 'Nonce-bound',
+  'xml-signed': 'XML-signed',
+  'qr-code-handoff': 'QR handoff',
+  'metadata-discovery': 'Metadata discovery',
+  'audience-restricted': 'Audience-bound',
+  'attestation-bound': 'Attestation-bound',
+  'mutual-tls': 'mTLS',
+  'bearer': 'Bearer',
+
+  // Problem domains
+  'authentication': 'Authentication',
+  'authorization': 'Authorization',
+  'federation': 'Federation',
+  'provisioning': 'Provisioning',
+  'verifiable-credentials': 'Verifiable credentials',
+  'security-events': 'Security events',
+  'workload-identity': 'Workload identity',
+  'session-management': 'Session mgmt',
+  'key-management': 'Key mgmt',
+}
+
+export function axisValueLabel(value: string): string {
+  return VALUE_LABEL_OVERRIDES[value] ?? value
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  protocol: 'Protocol',
+  flow: 'Flow',
+  concept: 'Concept',
+  walkthrough: 'Walkthrough',
+  'spec-assertion': 'Spec assertion',
+}
+
+export function artefactTypeLabel(type: string): string {
+  return TYPE_LABEL[type] ?? type
+}

--- a/frontend/src/components/palette/paletteUrlState.ts
+++ b/frontend/src/components/palette/paletteUrlState.ts
@@ -1,0 +1,80 @@
+/**
+ * paletteUrlState — serialise and parse homepage palette state in the URL.
+ *
+ * Homepage-only persistence keeps shareable searches (`/?q=pkce&scope=concept`)
+ * without mutating unrelated pages when the cmd+K modal is used elsewhere.
+ */
+
+import type { PaletteAxis, PaletteFilter, PaletteScope } from './types'
+
+export const VALID_AXES: ReadonlySet<PaletteAxis> = new Set<PaletteAxis>([
+  'use_cases',
+  'actors',
+  'patterns',
+  'problem_domains',
+])
+
+export const VALID_SCOPES: ReadonlySet<PaletteScope> = new Set<PaletteScope>([
+  'flow',
+  'protocol',
+  'concept',
+  'spec',
+])
+
+export interface PaletteUrlState {
+  q: string
+  scope?: PaletteScope
+  filters: PaletteFilter[]
+}
+
+export interface ReadableSearchParams {
+  get(name: string): string | null
+  getAll(name: string): string[]
+}
+
+export function parsePaletteUrlState(params: ReadableSearchParams): PaletteUrlState {
+  const q = params.get('q') ?? ''
+  const scopeRaw = params.get('scope') as PaletteScope | null
+  const scope = scopeRaw && VALID_SCOPES.has(scopeRaw) ? scopeRaw : undefined
+  const filters: PaletteFilter[] = []
+  for (const raw of params.getAll('filter')) {
+    const idx = raw.indexOf(':')
+    if (idx <= 0) continue
+    const axis = raw.slice(0, idx) as PaletteAxis
+    const value = raw.slice(idx + 1)
+    if (!VALID_AXES.has(axis) || !value) continue
+    filters.push({ axis, value })
+  }
+  return { q, scope, filters }
+}
+
+export function buildPaletteSearchParams(state: PaletteUrlState): URLSearchParams {
+  const params = new URLSearchParams()
+  if (state.q.trim().length > 0) params.set('q', state.q)
+  if (state.scope) params.set('scope', state.scope)
+  for (const f of state.filters) {
+    params.append('filter', `${f.axis}:${f.value}`)
+  }
+  return params
+}
+
+export function buildPalettePathname(
+  pathname: string,
+  state: PaletteUrlState,
+): string {
+  const queryString = buildPaletteSearchParams(state).toString()
+  return queryString ? `${pathname}?${queryString}` : pathname
+}
+
+/**
+ * Returns true when the resolved alias points at a concrete search target
+ * the palette can re-issue as a query string.
+ */
+export function aliasSearchTarget(alias: {
+  value?: string
+  artefact?: string
+  matched_token?: string
+}): string | null {
+  const target = (alias.value || alias.artefact || alias.matched_token || '').trim()
+  return target.length > 0 ? target : null
+}

--- a/frontend/src/components/palette/runDispatch.ts
+++ b/frontend/src/components/palette/runDispatch.ts
@@ -1,0 +1,85 @@
+/**
+ * Helpers that translate a palette flow result into the existing Looking
+ * Glass dispatch path. We reuse `/api/protocols/{id}/demo/{flow}` followed
+ * by a navigation to the Looking Glass page with the flow pre-selected;
+ * the Looking Glass page wires the rest of the dispatch.
+ *
+ * The Looking Glass deep-link contract is `?protocol=X&flow=Y`. The
+ * backend's runURLFor (backend/internal/palette/rank.go) emits exactly
+ * this shape on PaletteResult.run_url. Both the palette handoff and the
+ * `/looking-glass` page parse it through `parseFlowDeepLink` below so the
+ * contract has a single source of truth on the frontend.
+ */
+
+import type { PaletteResult } from './types'
+
+export interface FlowDeepLink {
+  protocolId: string
+  flowId: string
+}
+
+export interface FlowRunHandoff extends FlowDeepLink {
+  lookingGlassPath: string
+}
+
+/**
+ * URLSearchParams-like surface. Next.js' `useSearchParams()` returns a
+ * `ReadonlyURLSearchParams` which has the same `get` method as the
+ * standard `URLSearchParams`, so we accept the lowest common shape and
+ * stay agnostic of the call site.
+ */
+export interface ReadableSearchParams {
+  get(name: string): string | null
+}
+
+/**
+ * parseFlowDeepLink reads `?protocol=X&flow=Y` from a search-params
+ * surface and returns the pair, or null when either parameter is missing
+ * or empty. Trimming + empty-string rejection is centralised here so
+ * callers don't accidentally treat `?protocol=&flow=` as a valid deep-link.
+ */
+export function parseFlowDeepLink(params: ReadableSearchParams): FlowDeepLink | null {
+  const protocolId = (params.get('protocol') ?? '').trim()
+  const flowId = (params.get('flow') ?? '').trim()
+  if (!protocolId || !flowId) {
+    return null
+  }
+  return { protocolId, flowId }
+}
+
+/**
+ * resolveFlowHandoff extracts the (protocol, flow) pair the Looking Glass
+ * page expects from a runnable palette result. Returns null when the result
+ * is not runnable or lacks the metadata needed to dispatch.
+ */
+export function resolveFlowHandoff(result: PaletteResult): FlowRunHandoff | null {
+  if (!result.runnable || result.type !== 'flow') {
+    return null
+  }
+  if (!result.run_url) {
+    return null
+  }
+  try {
+    // run_url is /looking-glass?protocol=X&flow=Y on a same-origin path.
+    const url = new URL(result.run_url, window.location.origin)
+    const pair = parseFlowDeepLink(url.searchParams)
+    if (!pair) {
+      return null
+    }
+    return {
+      ...pair,
+      lookingGlassPath: buildLookingGlassPath(pair),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * buildLookingGlassPath constructs the canonical deep-link path for a
+ * (protocol, flow) pair. Exported so callers that already have the pair
+ * (e.g. tests, alternative entry points) can produce a consistent URL.
+ */
+export function buildLookingGlassPath({ protocolId, flowId }: FlowDeepLink): string {
+  return `/looking-glass?protocol=${encodeURIComponent(protocolId)}&flow=${encodeURIComponent(flowId)}`
+}

--- a/frontend/src/components/palette/types.ts
+++ b/frontend/src/components/palette/types.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared TypeScript types for the ProtocolSoup palette.
+ *
+ * Mirrors the JSON shapes produced by the backend at POST /api/palette/query.
+ * Keep field names in sync with backend/internal/palette/query.go.
+ */
+
+export type PaletteArtefactType =
+  | 'protocol'
+  | 'flow'
+  | 'concept'
+  | 'walkthrough'
+  | 'spec-assertion'
+
+export type PaletteAxis =
+  | 'use_cases'
+  | 'actors'
+  | 'patterns'
+  | 'problem_domains'
+
+export type PaletteScope = 'flow' | 'protocol' | 'spec' | 'concept'
+
+export interface PaletteFilter {
+  axis: PaletteAxis
+  value: string
+}
+
+export interface PaletteRequest {
+  q: string
+  scope?: PaletteScope
+  filters?: PaletteFilter[]
+  limit?: number
+}
+
+export interface PaletteAxisChip {
+  axis: PaletteAxis
+  value: string
+}
+
+export type PaletteMatchReasonKind =
+  | 'axis'
+  | 'alias'
+  | 'fts'
+  | 'edge'
+  | 'runnable'
+  | 'protocol-name'
+
+export interface PaletteMatchReason {
+  kind: PaletteMatchReasonKind
+  axis?: PaletteAxis
+  value?: string
+  artefact?: string
+  matched_token?: string
+  matched_phrase?: string
+  edge_kind?: string
+  weight: number
+}
+
+export interface PaletteNormativeAnchor {
+  rfc: string
+  sections: string[]
+}
+
+export interface PaletteSpecAssertionDetails {
+  normative_level: 'MUST' | 'SHOULD' | 'MAY' | 'MUST NOT' | 'SHOULD NOT'
+  assertion_text: string
+  anchors: PaletteNormativeAnchor[]
+}
+
+export interface PaletteResult {
+  id: string
+  type: PaletteArtefactType
+  name: string
+  summary?: string
+  protocol?: string
+  axis_chips: PaletteAxisChip[]
+  match_reasons: PaletteMatchReason[]
+  runnable: boolean
+  href: string
+  run_url?: string
+  score: number
+  status?: string
+
+  // Plain-text first paragraph of the artefact body. Always safe to render
+  // as text. Used for the always-visible row summary.
+  body_preview?: string
+
+  // Full markdown body of the artefact. Used when the row is expanded so
+  // the user can read the answer inline without navigating away.
+  body?: string
+
+  // Query-aware excerpt of the body with matching tokens wrapped in
+  // `<mark>` tags. Empty when no body region matched the query.
+  snippet?: string
+
+  // RFC / spec anchors attached to the artefact frontmatter. Mirrored
+  // onto each result so the frontend can render anchor chips without a
+  // catalog lookup.
+  normative_anchors?: PaletteNormativeAnchor[]
+
+  // related_concepts list as artefact ids. The frontend resolves names
+  // via follow-up navigation; not all ids in this list are guaranteed
+  // to be in the current result set.
+  related_concepts?: string[]
+
+  spec_assertion?: PaletteSpecAssertionDetails
+}
+
+export interface PaletteRefinementChip {
+  axis: PaletteAxis
+  value: string
+  count: number
+}
+
+export interface PaletteResolvedAlias {
+  matched_token: string
+  axis?: PaletteAxis
+  value?: string
+  artefact?: string
+}
+
+export interface PaletteResponse {
+  query: string
+  results: PaletteResult[]
+  refinement_chips: PaletteRefinementChip[]
+  resolved_aliases: PaletteResolvedAlias[]
+  total_candidates: number
+  elapsed_micros: number
+}

--- a/frontend/src/components/palette/usePaletteQuery.ts
+++ b/frontend/src/components/palette/usePaletteQuery.ts
@@ -100,3 +100,85 @@ export function usePaletteQuery({
 
   return { data, loading, error, refresh: issueQuery }
 }
+
+
+// usePlatformShortcutLabel
+export function usePlatformShortcutLabel(): string | null {
+  const [label, setLabel] = useState<string | null>(null)
+
+  useEffect(() => {
+    const ua = navigator.userAgent || ''
+    const isMac = /Mac OS X|Macintosh|iPhone|iPad|iPod/.test(ua)
+    setLabel(isMac ? '\u2318 K' : 'Ctrl K')
+  }, [])
+
+  return label
+}
+
+// useRecentSearches
+const RECENT_STORAGE_KEY = 'protocolsoup.palette.recent.v1'
+const MAX_RECENT = 5
+
+function readRecentFromStorage(): string[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(RECENT_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((v): v is string => typeof v === 'string').slice(0, MAX_RECENT)
+  } catch {
+    return []
+  }
+}
+
+function writeRecentToStorage(next: string[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // Quota exceeded, private mode, or storage disabled — drop the write.
+  }
+}
+
+export interface UseRecentSearchesResult {
+  recent: string[]
+  push: (query: string) => void
+  clear: () => void
+}
+
+/**
+ * localStorage-backed recent palette queries for the empty state.
+ */
+export function useRecentSearches(): UseRecentSearchesResult {
+  const [recent, setRecent] = useState<string[]>([])
+
+  useEffect(() => {
+    setRecent(readRecentFromStorage())
+
+    function onStorage(event: StorageEvent) {
+      if (event.key !== RECENT_STORAGE_KEY) return
+      setRecent(readRecentFromStorage())
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
+
+  const push = useCallback((query: string) => {
+    const normalized = query.trim()
+    if (normalized.length === 0) return
+    setRecent((prev) => {
+      const without = prev.filter((entry) => entry !== normalized)
+      const next = [normalized, ...without].slice(0, MAX_RECENT)
+      writeRecentToStorage(next)
+      return next
+    })
+  }, [])
+
+  const clear = useCallback(() => {
+    writeRecentToStorage([])
+    setRecent([])
+  }, [])
+
+  return { recent, push, clear }
+}

--- a/frontend/src/components/palette/usePaletteQuery.ts
+++ b/frontend/src/components/palette/usePaletteQuery.ts
@@ -1,0 +1,102 @@
+/**
+ * usePaletteQuery — debounced React hook that queries POST /api/palette/query.
+ *
+ * The hook keeps the most recent successful response alongside loading and
+ * error state. Race conditions are eliminated by tracking the latest
+ * dispatched query id; out-of-order responses are dropped.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import type {
+  PaletteFilter,
+  PaletteRequest,
+  PaletteResponse,
+  PaletteScope,
+} from './types'
+
+interface UsePaletteQueryOptions {
+  q: string
+  scope?: PaletteScope
+  filters?: PaletteFilter[]
+  debounceMs?: number
+  enabled?: boolean
+}
+
+interface UsePaletteQueryResult {
+  data: PaletteResponse | null
+  loading: boolean
+  error: string | null
+  refresh: () => void
+}
+
+const PALETTE_QUERY_ENDPOINT = '/api/palette/query'
+
+export function usePaletteQuery({
+  q,
+  scope,
+  filters,
+  debounceMs = 80,
+  enabled = true,
+}: UsePaletteQueryOptions): UsePaletteQueryResult {
+  const [data, setData] = useState<PaletteResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Stable JSON of the filters keyed array so effect deps stay simple.
+  const filtersKey = useMemo(() => JSON.stringify(filters ?? []), [filters])
+
+  const requestSeq = useRef(0)
+
+  const issueQuery = useCallback(async () => {
+    const body: PaletteRequest = {
+      q,
+      ...(scope ? { scope } : {}),
+      ...(filters && filters.length ? { filters } : {}),
+    }
+    const seq = ++requestSeq.current
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch(PALETTE_QUERY_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        throw new Error(`palette query failed (${response.status})`)
+      }
+      const payload = (await response.json()) as PaletteResponse
+      // Drop stale responses so we never overwrite a newer successful one.
+      if (seq === requestSeq.current) {
+        setData(payload)
+      }
+    } catch (err) {
+      if (seq === requestSeq.current) {
+        setError(err instanceof Error ? err.message : String(err))
+      }
+    } finally {
+      if (seq === requestSeq.current) {
+        setLoading(false)
+      }
+    }
+  }, [q, scope, filters])
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
+    const handle = window.setTimeout(() => {
+      void issueQuery()
+    }, debounceMs)
+    return () => window.clearTimeout(handle)
+    // We deliberately include filtersKey instead of the array reference so
+    // referentially-fresh-but-shallow-equal filter arrays do not retrigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q, scope, filtersKey, debounceMs, enabled])
+
+  return { data, loading, error, refresh: issueQuery }
+}

--- a/frontend/src/views/Dashboard.tsx
+++ b/frontend/src/views/Dashboard.tsx
@@ -5,6 +5,8 @@ import {
   Code, FileSearch, Zap, FileKey, Users, Radio
 } from 'lucide-react'
 
+import { HomepagePalette } from '@/components/palette/HomepagePalette'
+
 interface SpecLinkItem {
   label: string
   url: string
@@ -85,6 +87,11 @@ export function Dashboard() {
           infrastructure and see exactly what happens at each step.
         </p>
       </header>
+
+      {/* Palette: prominent multi-axis content retrieval surface */}
+      <section aria-label="Search protocols, flows, and concepts">
+        <HomepagePalette />
+      </section>
 
       {/* Value Props */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/frontend/src/views/LookingGlass.tsx
+++ b/frontend/src/views/LookingGlass.tsx
@@ -4,8 +4,10 @@
 
 'use client'
 
-import { useState, useCallback, useMemo, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+import { parseFlowDeepLink } from '@/components/palette/runDispatch'
 import { motion, AnimatePresence } from 'framer-motion'
 import { 
   Eye, Play, RotateCcw, Key, Square,
@@ -100,6 +102,7 @@ function describeWalletSubmitError(responsePayload: Record<string, unknown> | nu
 
 export function LookingGlass() {
   const router = useRouter()
+  const searchParams = useSearchParams()
 
   const [selectedProtocol, setSelectedProtocol] = useState<LookingGlassProtocol | null>(null)
   const [selectedFlow, setSelectedFlow] = useState<LookingGlassFlow | null>(null)
@@ -1005,6 +1008,30 @@ export function LookingGlass() {
       }
     }
   }, [protocols, resetFlow, clearWireEvents, router])
+
+  // Honour ?protocol=X&flow=Y from deep-links (palette run dispatch, shared
+  // URLs, browser bookmarks). The effect must work for three cases:
+  //
+  //   1. Direct visit / refresh / shared URL — the param-loaded path.
+  //   2. Palette dispatch from another page — router.push() changes the
+  //      route and the URL.
+  //   3. Palette re-dispatch while already on /looking-glass — only the
+  //      search params change.
+  //
+  // Using `useSearchParams()` makes the effect reactive to URL changes
+  // (case 3), and tracking the last handled (protocol, flow) pair in a
+  // ref prevents a redundant re-dispatch when the `protocols` array
+  // reference changes (e.g. refetch) but the deep-link target has not.
+  const lastHandledPairRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (protocolsLoading || protocols.length === 0) return
+    const pair = parseFlowDeepLink(searchParams)
+    if (!pair) return
+    const key = `${pair.protocolId}\u0000${pair.flowId}`
+    if (lastHandledPairRef.current === key) return
+    lastHandledPairRef.current = key
+    handleQuickSelect(pair.protocolId, pair.flowId)
+  }, [searchParams, protocols, protocolsLoading, handleQuickSelect])
 
   const hasCapturedTokens = realExecutor.state?.decodedTokens && realExecutor.state.decodedTokens.length > 0
   const quickStartFlows = [


### PR DESCRIPTION
## What does this PR do?

<!-- Briefly describe the change and its motivation. Link to the related issue if one exists. -->

Adds ProtocolSoup palette - a deterministic, multi-axis content retrieval surface for protocolsoup.com.

Users search from a homepage hero input or a global cmd+K modal and get typed, ranked results across structured axes (use_cases, actors, patterns, problem_domains) with visible match reasons on every row through SQLite FTS5 plus rule-based ranking.

**Backend**
Content substrate under content/ (taxonomy, aliases, protocol/flow/concept artefacts)
content-validate and palette-indexer (idempotent FTS5 build)
POST /api/palette/query - parse → candidates → rank → match reasons → refinement chips
Runnable flows dispatch to Looking Glass via ?protocol=X&flow=Y

**Frontend**
Shared Palette component (homepage + cmd+K)
Rich inline results (snippets, expanded markdown, normative anchors, related concepts)
Compact results with top-level refinements, mobile layout, accessibility fixes
Shareable homepage URLs (?q=&scope=&filter=)
Recent searches (localStorage), header Search chip, keyboard shortcut hints
Reactive Looking Glass deep-link handling for palette handoff

**Docs / CI**
CONTRIBUTING.md palette authoring and validation guidance
.github/workflows/palette-content.yml for content/index validation

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New protocol implementation

## How was this tested?

<!-- Describe how you verified your changes work correctly. -->

- [x] Ran the affected flow in Looking Glass and verified real-time events
- [x] Tested locally with `cd backend && go run ./cmd/server` and `cd frontend && npm run dev`
- [ ] Other (describe below)

## Validation checklist

<!-- Run the checks that match your change. Mark not applicable items as N/A in the PR description. -->

- [x] Backend: `cd backend && go build ./... && go test ./...`
- [x] Backend lint: `cd backend && golangci-lint run ./...`
- [x] Frontend: `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- [x] Frontend references: `cd frontend && npm run verify-refs`
- [ ] Wallet UI: `cd wallet-ui && npx tsc --noEmit && npm run build`
- [x] Docs: `cd docs/starlight && npm run build`
- [ ] OpenAPI: `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1`
- [ ] Docker/topology: `cd docker && docker compose config`
- [ ] OID4VCI/OID4VP conformance: `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1`

## Checklist

<!-- Complete all items before requesting review. -->

- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] I have read the [CONTRIBUTING](https://github.com/ParleSec/ProtocolSoup/blob/master/CONTRIBUTING.md) guide
- [x] I selected the relevant validation checks above
- [x] I have updated documentation if needed
- [x] I have not committed secrets, credentials, or `.env` files

## Screenshots / Looking Glass output

<!-- If this is a UI change or protocol change, include screenshots or Looking Glass timeline output. -->
<img width="1481" height="1851" alt="image" src="https://github.com/user-attachments/assets/8df79285-fda2-42cf-9d70-318e0b0f0a20" />
<img width="586" height="1176" alt="image" src="https://github.com/user-attachments/assets/e1beddd8-eca9-4e45-ad9f-aa8564f02bb6" />