### PR TITLE
Feature/paletteEmbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run the full stack locally with Docker:
 ```bash
 git clone https://github.com/ParleSec/ProtocolSoup.git
 cd ProtocolSoup/docker
-docker compose up -d
+docker compose up -d --build
 ```
 
 Then open:

--- a/backend/cmd/gateway/main.go
+++ b/backend/cmd/gateway/main.go
@@ -12,10 +12,27 @@ import (
 
 	"github.com/ParleSec/ProtocolSoup/internal/core"
 	"github.com/ParleSec/ProtocolSoup/internal/gateway"
+	"github.com/ParleSec/ProtocolSoup/internal/palette"
 )
 
 func main() {
 	cfg := core.LoadConfig()
+
+	var paletteSvc *palette.Service
+	if cfg.PaletteDBPath != "" {
+		svc, err := palette.NewService(cfg.PaletteDBPath)
+		if err != nil {
+			if cfg.IsProduction() {
+				log.Fatalf("Failed to load palette index at %s: %v", cfg.PaletteDBPath, err)
+			}
+			log.Printf("Palette service disabled: %v", err)
+		} else {
+			paletteSvc = svc
+			stats := svc.Stats()
+			log.Printf("Palette service initialized from %s (%d artefacts, index v%s)",
+				cfg.PaletteDBPath, stats.ArtefactCount, stats.IndexVersion)
+		}
+	}
 
 	upstreams := []gateway.UpstreamConfig{
 		{Name: "federation", BaseURL: strings.TrimSpace(os.Getenv("FEDERATION_SERVICE_URL"))},
@@ -33,6 +50,7 @@ func main() {
 		StartupRetryInitial: envDuration("GATEWAY_STARTUP_RETRY_INITIAL", 2*time.Second),
 		StartupRetryMax:     envDuration("GATEWAY_STARTUP_RETRY_MAX", 30*time.Second),
 		RequestTimeout:      envDuration("GATEWAY_REQUEST_TIMEOUT", 5*time.Second),
+		Palette:             paletteSvc,
 	})
 	if err != nil {
 		log.Fatalf("Failed to initialize gateway: %v", err)

--- a/backend/internal/gateway/gateway.go
+++ b/backend/internal/gateway/gateway.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ParleSec/ProtocolSoup/internal/palette"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 )
@@ -29,6 +30,9 @@ type Config struct {
 	StartupRetryInitial time.Duration
 	StartupRetryMax     time.Duration
 	RequestTimeout      time.Duration
+	// Palette serves POST /api/palette/query from a local SQLite index. Nil
+	// omits the route (split deployments without a baked index).
+	Palette *palette.Service
 }
 
 // UpstreamConfig represents an upstream service.
@@ -65,6 +69,8 @@ type Upstream struct {
 // Gateway routes API and protocol traffic to upstream services.
 type Gateway struct {
 	cfg Config
+
+	palette *palette.Service
 
 	client    *http.Client
 	upstreams map[string]*Upstream
@@ -119,7 +125,8 @@ func NewGateway(cfg Config) (*Gateway, error) {
 	}
 
 	return &Gateway{
-		cfg: cfg,
+		cfg:     cfg,
+		palette: cfg.Palette,
 		client: &http.Client{
 			Timeout: cfg.RequestTimeout,
 		},
@@ -161,6 +168,10 @@ func (g *Gateway) Router() http.Handler {
 		r.Post("/lookingglass/decode", g.handleDecodeToken)
 		r.Get("/lookingglass/sessions", g.handleListSessions)
 		r.Get("/lookingglass/sessions/{id}", g.handleGetSession)
+
+		if g.palette != nil {
+			r.Post("/palette/query", g.palette.Handler())
+		}
 	})
 
 	r.Get("/ws/lookingglass/{session}", g.handleLookingGlassWS)

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -60,6 +60,9 @@ func (g *Gateway) handleAPIIndex(w http.ResponseWriter, r *http.Request) {
 		"lookingglass":     "/api/lookingglass",
 		"lookingglass_ws":  "/ws/lookingglass/{session}",
 	}
+	if g.palette != nil {
+		endpoints["palette"] = "/api/palette/query"
+	}
 
 	g.writeJSON(w, http.StatusOK, apiIndexResponse{
 		Service:   "protocol-lens-gateway",

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,7 @@
 # Protocol Soup - Split Backend Services (Base)
-# Run with: docker compose up -d
+# Run with: docker compose up -d --build
+# After pulling new code, always pass --build so frontend and gateway images
+# are rebuilt from source (palette UI and /api/palette/query are baked in).
 #
 # This starts:
 # - Gateway (API aggregation + protocol routing)
@@ -45,6 +47,7 @@ services:
       - SHOWCASE_LISTEN_ADDR=:8080
       - SHOWCASE_BASE_URL=http://localhost:8080
       - SHOWCASE_CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+      - SHOWCASE_PALETTE_DB=/app/palette.db
       - FEDERATION_SERVICE_URL=http://federation-service:8080
       - SCIM_SERVICE_URL=http://scim-service:8080
       - SSF_SERVICE_URL=http://ssf-service:8080
@@ -177,6 +180,7 @@ services:
         NEXT_PUBLIC_WS_BASE_URL: ws://localhost:8080
     # For using published GHCR images, comment 'build:' above and uncomment:
     # image: ghcr.io/parlesec/protocolsoup-frontend:latest
+    image: protocol-lens-frontend:latest
     container_name: protocol-showcase-frontend
     ports:
       - "3000:3000"

--- a/docs/starlight/src/content/docs/deploy/deployment-models.mdx
+++ b/docs/starlight/src/content/docs/deploy/deployment-models.mdx
@@ -11,10 +11,12 @@ Run the complete ProtocolSoup experience with all services.
 
 ```bash
 cd docker
-docker compose up -d
+docker compose up -d --build
 ```
 
 **Services started:** frontend, gateway, federation-service, scim-service, ssf-service
+
+The gateway image ships the [palette content index](/deploy/palette-index/) at `/app/palette.db` and serves `POST /api/palette/query` for homepage search and **cmd+K**. Rebuild images after pulling new code (`--build`); `docker compose up -d` alone reuses cached layers and can leave you on an older UI.
 
 **Add SPIFFE:**
 

--- a/docs/starlight/src/content/docs/start-here/quickstart.mdx
+++ b/docs/starlight/src/content/docs/start-here/quickstart.mdx
@@ -16,7 +16,7 @@ Run the frontend, gateway, federation, SCIM, and SSF services together.
 
 ```bash
 cd docker
-docker compose up -d
+docker compose up -d --build
 ```
 
 This starts five services:


### PR DESCRIPTION
## What does this PR do?

Embeds the existing palette and search services into the existing gateway and main containers. This enables granular search functionality to be available for more localised services


## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New protocol implementation

## How was this tested?

<!-- Describe how you verified your changes work correctly. -->

- [x] Ran the affected flow in Looking Glass and verified real-time events
- [x] Tested locally with `cd backend && go run ./cmd/server` and `cd frontend && npm run dev`
- [ ] Other (describe below)

## Validation checklist

<!-- Run the checks that match your change. Mark not applicable items as N/A in the PR description. -->

- [x] Backend: `cd backend && go build ./... && go test ./...`
- [x] Backend lint: `cd backend && golangci-lint run ./...`
- [x] Frontend: `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- [x] Frontend references: `cd frontend && npm run verify-refs`
- [x] Wallet UI: `cd wallet-ui && npx tsc --noEmit && npm run build`
- [ ] Docs: `cd docs/starlight && npm run build`
- [ ] OpenAPI: `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1`
- [x] Docker/topology: `cd docker && docker compose config`
- [x] OID4VCI/OID4VP conformance: `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1`

## Checklist

<!-- Complete all items before requesting review. -->

- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] I have read the [CONTRIBUTING](https://github.com/ParleSec/ProtocolSoup/blob/master/CONTRIBUTING.md) guide
- [x] I selected the relevant validation checks above
- [x] I have updated documentation if needed
- [x] I have not committed secrets, credentials, or `.env` files

## Screenshots / Looking Glass output

<!-- If this is a UI change or protocol change, include screenshots or Looking Glass timeline output. -->
no visual changes