### PR TITLE
Feature/mso mdoc 260731

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,7 @@ Fixes #
 - [ ] Backend lint: `cd backend && golangci-lint run ./...`
 - [ ] Frontend: `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
 - [ ] Frontend references: `cd frontend && npm run verify-refs`
+- [ ] JWK thumbprint (RFC 7638): `cd frontend && npm run verify-jwk-thumbprint`
 - [ ] Wallet UI: `cd wallet-ui && npx tsc --noEmit && npm run build`
 - [ ] Docs: `cd docs/starlight && npm run build`
 - [ ] OpenAPI: `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1`

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -255,6 +255,10 @@ jobs:
         working-directory: frontend
         run: npm run verify-refs
 
+      - name: Verify JWK thumbprint helper (RFC 7638)
+        working-directory: frontend
+        run: npm run verify-jwk-thumbprint
+
   # Job 5: Backend Linting and Vet
   backend-lint:
     name: Backend Lint & Vet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,7 @@ Run the smallest set that covers your change. CI may run additional checks, but 
 | Backend lint-sensitive changes | `cd backend && golangci-lint run ./...` |
 | Frontend UI or Looking Glass | `cd frontend && npm ci && npm run lint && npx tsc --noEmit && npm run build` |
 | Frontend protocol references | `cd frontend && npm run verify-refs` |
+| `cnf.jkt` / JWK thumbprint helper (`src/utils/crypto.ts`) | `cd frontend && npm run verify-jwk-thumbprint` |
 | Wallet UI | `cd wallet-ui && npm ci && npx tsc --noEmit && npm run build` |
 | Docs site | `cd docs/starlight && npm ci && npm run build` |
 | OpenAPI contracts | `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1` |

--- a/backend/cmd/walletharness/main.go
+++ b/backend/cmd/walletharness/main.go
@@ -2240,13 +2240,26 @@ func summarizeCredential(rawCredential string) *credentialSummary {
 	if normalized == "" {
 		return nil
 	}
+	// mso_mdoc credentials are base64url CBOR, not JWTs. vc.MSOMdocFormat
+	// registers mdoc with the shared registry and ParseAnyCredential now
+	// parses it successfully, but mdocCredentialSummary remains the richer,
+	// wallet-native summary -- it is also what mdocMatchEvidence and
+	// mdocAvailableElements are built against elsewhere in this package -- so
+	// mdoc is summarized directly from the IssuerSigned structure rather than
+	// through the generic parsed.Claims path below. Trying this first, ahead
+	// of the registry parse, is deliberate: gating on a successful registry
+	// parse instead would silently fall through to the generic path (and its
+	// SD-JWT-shaped DisclosureCount/KeyBindingJWT zero values) for any input
+	// mdocCredentialSummary can summarize but the registry's hardened decode
+	// rejects, which is exactly the fabrication this function exists to
+	// avoid. decodeMdocIssuerSignedB64 fails fast on a non-mdoc input (a
+	// compact JWT's '.' is not valid base64url), so this costs nothing for
+	// the other four formats.
+	if mdocSummary := mdocCredentialSummary(normalized); mdocSummary != nil {
+		return mdocSummary
+	}
 	parsed, err := vc.DefaultCredentialFormatRegistry().ParseAnyCredential(normalized)
 	if err != nil {
-		// mso_mdoc credentials are base64url CBOR, not JWTs, so the registry parse
-		// fails; summarize them directly from the IssuerSigned structure.
-		if mdocSummary := mdocCredentialSummary(normalized); mdocSummary != nil {
-			return mdocSummary
-		}
 		summary := &credentialSummary{}
 		if envelope, parseErr := vc.ParseSDJWTEnvelope(normalized); parseErr == nil {
 			summary.IsSDJWT = true
@@ -2258,7 +2271,10 @@ func summarizeCredential(rawCredential string) *credentialSummary {
 	}
 
 	claims := parsed.Claims
-	if evidence, evidenceErr := vc.BuildCredentialEvidence(normalized); evidenceErr == nil && evidence != nil && evidence.FullClaims != nil {
+	// summarizeCredential is only ever called with a wallet's own stored
+	// CredentialJWT (see call sites), never a vp_token, so this is always
+	// the issued artifact rather than something the holder presented.
+	if evidence, evidenceErr := vc.BuildCredentialEvidence(normalized, vc.LifecycleStageIssued); evidenceErr == nil && evidence != nil && evidence.FullClaims != nil {
 		claims = evidence.FullClaims
 	}
 
@@ -2939,7 +2955,12 @@ func matchWalletCredentialsToDCQL(credentials map[string]walletCredentialMateria
 	for credID, cred := range credentials {
 		// mso_mdoc credentials are base64url CBOR (not a JWT/SD-JWT), so they take
 		// the mdoc DCQL matcher (doctype + [namespace, elementIdentifier] paths)
-		// rather than vc.BuildCredentialEvidence, which would fail to parse them.
+		// rather than vc.BuildCredentialEvidence. vc.MSOMdocFormat means
+		// BuildCredentialEvidence now parses mdoc successfully rather than
+		// failing, but its CredentialEvidence.FullClaims is still the flat
+		// JWT/SD-JWT claim shape, not [namespace, elementIdentifier] paths --
+		// the wrong shape for vc.RequirementMatchesMdoc below, so mdoc still
+		// needs this separate branch even though the parse no longer fails.
 		if strings.EqualFold(strings.TrimSpace(cred.Format), credentialFormatMsoMdoc) {
 			mdocEvidence, err := mdocMatchEvidence(cred)
 			if err != nil {
@@ -2960,7 +2981,10 @@ func matchWalletCredentialsToDCQL(credentials map[string]walletCredentialMateria
 			}
 			continue
 		}
-		evidence, err := vc.BuildCredentialEvidence(cred.CredentialJWT)
+		// The wallet's own stored copy of an issued credential is being
+		// checked for eligibility here, not something the holder has
+		// presented, so this is LifecycleStageIssued.
+		evidence, err := vc.BuildCredentialEvidence(cred.CredentialJWT, vc.LifecycleStageIssued)
 		if err != nil {
 			reasons = append(reasons, fmt.Sprintf("credential %s: %v", credID, err))
 			continue
@@ -3011,7 +3035,23 @@ func matchWalletCredentialsToPresentationDefinition(credentials map[string]walle
 	var matched []walletCredentialMaterial
 	var reasons []string
 	for credentialID, credential := range credentials {
-		evidence, err := vc.BuildCredentialEvidence(credential.CredentialJWT)
+		// mso_mdoc credentials are matched via DCQL (ISO/IEC 18013-5 claims are
+		// addressed by [namespace, elementIdentifier] pairs), never
+		// Presentation Exchange, mirroring the format guard in
+		// matchWalletCredentialsToDCQL above. vc.MSOMdocFormat means
+		// BuildCredentialEvidence below now parses mdoc successfully rather
+		// than failing at parse, so without this guard an mdoc credential
+		// would proceed into PE field-path matching against
+		// CredentialEvidence.FullClaims, a shape PE constraints were never
+		// meant to address for this format.
+		if strings.EqualFold(strings.TrimSpace(credential.Format), credentialFormatMsoMdoc) {
+			reasons = append(reasons, fmt.Sprintf("credential %s: mso_mdoc credentials are matched via DCQL, not presentation_exchange", credentialID))
+			continue
+		}
+		// Same reasoning as matchWalletCredentialsToDCQL above: this checks
+		// wallet-held issued credentials for PE eligibility, not a
+		// presentation artifact.
+		evidence, err := vc.BuildCredentialEvidence(credential.CredentialJWT, vc.LifecycleStageIssued)
 		if err != nil {
 			reasons = append(reasons, fmt.Sprintf("credential %s: %v", credentialID, err))
 			continue
@@ -4339,8 +4379,14 @@ func (s *walletHarnessServer) bindCredential(wallet *walletMaterial, credentialJ
 		return fmt.Errorf("credential is required")
 	}
 
-	// mso_mdoc credentials are base64url CBOR (not a JWT/SD-JWT), so they bypass
-	// the JWT-oriented credential registry and are stored with device binding.
+	// mso_mdoc credentials are base64url CBOR (not a JWT/SD-JWT), so binding
+	// them needs mso_mdoc-specific handling rather than the generic path
+	// below. vc.MSOMdocFormat means vc.DefaultCredentialFormatRegistry() can
+	// parse mso_mdoc now, so this is no longer a parse-capability gap, but
+	// bindMdocCredential still does two things the generic path has no
+	// concept of: verifying the credential is bound to this wallet's
+	// persistent device key (s.deviceKey), and storing it with that device
+	// binding rather than a bearer JWT's holder-key binding.
 	if strings.EqualFold(strings.TrimSpace(credentialFormat), credentialFormatMsoMdoc) {
 		return s.bindMdocCredential(wallet, normalizedCredential, credentialConfigID)
 	}
@@ -4413,6 +4459,12 @@ func credentialRefreshRequired(credentialJWT string, minRemaining time.Duration)
 	if normalizedCredential == "" {
 		return true, fmt.Errorf("credential is required")
 	}
+	// Tried directly, ahead of the registry, rather than gated on
+	// parsedCredential.Format: mso_mdoc has no expectedUpdate-driven refresh
+	// signal analogous to a JWT exp claim beyond ValidityInfo.ValidUntil
+	// read here, and decodeMdocIssuerSignedB64 fails fast on non-mdoc input,
+	// so trying it first costs nothing for the other four formats and needs
+	// no separate format check.
 	if issuerSigned, err := decodeMdocIssuerSignedB64(normalizedCredential); err == nil {
 		msoBytes, _, err := mdoc.ParseIssuerAuth(issuerSigned.IssuerAuth)
 		if err != nil {

--- a/backend/cmd/walletharness/mdoc_holder.go
+++ b/backend/cmd/walletharness/mdoc_holder.go
@@ -14,7 +14,6 @@ import (
 	intcrypto "github.com/ParleSec/ProtocolSoup/internal/crypto"
 	"github.com/ParleSec/ProtocolSoup/internal/mdoc"
 	"github.com/ParleSec/ProtocolSoup/internal/vc"
-	"github.com/fxamacker/cbor/v2"
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -33,48 +32,6 @@ const (
 	// select the verifier's response-encryption key from client_metadata.jwks.
 	mdocResponseEncAlg = "ECDH-ES"
 )
-
-// jsonSafeValue converts a CBOR-decoded mdoc element value into a value that the
-// standard encoding/json marshaler can serialize. Generic CBOR decoding yields
-// map[any]any for maps, cbor.Tag for tagged values such as full-date (tag 1004,
-// used by mDL birth_date/issue_date/expiry_date), and []byte for byte strings.
-// encoding/json cannot marshal map[any]any (a non-string map key) and renders
-// cbor.Tag as an opaque struct, so an un-normalized mDL element (e.g. the nested
-// driving_privileges array) would fail to encode and leave the response body
-// empty. Normalizing here keeps the credential summary JSON-serializable while
-// preserving the real disclosed values (ISO/IEC 18013-5 mDL data elements).
-func jsonSafeValue(value any) any {
-	switch typed := value.(type) {
-	case nil:
-		return nil
-	case cbor.Tag:
-		return jsonSafeValue(typed.Content)
-	case map[any]any:
-		out := make(map[string]any, len(typed))
-		for key, val := range typed {
-			out[fmt.Sprintf("%v", key)] = jsonSafeValue(val)
-		}
-		return out
-	case map[string]any:
-		out := make(map[string]any, len(typed))
-		for key, val := range typed {
-			out[key] = jsonSafeValue(val)
-		}
-		return out
-	case []any:
-		out := make([]any, len(typed))
-		for i, val := range typed {
-			out[i] = jsonSafeValue(val)
-		}
-		return out
-	case []byte:
-		return base64.RawURLEncoding.EncodeToString(typed)
-	case time.Time:
-		return typed.UTC().Format(time.RFC3339)
-	default:
-		return typed
-	}
-}
 
 // credentialFormatMsoMdoc is the OID4VCI/ISO 18013-5 mso_mdoc credential format
 // identifier (OID4VCI Appendix A.3). mso_mdoc credentials are base64url-encoded
@@ -292,7 +249,7 @@ func mdocCredentialSummary(rawCredential string) *credentialSummary {
 		elements := disclosed[mdoc.NameSpace(ns)]
 		nsClaims := make(map[string]interface{}, len(elements))
 		for element, value := range elements {
-			nsClaims[element] = jsonSafeValue(value)
+			nsClaims[element] = mdoc.JSONSafeValue(value)
 		}
 		claims[ns] = nsClaims
 	}

--- a/backend/cmd/walletharness/mdoc_holder_test.go
+++ b/backend/cmd/walletharness/mdoc_holder_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -264,6 +265,63 @@ func TestHarnessMatchWalletCredentialsToDCQLMdoc(t *testing.T) {
 	missingElementDCQL := `{"credentials":[{"id":"mdl","format":"mso_mdoc","meta":{"doctype_values":["org.iso.18013.5.1.mDL"]},"claims":[{"path":["org.iso.18013.5.1","portrait"]}]}]}`
 	if matched, _ := matchWalletCredentialsToDCQL(wallet.Credentials, missingElementDCQL); len(matched) != 0 {
 		t.Fatalf("expected no match when a required element is absent, got %d", len(matched))
+	}
+}
+
+// TestHarnessMatchWalletCredentialsToPresentationDefinitionRefusesMdoc pins
+// the A3c PE format guard: before mso_mdoc registration, an mdoc credential
+// failed at vc.BuildCredentialEvidence's parse step and was refused with a
+// parse-error reason. After registration it parses successfully, so without
+// the guard in matchWalletCredentialsToPresentationDefinition it would
+// proceed into PE field-path matching against a claim shape (namespace-
+// nested, not JWT/SD-JWT flat) that Presentation Exchange constraints were
+// never meant to address. This asserts the refusal is the explicit format
+// guard, not a parse failure wearing a different message.
+func TestHarnessMatchWalletCredentialsToPresentationDefinitionRefusesMdoc(t *testing.T) {
+	s := newMdocTestHarness(t)
+	wallet := &walletMaterial{
+		Subject:     "did:example:wallet:alice",
+		Credentials: make(map[string]walletCredentialMaterial),
+	}
+	credential := issueMdocBoundTo(t, s, &s.deviceKey.PublicKey)
+	if err := s.bindCredential(wallet, credential, "MobileDrivingLicenceMsoMdoc", credentialFormatMsoMdoc); err != nil {
+		t.Fatalf("bindCredential: %v", err)
+	}
+
+	presentationDefinition := map[string]interface{}{
+		"id": "pd-mdoc-guard",
+		"input_descriptors": []interface{}{
+			map[string]interface{}{
+				"id": "descriptor-1",
+				"constraints": map[string]interface{}{
+					"fields": []interface{}{
+						map[string]interface{}{"path": []interface{}{"$.vc.type"}},
+					},
+				},
+			},
+		},
+	}
+
+	matched, reasons := matchWalletCredentialsToPresentationDefinition(wallet.Credentials, presentationDefinition)
+	if len(matched) != 0 {
+		t.Fatalf("expected 0 matched credentials for mso_mdoc under presentation_exchange, got %d", len(matched))
+	}
+
+	foundGuardReason := false
+	for _, reason := range reasons {
+		if strings.Contains(reason, "matched via DCQL, not presentation_exchange") {
+			foundGuardReason = true
+		}
+		// Before the guard existed, refusal came from
+		// vc.BuildCredentialEvidence/ParseAnyCredential failing at parse.
+		// A reason that still looks like a parse failure would mean the
+		// guard regressed back to relying on the parse erroring out.
+		if strings.Contains(reason, "unsupported credential format") || strings.Contains(reason, "decode base64url") {
+			t.Fatalf("refusal reason %q looks like a parse failure, not the explicit format guard", reason)
+		}
+	}
+	if !foundGuardReason {
+		t.Fatalf("expected a refusal reason citing the DCQL-not-PE format guard, got reasons: %v", reasons)
 	}
 }
 

--- a/backend/cmd/walletharness/oid4vci_external.go
+++ b/backend/cmd/walletharness/oid4vci_external.go
@@ -1301,13 +1301,23 @@ func (s *walletHarnessServer) validateImportedCredential(
 	if err != nil {
 		return nil, err
 	}
-	if err := formatHandler.ValidateIssuerSignature(vc.CredentialValidationInput{
+	// This accepts arbitrary pasted or externally-fetched credentials, so it
+	// is a trust boundary rather than a reporting surface: not-evaluated must
+	// refuse import exactly like a checked failure, never fall through as an
+	// accepted-but-unverified credential. vc.IssuerTrustStatus guarantees a
+	// non-nil error for both IssuerTrustFailed and IssuerTrustNotEvaluated,
+	// so keeping this as a plain err != nil check -- rather than special
+	// casing on trustStatus -- is what enforces that refusal. No
+	// IssuerTrustAnchors is supplied here: an arbitrary external issuer has
+	// no IACA root this wallet can know in advance, so an mdoc import always
+	// reports IssuerTrustNotEvaluated and is refused by this same check.
+	if trustStatus, err := formatHandler.ValidateIssuerSignature(vc.CredentialValidationInput{
 		Credential:       strings.TrimSpace(credential),
 		ParsedCredential: parsedCredential,
 		IssuerKeys:       issuerKeys,
 		HTTPClient:       s.httpClient,
 	}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate issuer signature (issuer_trust=%s): %w", trustStatus, err)
 	}
 	return parsedCredential, nil
 }

--- a/backend/cmd/walletharness/oid4vci_external.go
+++ b/backend/cmd/walletharness/oid4vci_external.go
@@ -119,11 +119,25 @@ type pendingOID4VCIAuthState struct {
 
 const oid4vciAuthorizationStateTTL = 15 * time.Minute
 
+// maxCredentialImportBodyBytes caps the request body for handleAPIImport,
+// the HTTP entry point through which a caller can paste an arbitrary
+// credential directly (apiImportRequest.Credential) rather than one this
+// server fetched itself from a negotiated OID4VCI credential endpoint. Per
+// internal/cose's decModeUntrusted, this is one of the two externally-supplied
+// credential surfaces (the other is the Looking Glass decode endpoint);
+// enforcing the cap here, before the body is buffered, keeps it consistent
+// with that surface rather than relying solely on decodeJSONBody's general
+// 1 MiB safety net. 64 KiB comfortably covers a real mDL or SD-JWT VC
+// (including one carrying a portrait image), well above anything this
+// project issues.
+const maxCredentialImportBodyBytes = 64 * 1024
+
 func (s *walletHarnessServer) handleAPIImport(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
 		return
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxCredentialImportBodyBytes)
 
 	var req apiImportRequest
 	if err := decodeJSONBody(r, &req); err != nil {

--- a/backend/cmd/walletharness/oid4vci_external_test.go
+++ b/backend/cmd/walletharness/oid4vci_external_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -74,6 +77,39 @@ func TestIssueFromExternalIssuerRequiresTxCode(t *testing.T) {
 	}
 	if apiErr.Fields["tx_code_required"] != true {
 		t.Fatalf("expected tx_code_required field in error")
+	}
+}
+
+// TestValidateImportedCredentialRefusesNotEvaluatedMdoc pins the A3c item 4
+// trust boundary: validateImportedCredential accepts arbitrary pasted or
+// externally-fetched credentials, and before mso_mdoc registration an mdoc
+// import failed at parse. After registration it parses successfully, and
+// this wallet supplies no IssuerTrustAnchors for an arbitrary external
+// issuer's mdoc -- so ValidateIssuerSignature reports IssuerTrustNotEvaluated.
+// That must refuse the import exactly like a checked failure, never fall
+// through as an accepted-but-unverified credential.
+func TestValidateImportedCredentialRefusesNotEvaluatedMdoc(t *testing.T) {
+	deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := &walletHarnessServer{deviceKey: deviceKey, httpClient: http.DefaultClient}
+	credential := issueMdocBoundTo(t, server, &deviceKey.PublicKey)
+
+	// issuerMetadata and authorizationServerMetadata are both nil, and the
+	// parsed mdoc carries no Issuer claim (mdoc has no JWT-style iss), so
+	// this exercises exactly the "arbitrary external issuer, no trust
+	// anchor available" path A3c item 4 describes -- not a resolvable-but-
+	// unresolved JWKS lookup.
+	parsed, err := server.validateImportedCredential(context.Background(), credential, "mso_mdoc", nil, nil, "")
+	if err == nil {
+		t.Fatalf("validateImportedCredential accepted an mdoc credential with no issuer trust anchor; parsed=%+v", parsed)
+	}
+	if parsed != nil {
+		t.Fatalf("validateImportedCredential returned a non-nil parsed credential alongside a refusal error")
+	}
+	if !strings.Contains(err.Error(), "issuer_trust=not_evaluated") {
+		t.Fatalf("expected refusal to name issuer_trust=not_evaluated, got: %v", err)
 	}
 }
 

--- a/backend/internal/core/server.go
+++ b/backend/internal/core/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ParleSec/ProtocolSoup/internal/lookingglass"
 	"github.com/ParleSec/ProtocolSoup/internal/palette"
 	"github.com/ParleSec/ProtocolSoup/internal/plugin"
+	"github.com/ParleSec/ProtocolSoup/internal/vc"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
@@ -99,6 +100,7 @@ func (s *Server) setupRouter() {
 		if s.lookingGlass != nil {
 			r.Route("/lookingglass", func(r chi.Router) {
 				r.Post("/decode", s.handleDecodeToken)
+				r.Post("/decode/credential", s.handleDecodeCredential)
 				r.Get("/sessions", s.handleListSessions)
 				r.Get("/sessions/{id}", s.handleGetSession)
 			})
@@ -457,6 +459,178 @@ func (s *Server) handleDecodeToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, decoded)
+}
+
+// maxCredentialDecodeBodyBytes caps the request body for
+// POST /lookingglass/decode/credential, mirroring the external-import cap in
+// cmd/walletharness/oid4vci_external.go. This is one of the two HTTP entry
+// points the A2 hardening rule names: every path that accepts an
+// externally-supplied credential gets a body cap enforced before the
+// request is buffered, in addition to the CBOR-specific decode limits
+// vc.MSOMdocFormat.ParseCredential applies unconditionally further down the
+// call chain.
+const maxCredentialDecodeBodyBytes = 64 * 1024
+
+// DecodeCredentialRequest is the request body for
+// POST /lookingglass/decode/credential.
+type DecodeCredentialRequest struct {
+	Credential string `json:"credential"`
+}
+
+// namespaceDisclosureCountsResponse is the wire form of
+// vc.NamespaceDisclosureCounts.
+type namespaceDisclosureCountsResponse struct {
+	CommittedCount int `json:"committed_count"`
+	PresentCount   int `json:"present_count"`
+}
+
+// selectiveDisclosureResponse is the wire form of vc.SelectiveDisclosureSummary.
+type selectiveDisclosureResponse struct {
+	Mechanism                       string                                       `json:"mechanism"`
+	CommittedCount                  int                                          `json:"committed_count"`
+	CommittedCountIsExact           bool                                         `json:"committed_count_is_exact"`
+	PresentCount                    int                                          `json:"present_count"`
+	LifecycleStage                  string                                       `json:"lifecycle_stage"`
+	DigestAlgorithm                 string                                       `json:"digest_algorithm,omitempty"`
+	PerNamespace                    map[string]namespaceDisclosureCountsResponse `json:"per_namespace,omitempty"`
+	HasUnrepresentedDisclosureForms bool                                         `json:"has_unrepresented_disclosure_forms"`
+}
+
+// credentialAssuranceResponse is the wire form of vc.CredentialAssurance. It
+// never collapses to a single validity flag: IssuerTrust is the tri-state
+// string ("verified" / "failed" / "not_evaluated") from
+// vc.IssuerTrustStatus.String(), and DigestsConsistentWithMSO is absent
+// entirely (omitted, not false) for every format except mso_mdoc. Per
+// vc.MdocDigestsConsistentWithMSO's doc comment, that field proves internal
+// consistency between the presented items and the credential's own MSO, not
+// authenticity of the MSO -- callers must not rename or relabel it as
+// "verified" or "ok".
+type credentialAssuranceResponse struct {
+	IssuerTrust              string `json:"issuer_trust"`
+	IssuerTrustDetail        string `json:"issuer_trust_detail,omitempty"`
+	DigestsConsistentWithMSO *bool  `json:"digests_consistent_with_mso,omitempty"`
+	DigestConsistencyDetail  string `json:"digest_consistency_detail,omitempty"`
+}
+
+// credentialEvidenceResponse is the wire form of vc.CredentialEvidence.
+// IssuedAt/ExpiresAt are omitted entirely (not sent as a zero-value
+// timestamp) when the source credential carried no corresponding claim --
+// see vc.CredentialEvidence's doc comment on why this must never be
+// back-filled.
+type credentialEvidenceResponse struct {
+	Format              string                       `json:"format,omitempty"`
+	VCT                 string                       `json:"vct,omitempty"`
+	Doctype             string                       `json:"doctype,omitempty"`
+	CredentialTypes     []string                     `json:"credential_types,omitempty"`
+	FullClaims          map[string]interface{}       `json:"full_claims,omitempty"`
+	DisclosedClaims     map[string]interface{}       `json:"disclosed_claims,omitempty"`
+	SelectiveDisclosure *selectiveDisclosureResponse `json:"selective_disclosure,omitempty"`
+	IssuedAt            string                       `json:"issued_at,omitempty"`
+	ExpiresAt           string                       `json:"expires_at,omitempty"`
+}
+
+// decodeCredentialResponse is the full response body for
+// POST /lookingglass/decode/credential: the shared evidence plus the
+// assurance envelope, kept as distinct top-level objects so a client cannot
+// merge "what this artifact contains" and "what has been checked about it"
+// into one register by accident.
+type decodeCredentialResponse struct {
+	Evidence  credentialEvidenceResponse  `json:"evidence"`
+	Assurance credentialAssuranceResponse `json:"assurance"`
+}
+
+func newSelectiveDisclosureResponse(summary *vc.SelectiveDisclosureSummary) *selectiveDisclosureResponse {
+	if summary == nil {
+		return nil
+	}
+	var perNamespace map[string]namespaceDisclosureCountsResponse
+	if len(summary.PerNamespace) > 0 {
+		perNamespace = make(map[string]namespaceDisclosureCountsResponse, len(summary.PerNamespace))
+		for ns, counts := range summary.PerNamespace {
+			perNamespace[ns] = namespaceDisclosureCountsResponse{
+				CommittedCount: counts.CommittedCount,
+				PresentCount:   counts.PresentCount,
+			}
+		}
+	}
+	return &selectiveDisclosureResponse{
+		Mechanism:                       summary.Mechanism,
+		CommittedCount:                  summary.CommittedCount,
+		CommittedCountIsExact:           summary.CommittedCountIsExact,
+		PresentCount:                    summary.PresentCount,
+		LifecycleStage:                  string(summary.LifecycleStage),
+		DigestAlgorithm:                 summary.DigestAlgorithm,
+		PerNamespace:                    perNamespace,
+		HasUnrepresentedDisclosureForms: summary.HasUnrepresentedDisclosureForms,
+	}
+}
+
+func formatCredentialTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func newDecodeCredentialResponse(result *vc.CredentialInspectionResult) decodeCredentialResponse {
+	return decodeCredentialResponse{
+		Evidence: credentialEvidenceResponse{
+			Format:              result.Evidence.Format,
+			VCT:                 result.Evidence.VCT,
+			Doctype:             result.Evidence.Doctype,
+			CredentialTypes:     result.Evidence.CredentialTypes,
+			FullClaims:          result.Evidence.FullClaims,
+			DisclosedClaims:     result.Evidence.DisclosedClaims,
+			SelectiveDisclosure: newSelectiveDisclosureResponse(result.Evidence.SelectiveDisclosure),
+			IssuedAt:            formatCredentialTimestamp(result.Evidence.IssuedAt),
+			ExpiresAt:           formatCredentialTimestamp(result.Evidence.ExpiresAt),
+		},
+		Assurance: credentialAssuranceResponse{
+			IssuerTrust:              result.Assurance.IssuerTrust.String(),
+			IssuerTrustDetail:        result.Assurance.IssuerTrustDetail,
+			DigestsConsistentWithMSO: result.Assurance.DigestsConsistentWithMSO,
+			DigestConsistencyDetail:  result.Assurance.DigestConsistencyDetail,
+		},
+	}
+}
+
+// handleDecodeCredential is the sibling of handleDecodeToken for credentials
+// rather than bearer/DPoP JWTs: it decodes a pasted credential of any
+// registered vc.CredentialFormat (including mso_mdoc) into the same shared
+// evidence shape BuildCredentialEvidence produces for issuance and
+// verification, wrapped in an assurance envelope that reports issuer trust
+// and (mdoc only) digest consistency honestly rather than as a blanket
+// validity flag. See vc.InspectCredential.
+func (s *Server) handleDecodeCredential(w http.ResponseWriter, r *http.Request) {
+	if s.lookingGlass == nil {
+		writeError(w, http.StatusServiceUnavailable, "Looking Glass is disabled")
+		return
+	}
+
+	// This endpoint accepts a pasted credential from any issuer, so it is
+	// one of the two externally-supplied-credential HTTP entry points the
+	// A2 hardening rule covers (the other is walletharness's external
+	// import). Cap the body before it is buffered at all.
+	r.Body = http.MaxBytesReader(w, r.Body, maxCredentialDecodeBodyBytes)
+
+	var req DecodeCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	credential := strings.TrimSpace(req.Credential)
+	if credential == "" {
+		writeError(w, http.StatusBadRequest, "credential is required")
+		return
+	}
+
+	result, err := vc.InspectCredential(credential)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, newDecodeCredentialResponse(result))
 }
 
 func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/cose/cbor.go
+++ b/backend/internal/cose/cbor.go
@@ -43,6 +43,14 @@ const (
 	tagFullDate uint64 = 1004
 )
 
+// TagEncodedCBOR exports tagEncodedCBOR (CBOR tag 24) for callers that need to
+// recognise a tag-24 wrapper surviving a generic (interface{}) decode as a
+// cbor.Tag, rather than through the typed DecodeTagged24 path. mdoc's
+// untrusted-CBOR depth gate is the current caller: it decodes into `any` to
+// enforce limits and must recurse into tag-24 content, so it needs the tag
+// number without hardcoding the RFC 8949 Section 3.4.5.1 value itself.
+const TagEncodedCBOR = tagEncodedCBOR
+
 // RawCBOR is pre-encoded CBOR that is embedded verbatim during marshaling
 // rather than re-encoded. It is an alias of fxamacker's RawMessage. mdoc needs
 // this to carry already-encoded items (the tag-24 IssuerSignedItemBytes and the
@@ -68,8 +76,28 @@ var (
 
 	// decMode decodes CBOR with the conservative options COSE expects:
 	// duplicate map keys rejected, indefinite-length items rejected, and
-	// integers decoded to int64 so COSE labels compare cleanly.
+	// integers decoded to int64 so COSE labels compare cleanly. It has no
+	// explicit MaxNestedLevels/MaxArrayElements/MaxMapPairs, so fxamacker's
+	// generous defaults apply (131072 elements). That is fine here: decMode is
+	// reserved for CBOR the platform itself produced or received over an
+	// already-verified wire path (mdoc.DecodeDeviceResponse and
+	// mdoc.DecodeIssuerSigned called directly, not through the vc registry),
+	// where tightening the limits risks rejecting a legitimate credential for
+	// no security benefit.
 	decMode cbor.DecMode
+
+	// decModeUntrusted decodes CBOR from externally-supplied credentials --
+	// pasted into the Looking Glass inspector or imported from a third-party
+	// issuer -- which is an attacker-controlled parse surface that decMode's
+	// generous defaults were never meant to withstand. Same base options as
+	// decMode, plus explicit MaxNestedLevels (16), MaxArrayElements (1024),
+	// and MaxMapPairs (1024) ceilings, each roughly two orders of magnitude
+	// above what a real ISO/IEC 18013-5 mDL uses. See mdoc.CheckUntrustedCBOR
+	// for the tag-24 recursion this mode alone cannot provide: fxamacker
+	// enforces MaxNestedLevels per Unmarshal call, so a nesting bomb hidden
+	// inside a tag-24-wrapped byte string (mdoc's IssuerSignedItemBytes and
+	// MobileSecurityObjectBytes) is invisible to a single outer decode.
+	decModeUntrusted cbor.DecMode
 )
 
 func init() {
@@ -106,6 +134,15 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("cose: build CBOR decoder: %v", err))
 	}
+
+	untrustedOpts := decOpts
+	untrustedOpts.MaxNestedLevels = 16
+	untrustedOpts.MaxArrayElements = 1024
+	untrustedOpts.MaxMapPairs = 1024
+	decModeUntrusted, err = untrustedOpts.DecMode()
+	if err != nil {
+		panic(fmt.Sprintf("cose: build untrusted CBOR decoder: %v", err))
+	}
 }
 
 // MarshalDeterministic encodes v as canonical CBOR for the mdoc data model
@@ -117,8 +154,21 @@ func MarshalDeterministic(v any) ([]byte, error) {
 }
 
 // Unmarshal decodes CBOR data into v using the conservative COSE decode mode.
+// Reserved for CBOR the platform itself produced or received over an
+// already-verified wire path; see UnmarshalUntrusted for externally-supplied
+// credentials.
 func Unmarshal(data []byte, v any) error {
 	return decMode.Unmarshal(data, v)
+}
+
+// UnmarshalUntrusted decodes CBOR data into v using decModeUntrusted: the same
+// conservative COSE options as Unmarshal, plus explicit nesting depth (16),
+// array element (1024), and map pair (1024) ceilings. Use this only for CBOR
+// from an externally-supplied credential (pasted into an inspector, or
+// imported from a third-party issuer) rather than CBOR the platform itself
+// produced or received over an already-verified wire path.
+func UnmarshalUntrusted(data []byte, v any) error {
+	return decModeUntrusted.Unmarshal(data, v)
 }
 
 // TagEncode encodes v as canonical CBOR and wraps the resulting bytes in a CBOR

--- a/backend/internal/crypto/keys_test.go
+++ b/backend/internal/crypto/keys_test.go
@@ -37,6 +37,76 @@ func TestThumbprintBytesSpecVector(t *testing.T) {
 	}
 }
 
+// TestThumbprintSpecVectors pins Thumbprint() (the base64url string form,
+// distinct from ThumbprintBytes above) against RFC 7638/7515/8037 known-
+// answer vectors for all three key types this codebase mints: RSA, EC, and
+// OKP. frontend/scripts/verify-jwk-thumbprint.mjs pins its jwkThumbprint()
+// TypeScript port against the identical three vectors and identical
+// expected constants, so this test and that script keep the Go and
+// TypeScript implementations pinned to the same answers rather than each
+// silently drifting to a self-consistent-but-wrong value. If either
+// implementation's canonicalization or encoding regresses, only the vector
+// for the affected key type fails -- not the other two -- pointing
+// directly at which kty branch broke.
+func TestThumbprintSpecVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		jwk  JWK
+		want string
+	}{
+		{
+			// RFC 7638 Section 3.1's own worked example; want is the value
+			// the RFC itself publishes for this exact key.
+			name: "RSA (RFC 7638 §3.1)",
+			jwk: JWK{
+				Kty: "RSA",
+				N:   "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+				E:   "AQAB",
+			},
+			want: "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+		},
+		{
+			name: "EC P-256 (RFC 7515 Appendix A.3 public key)",
+			jwk: JWK{
+				Kty: "EC",
+				Crv: "P-256",
+				X:   "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+				Y:   "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+			},
+			want: "oKIywvGUpTVTyxMQ3bwIIeQUudfr_CkLMjCE19ECD-U",
+		},
+		{
+			name: "OKP Ed25519 (RFC 8037 Appendix A.1 public key)",
+			jwk: JWK{
+				Kty: "OKP",
+				Crv: "Ed25519",
+				X:   "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+			},
+			want: "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.jwk.Thumbprint(); got != tt.want {
+				t.Fatalf("Thumbprint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestThumbprintUnsupportedKtyReturnsEmptyString pins the "cannot compute"
+// contract jwkThumbprint in crypto.ts is documented to mirror: an
+// unsupported kty must return "" rather than guess or panic, so a caller
+// can render "cannot compute for this key type" as its own state distinct
+// from mismatch.
+func TestThumbprintUnsupportedKtyReturnsEmptyString(t *testing.T) {
+	jwk := JWK{Kty: "oct", K: "GawgguFyGrWKav7AX4VKUg"}
+	if got := jwk.Thumbprint(); got != "" {
+		t.Fatalf("Thumbprint() for unsupported kty %q = %q, want empty string", jwk.Kty, got)
+	}
+}
+
 func TestKeySetExposesEd25519JWK(t *testing.T) {
 	keySet, err := NewKeySet()
 	if err != nil {

--- a/backend/internal/gateway/gateway.go
+++ b/backend/internal/gateway/gateway.go
@@ -166,6 +166,11 @@ func (g *Gateway) Router() http.Handler {
 		r.Post("/protocols/{id}/demo/{flow}", g.handleStartDemo)
 
 		r.Post("/lookingglass/decode", g.handleDecodeToken)
+		// handleDecodeToken is a generic byte-forwarding proxy (it forwards
+		// r.URL.Path verbatim to whichever upstream responds), so the same
+		// handler is correct for this sibling route with no new code: the
+		// path-specific decode logic lives entirely upstream in internal/core.
+		r.Post("/lookingglass/decode/credential", g.handleDecodeToken)
 		r.Get("/lookingglass/sessions", g.handleListSessions)
 		r.Get("/lookingglass/sessions/{id}", g.handleGetSession)
 

--- a/backend/internal/mdoc/disclosure.go
+++ b/backend/internal/mdoc/disclosure.go
@@ -1,6 +1,54 @@
 package mdoc
 
-import "fmt"
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// JSONSafeValue converts a CBOR-decoded mdoc element value (as returned by
+// CollectDisclosedElements) into a value encoding/json can marshal. Generic
+// CBOR decoding yields map[any]any for maps, cbor.Tag for tagged values such
+// as full-date (tag 1004, used by mDL birth_date/issue_date/expiry_date), and
+// []byte for byte strings. encoding/json cannot marshal map[any]any (a
+// non-string map key) and renders cbor.Tag as an opaque struct, so an
+// un-normalized mDL element (e.g. the nested driving_privileges array) would
+// fail to encode. Normalizing here keeps a disclosed element
+// JSON-serializable while preserving the real disclosed value.
+func JSONSafeValue(value any) any {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case cbor.Tag:
+		return JSONSafeValue(typed.Content)
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, val := range typed {
+			out[fmt.Sprintf("%v", key)] = JSONSafeValue(val)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, val := range typed {
+			out[key] = JSONSafeValue(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, val := range typed {
+			out[i] = JSONSafeValue(val)
+		}
+		return out
+	case []byte:
+		return base64.RawURLEncoding.EncodeToString(typed)
+	case time.Time:
+		return typed.UTC().Format(time.RFC3339)
+	default:
+		return typed
+	}
+}
 
 // Disclose returns an IssuerSigned carrying only the requested
 // elementIdentifiers per namespace, with issuerAuth unchanged. Selective

--- a/backend/internal/mdoc/issuersigned.go
+++ b/backend/internal/mdoc/issuersigned.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	intcose "github.com/ParleSec/ProtocolSoup/internal/cose"
+	"github.com/fxamacker/cbor/v2"
 )
 
 const (
@@ -115,6 +116,125 @@ func DecodeIssuerSigned(data []byte) (IssuerSigned, error) {
 		}
 	}
 	return out, nil
+}
+
+// maxUntrustedNestedLevels mirrors decModeUntrusted's MaxNestedLevels in
+// internal/cose. Duplicated here (rather than exported from cose) because
+// this gate enforces the cumulative depth *across* tag-24 recursion, which
+// cose's per-Unmarshal-call limit cannot see: cose only bounds one decode
+// call at a time, and a nesting bomb split across a tag-24 boundary is two
+// calls. This constant is the budget the two calls must share.
+const maxUntrustedNestedLevels = 16
+
+// CheckUntrustedCBOR decodes externally-supplied mdoc CBOR under the hardened
+// untrusted limits (cose.UnmarshalUntrusted: MaxNestedLevels 16,
+// MaxArrayElements 1024, MaxMapPairs 1024) and returns the observed nesting
+// depth alongside any error. MSOMdocFormat.ParseCredential calls this
+// unconditionally, before any typed decode, so every externally-supplied
+// credential that reaches the registry inherits it; the wire verification
+// paths (mdoc.DecodeDeviceResponse, mdoc.DecodeIssuerSigned called directly)
+// are untouched and keep the shared decMode.
+//
+// It recurses into CBOR tag 24 (Encoded CBOR data item) content because mdoc
+// wraps IssuerSignedItemBytes and MobileSecurityObjectBytes in tag 24 as byte
+// strings: a single outer decode sees each as an opaque bstr and counts none
+// of its internal depth, so a nesting bomb placed inside an
+// IssuerSignedItemBytes would pass an outer-only check and then be decoded by
+// the typed path under the shared (loose) decode mode. The outer nesting
+// level is carried into the recursive decode's depth count, so tag-24
+// wrapping cannot be used to reset the budget.
+//
+// The decode is into `any` solely to enforce the limits; the decoded value is
+// discarded once measured. This materialises maps and slices for the whole
+// document -- it is not allocation-free -- but the cost is bounded by the
+// same limits it enforces and by the caller's byte cap, and it is paid only
+// on externally-supplied credentials.
+func CheckUntrustedCBOR(data []byte) (int, error) {
+	return checkUntrustedCBORDepth(data, 0)
+}
+
+func checkUntrustedCBORDepth(data []byte, outerDepth int) (int, error) {
+	var decoded any
+	if err := intcose.UnmarshalUntrusted(data, &decoded); err != nil {
+		return outerDepth, fmt.Errorf("mdoc: untrusted CBOR decode: %w", err)
+	}
+	return measureUntrustedCBORDepth(decoded, outerDepth)
+}
+
+// measureUntrustedCBORDepth walks a value already decoded by
+// cose.UnmarshalUntrusted and returns the deepest nesting level reached,
+// recursing into tag-24 byte-string content with depth carried forward.
+// Counting follows fxamacker's own MaxNestedLevels convention: every map,
+// array, and tag adds one level; leaf scalars (strings, numbers, bools, plain
+// byte strings) add none.
+func measureUntrustedCBORDepth(value any, depth int) (int, error) {
+	switch typed := value.(type) {
+	case cbor.Tag:
+		next := depth + 1
+		if next > maxUntrustedNestedLevels {
+			return next, fmt.Errorf("mdoc: untrusted CBOR nesting depth %d exceeds maximum %d", next, maxUntrustedNestedLevels)
+		}
+		if typed.Number == intcose.TagEncodedCBOR {
+			if innerBytes, ok := typed.Content.([]byte); ok {
+				return checkUntrustedCBORDepth(innerBytes, next)
+			}
+		}
+		return measureUntrustedCBORDepth(typed.Content, next)
+	case map[any]any:
+		deepest := depth + 1
+		if deepest > maxUntrustedNestedLevels {
+			return deepest, fmt.Errorf("mdoc: untrusted CBOR nesting depth %d exceeds maximum %d", deepest, maxUntrustedNestedLevels)
+		}
+		for key, val := range typed {
+			keyDepth, err := measureUntrustedCBORDepth(key, depth+1)
+			if err != nil {
+				return keyDepth, err
+			}
+			if keyDepth > deepest {
+				deepest = keyDepth
+			}
+			valDepth, err := measureUntrustedCBORDepth(val, depth+1)
+			if err != nil {
+				return valDepth, err
+			}
+			if valDepth > deepest {
+				deepest = valDepth
+			}
+		}
+		return deepest, nil
+	case map[string]any:
+		deepest := depth + 1
+		if deepest > maxUntrustedNestedLevels {
+			return deepest, fmt.Errorf("mdoc: untrusted CBOR nesting depth %d exceeds maximum %d", deepest, maxUntrustedNestedLevels)
+		}
+		for _, val := range typed {
+			valDepth, err := measureUntrustedCBORDepth(val, depth+1)
+			if err != nil {
+				return valDepth, err
+			}
+			if valDepth > deepest {
+				deepest = valDepth
+			}
+		}
+		return deepest, nil
+	case []any:
+		deepest := depth + 1
+		if deepest > maxUntrustedNestedLevels {
+			return deepest, fmt.Errorf("mdoc: untrusted CBOR nesting depth %d exceeds maximum %d", deepest, maxUntrustedNestedLevels)
+		}
+		for _, element := range typed {
+			elementDepth, err := measureUntrustedCBORDepth(element, depth+1)
+			if err != nil {
+				return elementDepth, err
+			}
+			if elementDepth > deepest {
+				deepest = elementDepth
+			}
+		}
+		return deepest, nil
+	default:
+		return depth, nil
+	}
 }
 
 // BuildIssuerNameSpaces encodes a map of namespace -> items into

--- a/backend/internal/mdoc/issuersigned_test.go
+++ b/backend/internal/mdoc/issuersigned_test.go
@@ -1,0 +1,163 @@
+package mdoc
+
+import (
+	"fmt"
+	"testing"
+
+	intcose "github.com/ParleSec/ProtocolSoup/internal/cose"
+	"github.com/fxamacker/cbor/v2"
+)
+
+// nestedArrayValue builds a value nested `depth` levels deep in single-
+// element CBOR arrays, bottoming out in a scalar leaf. measureUntrustedCBORDepth
+// counts each array as one level and the leaf as zero, so this produces an
+// exact, predictable depth for testing CheckUntrustedCBOR's limit.
+func nestedArrayValue(depth int) any {
+	if depth <= 0 {
+		return "leaf"
+	}
+	return []any{nestedArrayValue(depth - 1)}
+}
+
+func TestCheckUntrustedCBORAcceptsNestingWithinLimit(t *testing.T) {
+	// 8 mirrors the measured depth of a real issued mDL's deepest path (the
+	// driving_privileges element) -- see the MaxNestedLevels derivation this
+	// gate backs. A credential at that real-world depth must never be
+	// rejected by the hardened path.
+	const depth = 8
+	data, err := intcose.MarshalDeterministic(nestedArrayValue(depth))
+	if err != nil {
+		t.Fatalf("MarshalDeterministic: %v", err)
+	}
+
+	got, err := CheckUntrustedCBOR(data)
+	if err != nil {
+		t.Fatalf("CheckUntrustedCBOR rejected depth %d input, within the MaxNestedLevels=%d ceiling: %v", depth, maxUntrustedNestedLevels, err)
+	}
+	if got != depth {
+		t.Fatalf("CheckUntrustedCBOR depth = %d, want %d", got, depth)
+	}
+	if margin := maxUntrustedNestedLevels - got; margin <= 0 {
+		t.Fatalf("measured depth %d leaves no margin to MaxNestedLevels=%d", got, maxUntrustedNestedLevels)
+	}
+}
+
+func TestCheckUntrustedCBORRejectsDeepNesting(t *testing.T) {
+	data, err := intcose.MarshalDeterministic(nestedArrayValue(maxUntrustedNestedLevels + 4))
+	if err != nil {
+		t.Fatalf("MarshalDeterministic: %v", err)
+	}
+
+	if _, err := CheckUntrustedCBOR(data); err == nil {
+		t.Fatalf("CheckUntrustedCBOR accepted nesting %d levels deep, exceeding MaxNestedLevels=%d", maxUntrustedNestedLevels+4, maxUntrustedNestedLevels)
+	}
+}
+
+// TestCheckUntrustedCBORRejectsNestingBombInsideTag24 is the specific bypass
+// this gate exists to close. mdoc wraps IssuerSignedItemBytes and
+// MobileSecurityObjectBytes in CBOR tag 24, so a generic outer decode sees
+// each as an opaque byte string and never looks inside it. Here the outer
+// shell (10 array levels plus the tag itself, 11 total) and the tag-24
+// content (10 more array levels) are each, in isolation, comfortably under
+// MaxNestedLevels -- an outer-only check, or a recursive check that resets
+// the budget at the tag boundary instead of carrying it forward, would let
+// this through. Only cumulative accounting across the tag-24 boundary
+// (outer 11 + inner 10 = 21) catches it.
+func TestCheckUntrustedCBORRejectsNestingBombInsideTag24(t *testing.T) {
+	const outerDepth = 10
+	const innerDepth = 10
+
+	innerBytes, err := intcose.MarshalDeterministic(nestedArrayValue(innerDepth))
+	if err != nil {
+		t.Fatalf("MarshalDeterministic(inner): %v", err)
+	}
+
+	var value any = cbor.Tag{Number: intcose.TagEncodedCBOR, Content: innerBytes}
+	for i := 0; i < outerDepth; i++ {
+		value = []any{value}
+	}
+
+	// Sanity-check the test's own premise: the outer shell alone (treating
+	// the tag's content as an opaque leaf, i.e. what an outer-only decode
+	// would see) must stay under the limit, or this test would not be
+	// distinguishing cumulative accounting from a trivial single-shell
+	// rejection.
+	if outerShellDepth := outerDepth + 1; outerShellDepth >= maxUntrustedNestedLevels {
+		t.Fatalf("test setup invalid: outer shell alone (%d) must stay under MaxNestedLevels=%d for this test to prove anything", outerShellDepth, maxUntrustedNestedLevels)
+	}
+	if innerDepth >= maxUntrustedNestedLevels {
+		t.Fatalf("test setup invalid: inner content alone (%d) must stay under MaxNestedLevels=%d for this test to prove anything", innerDepth, maxUntrustedNestedLevels)
+	}
+
+	data, err := intcose.MarshalDeterministic(value)
+	if err != nil {
+		t.Fatalf("MarshalDeterministic(outer): %v", err)
+	}
+
+	if _, err := CheckUntrustedCBOR(data); err == nil {
+		t.Fatalf("CheckUntrustedCBOR accepted a nesting bomb hidden inside a tag-24 wrapper (outer %d + inner %d = %d, exceeding MaxNestedLevels=%d) -- the tag-24 recursion this gate exists to perform did not catch it", outerDepth, 1, innerDepth, maxUntrustedNestedLevels)
+	}
+}
+
+func TestCheckUntrustedCBORRejectsOversizedArray(t *testing.T) {
+	const oversized = 1025 // one past the 1024 MaxArrayElements ceiling
+	elements := make([]any, oversized)
+	for i := range elements {
+		elements[i] = i
+	}
+	data, err := intcose.MarshalDeterministic(elements)
+	if err != nil {
+		t.Fatalf("MarshalDeterministic: %v", err)
+	}
+
+	if _, err := CheckUntrustedCBOR(data); err == nil {
+		t.Fatalf("CheckUntrustedCBOR accepted a %d-element array, exceeding MaxArrayElements=1024", oversized)
+	}
+}
+
+func TestCheckUntrustedCBORRejectsOversizedMap(t *testing.T) {
+	const oversized = 1025 // one past the 1024 MaxMapPairs ceiling
+	m := make(map[string]any, oversized)
+	for i := 0; i < oversized; i++ {
+		m[fmt.Sprintf("k%d", i)] = i
+	}
+	data, err := intcose.MarshalDeterministic(m)
+	if err != nil {
+		t.Fatalf("MarshalDeterministic: %v", err)
+	}
+
+	if _, err := CheckUntrustedCBOR(data); err == nil {
+		t.Fatalf("CheckUntrustedCBOR accepted a %d-pair map, exceeding MaxMapPairs=1024", oversized)
+	}
+}
+
+// TestCheckUntrustedCBORRejectsAtSizeCapNotTruncation is a narrow check that
+// the gate itself makes no attempt to truncate or partially accept
+// oversized input -- it must fail outright, with depth/decoding abandoned,
+// rather than silently processing a truncated prefix. The HTTP-level byte
+// cap (http.MaxBytesReader) is a separate, transport-level control; this
+// only pins the decode gate's own behaviour on oversized collections.
+func TestCheckUntrustedCBORRejectsAtSizeCapNotTruncation(t *testing.T) {
+	const oversized = 2048
+	elements := make([]any, oversized)
+	for i := range elements {
+		elements[i] = "x"
+	}
+	data, err := intcose.MarshalDeterministic(elements)
+	if err != nil {
+		t.Fatalf("MarshalDeterministic: %v", err)
+	}
+
+	depth, err := CheckUntrustedCBOR(data)
+	if err == nil {
+		t.Fatalf("CheckUntrustedCBOR accepted a %d-element array outright instead of rejecting it", oversized)
+	}
+	// A truncating implementation would report a plausible depth (e.g. 1,
+	// for "array of scalars") rather than failing before depth is
+	// established at all. checkUntrustedCBORDepth returns outerDepth (0 at
+	// the top level) on a decode error, which is the "abandoned, not
+	// truncated" signal this test pins.
+	if depth != 0 {
+		t.Fatalf("CheckUntrustedCBOR returned depth %d alongside a decode error; want 0 (decode abandoned, not partially measured)", depth)
+	}
+}

--- a/backend/internal/protocols/oid4vci/mdoc_issuance_test.go
+++ b/backend/internal/protocols/oid4vci/mdoc_issuance_test.go
@@ -290,6 +290,196 @@ func TestMsoMdocAuthorizationCodeIssuance(t *testing.T) {
 	}
 }
 
+// TestMsoMdocIssuedCredentialNestingDepthWithinHardenedCeiling measures the
+// actual CBOR nesting depth of a real, production-shaped issued mDL --
+// including driving_privileges, the one element with array-of-maps-of-
+// tagged-full-dates structure, which is the deepest path in
+// buildMDLIssuerSignedItems -- against mdoc.CheckUntrustedCBOR's hardened
+// gate. This exists because a prior revision of the MaxNestedLevels=16
+// derivation stated a depth (~8) that did not match the gate's own
+// cumulative tag-24 accounting once that accounting was corrected; this
+// test replaces "asserted in a comment" with "measured against a real
+// issued credential", and fails if a future change to the mDL element set
+// or its encoding pushes the real depth close enough to 16 that the margin
+// this ceiling assumes no longer holds.
+func TestMsoMdocIssuedCredentialNestingDepthWithinHardenedCeiling(t *testing.T) {
+	server, _, _ := newMdocTestEnv(t)
+	defer server.Close()
+
+	offerResp := postJSON(t, server.URL+"/oid4vci/offers/pre-authorized", map[string]interface{}{
+		"credential_configuration_ids": []string{mdocConfigurationID},
+	})
+	assertStatus(t, offerResp, http.StatusCreated)
+	offerPayload := decodeJSONMap(t, offerResp)
+	walletSubject := asString(t, offerPayload["wallet_subject"])
+
+	tokenResp, err := http.PostForm(server.URL+"/oid4vci/token", url.Values{
+		"grant_type":          {"urn:ietf:params:oauth:grant-type:pre-authorized_code"},
+		"pre-authorized_code": {asString(t, offerPayload["pre_authorized_code"])},
+	})
+	if err != nil {
+		t.Fatalf("token request failed: %v", err)
+	}
+	assertStatus(t, tokenResp, http.StatusOK)
+	tokenPayload := decodeJSONMap(t, tokenResp)
+	accessToken := asString(t, tokenPayload["access_token"])
+	cNonce := asString(t, tokenPayload["c_nonce"])
+
+	deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate device key: %v", err)
+	}
+	proofJWT := createECDeviceProof(t, deviceKey, cNonce, walletSubject, testIssuerAudience)
+
+	credentialResp := postJSONWithHeaders(
+		t,
+		server.URL+"/oid4vci/credential",
+		map[string]interface{}{
+			"credential_configuration_id": mdocConfigurationID,
+			"format":                      "mso_mdoc",
+			"proofs": []map[string]interface{}{
+				{"proof_type": "jwt", "jwt": proofJWT},
+			},
+		},
+		map[string]string{"Authorization": "Bearer " + accessToken},
+	)
+	assertStatus(t, credentialResp, http.StatusOK)
+	credentialPayload := decodeJSONMap(t, credentialResp)
+	credential := asString(t, credentialPayload["credential"])
+	if credential == "" {
+		t.Fatal("expected non-empty mso_mdoc credential")
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(credential)
+	if err != nil {
+		t.Fatalf("base64url decode credential: %v", err)
+	}
+
+	depth, err := mdoc.CheckUntrustedCBOR(raw)
+	if err != nil {
+		t.Fatalf("mdoc.CheckUntrustedCBOR rejected a real production-shaped issued mDL: %v", err)
+	}
+	t.Logf("measured nesting depth of a real issued mDL (11 elements incl. driving_privileges): %d", depth)
+
+	// 16 mirrors mdoc.maxUntrustedNestedLevels (internal/mdoc/issuersigned.go),
+	// which is unexported; duplicated here as a literal rather than exported
+	// solely for this test's convenience.
+	const maxUntrustedNestedLevels = 16
+	if depth <= 0 {
+		t.Fatalf("measured depth %d is non-positive; a real IssuerSigned structure must nest at least a few levels deep", depth)
+	}
+	if depth >= maxUntrustedNestedLevels {
+		t.Fatalf("measured depth %d of a real issued mDL leaves no margin under MaxNestedLevels=%d", depth, maxUntrustedNestedLevels)
+	}
+	if margin := maxUntrustedNestedLevels - depth; margin < 4 {
+		t.Fatalf("measured depth %d leaves only %d levels of margin under MaxNestedLevels=%d, tighter than the intended headroom", depth, margin, maxUntrustedNestedLevels)
+	}
+}
+
+// TestMsoMdocIssuedCredentialValidateIssuerSignatureTriState exercises
+// vc.MSOMdocFormat.ValidateIssuerSignature's tri-state result against a real,
+// production-issued mDL (through the full HTTP issuance pipeline, not a
+// hand-assembled fixture), confirming the same trust outcomes the internal/vc
+// unit tests pin also hold end-to-end: verified against the issuing plugin's
+// own IACA root, failed against an unrelated one, and not evaluated when no
+// trust anchor is supplied at all.
+func TestMsoMdocIssuedCredentialValidateIssuerSignatureTriState(t *testing.T) {
+	server, testPlugin, _ := newMdocTestEnv(t)
+	defer server.Close()
+
+	offerResp := postJSON(t, server.URL+"/oid4vci/offers/pre-authorized", map[string]interface{}{
+		"credential_configuration_ids": []string{mdocConfigurationID},
+	})
+	assertStatus(t, offerResp, http.StatusCreated)
+	offerPayload := decodeJSONMap(t, offerResp)
+	walletSubject := asString(t, offerPayload["wallet_subject"])
+
+	tokenResp, err := http.PostForm(server.URL+"/oid4vci/token", url.Values{
+		"grant_type":          {"urn:ietf:params:oauth:grant-type:pre-authorized_code"},
+		"pre-authorized_code": {asString(t, offerPayload["pre_authorized_code"])},
+	})
+	if err != nil {
+		t.Fatalf("token request failed: %v", err)
+	}
+	assertStatus(t, tokenResp, http.StatusOK)
+	tokenPayload := decodeJSONMap(t, tokenResp)
+	accessToken := asString(t, tokenPayload["access_token"])
+	cNonce := asString(t, tokenPayload["c_nonce"])
+
+	deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate device key: %v", err)
+	}
+	proofJWT := createECDeviceProof(t, deviceKey, cNonce, walletSubject, testIssuerAudience)
+
+	credentialResp := postJSONWithHeaders(
+		t,
+		server.URL+"/oid4vci/credential",
+		map[string]interface{}{
+			"credential_configuration_id": mdocConfigurationID,
+			"format":                      "mso_mdoc",
+			"proofs": []map[string]interface{}{
+				{"proof_type": "jwt", "jwt": proofJWT},
+			},
+		},
+		map[string]string{"Authorization": "Bearer " + accessToken},
+	)
+	assertStatus(t, credentialResp, http.StatusOK)
+	credentialPayload := decodeJSONMap(t, credentialResp)
+	credential := asString(t, credentialPayload["credential"])
+	if credential == "" {
+		t.Fatal("expected non-empty mso_mdoc credential")
+	}
+
+	registry := vc.DefaultCredentialFormatRegistry()
+	formatHandler, ok := registry.Lookup("mso_mdoc")
+	if !ok {
+		t.Fatalf("mso_mdoc format handler not found in registry")
+	}
+
+	t.Run("verified_against_issuing_plugin_trust_anchor", func(t *testing.T) {
+		trustStatus, err := formatHandler.ValidateIssuerSignature(vc.CredentialValidationInput{
+			Credential:         credential,
+			IssuerTrustAnchors: testPlugin.mdocPKI.TrustAnchors(),
+		})
+		if err != nil {
+			t.Fatalf("ValidateIssuerSignature(issuing plugin's own IACA root): %v", err)
+		}
+		if trustStatus != vc.IssuerTrustVerified {
+			t.Fatalf("trust status = %v, want IssuerTrustVerified", trustStatus)
+		}
+	})
+
+	t.Run("failed_against_unrelated_trust_anchor", func(t *testing.T) {
+		unrelatedPKI, err := mdoc.GenerateIssuerPKI(mdoc.DefaultPKIParams("https://unrelated-issuer.example/oid4vci"))
+		if err != nil {
+			t.Fatalf("GenerateIssuerPKI(unrelated): %v", err)
+		}
+		trustStatus, err := formatHandler.ValidateIssuerSignature(vc.CredentialValidationInput{
+			Credential:         credential,
+			IssuerTrustAnchors: unrelatedPKI.TrustAnchors(),
+		})
+		if err == nil {
+			t.Fatalf("ValidateIssuerSignature(unrelated IACA root) unexpectedly succeeded")
+		}
+		if trustStatus != vc.IssuerTrustFailed {
+			t.Fatalf("trust status = %v, want IssuerTrustFailed", trustStatus)
+		}
+	})
+
+	t.Run("not_evaluated_without_trust_anchor", func(t *testing.T) {
+		trustStatus, err := formatHandler.ValidateIssuerSignature(vc.CredentialValidationInput{
+			Credential: credential,
+		})
+		if err == nil {
+			t.Fatalf("ValidateIssuerSignature(no trust anchor) unexpectedly succeeded")
+		}
+		if trustStatus != vc.IssuerTrustNotEvaluated {
+			t.Fatalf("trust status = %v, want IssuerTrustNotEvaluated", trustStatus)
+		}
+	})
+}
+
 // TestMsoMdocRejectsNonECDeviceKey confirms an RSA proof key is rejected, since
 // mdoc device keys must be EC2/P-256.
 func TestMsoMdocRejectsNonECDeviceKey(t *testing.T) {

--- a/backend/internal/protocols/oid4vp/handlers.go
+++ b/backend/internal/protocols/oid4vp/handlers.go
@@ -1402,7 +1402,7 @@ func (p *Plugin) validatePresentedCredentialEnvelopes(
 			return nil, newVerifierPolicyError("credential_subject_mismatch", "presented credential subject mismatch", nil)
 		}
 
-		credentialEvidence, err := vc.BuildCredentialEvidence(rawCredential)
+		credentialEvidence, err := vc.BuildCredentialEvidence(rawCredential, vc.LifecycleStagePresented)
 		if err != nil {
 			return nil, newVerifierPolicyError("credential_malformed", "presented credential evidence could not be derived", err)
 		}

--- a/backend/internal/protocols/oid4vp/handlers.go
+++ b/backend/internal/protocols/oid4vp/handlers.go
@@ -1428,12 +1428,19 @@ func (p *Plugin) validatePresentedCredentialEnvelopes(
 		if strings.TrimSpace(storedRecord.IssuerJWK.Kty) != "" {
 			issuerKeys = append(issuerKeys, storedRecord.IssuerJWK)
 		}
-		if err := formatHandler.ValidateIssuerSignature(vc.CredentialValidationInput{
+		// Any non-Verified status carries a non-nil error (see
+		// vc.IssuerTrustStatus), so this keeps hard-failing on both a
+		// checked failure and an unevaluated signature exactly as it did
+		// before ValidateIssuerSignature grew a status return. This path
+		// verifies a *presented* credential against its issuance-time
+		// lineage, so unlike the decode endpoint it has no use for a
+		// lenient "unevaluated but shown anyway" outcome.
+		if trustStatus, err := formatHandler.ValidateIssuerSignature(vc.CredentialValidationInput{
 			Credential:       rawCredential,
 			ParsedCredential: parsedCredential,
 			IssuerKeys:       issuerKeys,
 		}); err != nil {
-			return nil, newVerifierPolicyError("credential_signature_invalid", "presented credential signature validation failed", err)
+			return nil, newVerifierPolicyError("credential_signature_invalid", fmt.Sprintf("presented credential signature validation failed (issuer_trust=%s)", trustStatus), err)
 		}
 		issuer := strings.TrimSpace(parsedCredential.Issuer)
 		if strings.TrimSpace(storedRecord.Issuer) != "" && strings.TrimSpace(issuer) != strings.TrimSpace(storedRecord.Issuer) {

--- a/backend/internal/vc/dcql.go
+++ b/backend/internal/vc/dcql.go
@@ -40,8 +40,15 @@ type DCQLTrustedAuthority struct {
 // MdocCredentialEvidence is the mdoc view of a presented credential for DCQL
 // matching: the issuer-verified doctype plus the disclosed element identifiers
 // per namespace. It is format-specific to mso_mdoc (ISO/IEC 18013-5) and is
-// supplied by the verifier after CollectDisclosedElements, keeping this matcher
-// free of any CBOR/COSE dependency.
+// supplied by the verifier after CollectDisclosedElements.
+//
+// This keeps the DCQL *matcher* free of any CBOR/COSE dependency -- it
+// consumes this already-decoded shape rather than raw IssuerSigned bytes --
+// which is narrower than saying the vc package itself has no CBOR
+// dependency. MSOMdocFormat in format.go imports internal/mdoc (and
+// therefore internal/cose) to register mso_mdoc as a CredentialFormat, so
+// that package-wide boundary no longer holds; what still holds is that this
+// matcher's own logic never decodes CBOR itself.
 type MdocCredentialEvidence struct {
 	Format string
 	// Doctype is the credential docType (the DCQL meta for mdoc), e.g.

--- a/backend/internal/vc/format.go
+++ b/backend/internal/vc/format.go
@@ -3,6 +3,7 @@ package vc
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -13,24 +14,66 @@ import (
 	"time"
 
 	intcrypto "github.com/ParleSec/ProtocolSoup/internal/crypto"
+	"github.com/ParleSec/ProtocolSoup/internal/mdoc"
 )
+
+// IssuerTrustStatus reports the outcome of ValidateIssuerSignature as a
+// tri-state rather than a binary pass/fail. A plain error return cannot
+// distinguish "checked the signature against real trust material and it did
+// not verify" from "no trust material was available to check against at
+// all" (no IACA root for an mdoc, no issuer JWKs for a JWT-based format) --
+// yet callers such as the credential decode endpoint (POST
+// /lookingglass/decode/credential) must report exactly that distinction to
+// the user rather than reconstructing it from context.
+//
+// The zero value is IssuerTrustNotEvaluated, so a status left unset by
+// mistake reads as "not evaluated" rather than as a false Verified.
+//
+// ValidateIssuerSignature returns a non-nil error for both IssuerTrustFailed
+// and IssuerTrustNotEvaluated, never only for IssuerTrustFailed. Every
+// existing "if err != nil { reject }" caller therefore keeps its current,
+// conservative behaviour unchanged by this signature growing a return value:
+// it continues to refuse both a checked failure and an unevaluated
+// signature. A nil error occurs only with IssuerTrustVerified. Only a caller
+// that explicitly inspects the returned status -- rather than only the error
+// -- can tell a checked failure apart from an unevaluated one.
+type IssuerTrustStatus int
+
+const (
+	IssuerTrustNotEvaluated IssuerTrustStatus = iota
+	IssuerTrustVerified
+	IssuerTrustFailed
+)
+
+// String renders the status for logs and API responses. These values are
+// serialized verbatim by the credential decode endpoint, so keep them stable.
+func (s IssuerTrustStatus) String() string {
+	switch s {
+	case IssuerTrustVerified:
+		return "verified"
+	case IssuerTrustFailed:
+		return "failed"
+	default:
+		return "not_evaluated"
+	}
+}
 
 // TokenSigner signs a JWT-like claim set with the wallet's active key material.
 type TokenSigner func(claims map[string]interface{}, headerOverrides map[string]interface{}) (string, error)
 
 // PresentationBuildInput carries the wallet context required to build a presentation.
 type PresentationBuildInput struct {
-	Credential             string
-	ParsedCredential       *ParsedCredential
-	Holder                 string
-	HolderPublicJWK        intcrypto.JWK
-	HolderJWKThumbprint    string
+	Credential               string
+	ParsedCredential         *ParsedCredential
+	Holder                   string
+	HolderPublicJWK          intcrypto.JWK
+	HolderJWKThumbprint      string
 	HolderVerificationMethod string
-	Audience               string
-	Nonce                  string
-	PresentationDefinition map[string]interface{}
-	Signer                 TokenSigner
-	ProofSigner            func(data []byte) ([]byte, error)
+	Audience                 string
+	Nonce                    string
+	PresentationDefinition   map[string]interface{}
+	Signer                   TokenSigner
+	ProofSigner              func(data []byte) ([]byte, error)
 }
 
 // PresentationBuildResult contains the serialized presentation token and its format.
@@ -45,6 +88,18 @@ type CredentialValidationInput struct {
 	ParsedCredential *ParsedCredential
 	IssuerKeys       []intcrypto.JWK
 	HTTPClient       *http.Client
+	// IssuerTrustAnchors carries IACA root certificates for mso_mdoc's
+	// x5chain path validation (mdoc.VerifyIssuerSigned). JWT-based formats
+	// use IssuerKeys instead; this field exists because mdoc's trust model is
+	// X.509 certificate chains, not JWKs, and CredentialValidationInput was
+	// otherwise shaped entirely around the JWT formats it originally served.
+	// A nil pool means "no trust anchor was supplied", which MSOMdocFormat
+	// reports as IssuerTrustNotEvaluated rather than attempting path
+	// validation against it -- x509.Certificate.Verify falls back to the
+	// host OS root store when Roots is nil, which would otherwise turn an
+	// absent trust anchor into a misleading certificate-path error that
+	// reads as IssuerTrustFailed.
+	IssuerTrustAnchors *x509.CertPool
 }
 
 // ParsedCredential is a normalized, format-agnostic view of a held credential.
@@ -73,7 +128,7 @@ type CredentialFormat interface {
 	CanPresent() bool
 	BuildPresentation(input PresentationBuildInput) (*PresentationBuildResult, error)
 	ParseCredential(raw string) (*ParsedCredential, error)
-	ValidateIssuerSignature(input CredentialValidationInput) error
+	ValidateIssuerSignature(input CredentialValidationInput) (IssuerTrustStatus, error)
 }
 
 // CredentialFormatRegistry stores supported credential format handlers and provides format detection.
@@ -107,6 +162,9 @@ func DefaultCredentialFormatRegistry() *CredentialFormatRegistry {
 			&LDPVCFormat{},
 			&JWTVCFormat{formatID: "jwt_vc_json-ld"},
 			&JWTVCFormat{formatID: "jwt_vc_json"},
+			// Registered last: see MSOMdocFormat's doc comment for why
+			// ordering here is defensive rather than load-bearing.
+			&MSOMdocFormat{},
 		)
 	})
 	return defaultCredentialFormatRegistry
@@ -256,10 +314,10 @@ func (f *SDJWTFormat) BuildPresentation(input PresentationBuildInput) (*Presenta
 	}, nil
 }
 
-func (f *SDJWTFormat) ValidateIssuerSignature(input CredentialValidationInput) error {
+func (f *SDJWTFormat) ValidateIssuerSignature(input CredentialValidationInput) (IssuerTrustStatus, error) {
 	parsed, err := ensureParsedCredentialForValidation(f, input)
 	if err != nil {
-		return err
+		return IssuerTrustNotEvaluated, err
 	}
 	return validateJWTSignature(parsed.IssuerSignedJWT, input.IssuerKeys)
 }
@@ -300,10 +358,10 @@ func (f *JWTVCFormat) BuildPresentation(input PresentationBuildInput) (*Presenta
 	return buildWrappedPresentation(input, strings.TrimSpace(parsed.Original), firstNonEmptyFormat(parsed.Format, f.FormatID()))
 }
 
-func (f *JWTVCFormat) ValidateIssuerSignature(input CredentialValidationInput) error {
+func (f *JWTVCFormat) ValidateIssuerSignature(input CredentialValidationInput) (IssuerTrustStatus, error) {
 	parsed, err := ensureParsedCredentialForValidation(f, input)
 	if err != nil {
-		return err
+		return IssuerTrustNotEvaluated, err
 	}
 	return validateJWTSignature(parsed.Original, input.IssuerKeys)
 }
@@ -525,18 +583,25 @@ func parseJSONLDCredential(raw string, formatID string) (*ParsedCredential, erro
 	return parsed, nil
 }
 
-func validateJWTSignature(token string, issuerKeys []intcrypto.JWK) error {
+// validateJWTSignature verifies token against issuerKeys and reports the
+// tri-state outcome. Both an empty token and no issuer keys are
+// IssuerTrustNotEvaluated: neither is "checked and failed", each is "there
+// was nothing to check, or nothing to check it against". Every other
+// negative outcome -- an unusable key, a signature that does not verify --
+// is IssuerTrustFailed, because a check was actually attempted against real
+// trust material and did not succeed.
+func validateJWTSignature(token string, issuerKeys []intcrypto.JWK) (IssuerTrustStatus, error) {
 	normalized := strings.TrimSpace(token)
 	if normalized == "" {
-		return fmt.Errorf("credential jwt is required")
+		return IssuerTrustNotEvaluated, fmt.Errorf("credential jwt is required")
 	}
 	if len(issuerKeys) == 0 {
-		return fmt.Errorf("issuer keys are required")
+		return IssuerTrustNotEvaluated, fmt.Errorf("issuer keys are required")
 	}
 
 	decoded, err := intcrypto.DecodeTokenWithoutValidation(normalized)
 	if err != nil {
-		return fmt.Errorf("decode credential jwt: %w", err)
+		return IssuerTrustNotEvaluated, fmt.Errorf("decode credential jwt: %w", err)
 	}
 	kid := strings.TrimSpace(formatString(decoded.Header["kid"]))
 	alg := strings.TrimSpace(formatString(decoded.Header["alg"]))
@@ -564,7 +629,7 @@ func validateJWTSignature(token string, issuerKeys []intcrypto.JWK) error {
 		}
 		valid, err := intcrypto.VerifySignatureWithKey(normalized, publicKey)
 		if err == nil && valid {
-			return nil
+			return IssuerTrustVerified, nil
 		}
 		if err != nil {
 			lastErr = err
@@ -575,7 +640,7 @@ func validateJWTSignature(token string, issuerKeys []intcrypto.JWK) error {
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no usable issuer keys were provided")
 	}
-	return lastErr
+	return IssuerTrustFailed, lastErr
 }
 
 func normalizeCredentialFormatID(formatID string) string {

--- a/backend/internal/vc/format.go
+++ b/backend/internal/vc/format.go
@@ -398,15 +398,271 @@ func (f *LDPVCFormat) BuildPresentation(input PresentationBuildInput) (*Presenta
 	return buildWrappedPresentation(input, strings.TrimSpace(parsed.Original), parsed.Format)
 }
 
-func (f *LDPVCFormat) ValidateIssuerSignature(input CredentialValidationInput) error {
+func (f *LDPVCFormat) ValidateIssuerSignature(input CredentialValidationInput) (IssuerTrustStatus, error) {
 	parsed, err := ensureParsedCredentialForValidation(f, input)
 	if err != nil {
-		return err
+		return IssuerTrustNotEvaluated, err
 	}
 	if strings.HasPrefix(strings.TrimSpace(parsed.Original), "{") {
-		return validateDataIntegrityCredential(parsed, input)
+		// verifyDataIntegrityDocument can resolve a verification method from
+		// a self-certifying did:key inside the proof itself, so an empty
+		// IssuerKeys does not necessarily mean no trust material existed the
+		// way it does for the JWT path below. Rather than approximate that
+		// distinction, report every data-integrity outcome other than
+		// success as Failed: this never overclaims Verified, and the only
+		// cost is that a genuinely trust-anchor-less data-integrity check
+		// reads as Failed instead of the more precise NotEvaluated.
+		if err := validateDataIntegrityCredential(parsed, input); err != nil {
+			return IssuerTrustFailed, err
+		}
+		return IssuerTrustVerified, nil
 	}
 	return validateJWTSignature(parsed.Original, input.IssuerKeys)
+}
+
+// MSOMdocFormat implements the ISO/IEC 18013-5 mso_mdoc profile: base64url-encoded
+// CBOR IssuerSigned, selective disclosure via per-element salted digests
+// committed in the MobileSecurityObject (MSO) rather than SD-JWT-style
+// tilde-delimited disclosures, and issuer trust via an x5chain of
+// certificates rooted at an IACA, rather than a JWK set.
+//
+// Registered last in DefaultCredentialFormatRegistry: ParseAnyCredential
+// returns the first successful parse, and mdoc is unambiguous against the
+// other four formats purely by input shape. base64.RawURLEncoding rejects
+// the '.' in a compact JWT/SD-JWT immediately, and rejects the '{' that
+// opens a raw JSON-LD credential immediately, so mdoc can never shadow an
+// earlier format's input by accident, and does not need to run before one
+// that would otherwise mis-accept it.
+type MSOMdocFormat struct{}
+
+func (f *MSOMdocFormat) FormatID() string { return "mso_mdoc" }
+
+// CanPresent reports false. mdoc presentation is real, but it is the ISO/IEC
+// 18013-5 DeviceResponse path (mdoc.BuildDeviceResponse, driven by
+// walletharness's createMdocVPToken), not the generic JWT-wrapped VP path
+// every other format shares through BuildPresentation. That path needs the
+// holder's mdoc device private key and the OID4VP SessionTranscript
+// (handover bytes), neither of which PresentationBuildInput carries -- it
+// was shaped for a bearer JWT signer. CanPresent exists so callers can ask
+// "does the generic path work for this format" without attempting it; for
+// mdoc the honest answer is no, and BuildPresentation below is unreachable
+// through any caller that respects CanPresent.
+func (f *MSOMdocFormat) CanPresent() bool { return false }
+
+func (f *MSOMdocFormat) BuildPresentation(input PresentationBuildInput) (*PresentationBuildResult, error) {
+	return nil, fmt.Errorf("mdoc: presentation is built via the ISO/IEC 18013-5 DeviceResponse path, not CredentialFormat.BuildPresentation; CanPresent() reports false for this format")
+}
+
+func (f *MSOMdocFormat) ParseCredential(raw string) (*ParsedCredential, error) {
+	issuerSigned, err := decodeMdocIssuerSignedGated(raw)
+	if err != nil {
+		return nil, err
+	}
+	msoBytes, _, err := mdoc.ParseIssuerAuth(issuerSigned.IssuerAuth)
+	if err != nil {
+		return nil, fmt.Errorf("mdoc: parse IssuerAuth: %w", err)
+	}
+	mso, err := mdoc.DecodeMSOBytes(msoBytes)
+	if err != nil {
+		return nil, fmt.Errorf("mdoc: decode MobileSecurityObject: %w", err)
+	}
+	disclosed, err := mdoc.CollectDisclosedElements(issuerSigned)
+	if err != nil {
+		return nil, fmt.Errorf("mdoc: collect disclosed elements: %w", err)
+	}
+
+	claims := make(map[string]interface{}, len(disclosed))
+	subject := ""
+	for ns, elements := range disclosed {
+		nsClaims := make(map[string]interface{}, len(elements))
+		for elementID, value := range elements {
+			safeValue := mdoc.JSONSafeValue(value)
+			nsClaims[elementID] = safeValue
+			if elementID == "document_number" && subject == "" {
+				if s, ok := safeValue.(string); ok {
+					subject = s
+				} else {
+					subject = fmt.Sprint(safeValue)
+				}
+			}
+		}
+		claims[ns] = nsClaims
+	}
+
+	return &ParsedCredential{
+		Original:  strings.TrimSpace(raw),
+		Format:    f.FormatID(),
+		Subject:   subject,
+		Doctype:   mso.DocType,
+		Claims:    claims,
+		IsSDJWT:   false,
+		IssuedAt:  mso.ValidityInfo.Signed,
+		ExpiresAt: mso.ValidityInfo.ValidUntil,
+	}, nil
+}
+
+// ValidateIssuerSignature verifies the mdoc's IssuerAuth COSE_Sign1 against
+// IssuerTrustAnchors (an IACA root pool) and recomputes valueDigests. It
+// independently re-decodes and re-gates input.Credential rather than reusing
+// input.ParsedCredential, so the hardened CBOR limits apply on this path even
+// if a future caller reaches ValidateIssuerSignature without having called
+// ParseCredential first.
+func (f *MSOMdocFormat) ValidateIssuerSignature(input CredentialValidationInput) (IssuerTrustStatus, error) {
+	issuerSigned, err := decodeMdocIssuerSignedGated(input.Credential)
+	if err != nil {
+		return IssuerTrustNotEvaluated, err
+	}
+	// A nil pool must not reach mdoc.VerifyIssuerSigned: x509.Certificate.Verify
+	// falls back to the host OS root store when VerifyOptions.Roots is nil,
+	// which would turn "no trust anchor was supplied" into a certificate-path
+	// error indistinguishable from a genuine chain failure. Checking here is
+	// what makes "no IACA root" read as IssuerTrustNotEvaluated rather than
+	// IssuerTrustFailed.
+	if input.IssuerTrustAnchors == nil {
+		return IssuerTrustNotEvaluated, fmt.Errorf("mdoc: no IACA trust anchor was supplied")
+	}
+	if _, err := mdoc.VerifyIssuerSigned(issuerSigned, input.IssuerTrustAnchors, time.Now().UTC()); err != nil {
+		return IssuerTrustFailed, fmt.Errorf("mdoc: issuer signature verification failed: %w", err)
+	}
+	return IssuerTrustVerified, nil
+}
+
+// decodeMdocIssuerSignedGated decodes a base64url mso_mdoc credential into an
+// IssuerSigned, applying mdoc.CheckUntrustedCBOR unconditionally before any
+// typed decode. Both ParseCredential and ValidateIssuerSignature call this
+// rather than mdoc.DecodeIssuerSigned directly, so the hardened limits apply
+// regardless of which method a caller reaches first -- the gate cannot be
+// bypassed by a call path that only exercises one of the two.
+func decodeMdocIssuerSignedGated(raw string) (mdoc.IssuerSigned, error) {
+	normalized := strings.TrimSpace(raw)
+	if normalized == "" {
+		return mdoc.IssuerSigned{}, fmt.Errorf("mdoc: credential is required")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(normalized)
+	if err != nil {
+		return mdoc.IssuerSigned{}, fmt.Errorf("mdoc: decode base64url credential: %w", err)
+	}
+	if _, err := mdoc.CheckUntrustedCBOR(decoded); err != nil {
+		return mdoc.IssuerSigned{}, err
+	}
+	issuerSigned, err := mdoc.DecodeIssuerSigned(decoded)
+	if err != nil {
+		return mdoc.IssuerSigned{}, fmt.Errorf("mdoc: decode IssuerSigned: %w", err)
+	}
+	return issuerSigned, nil
+}
+
+// MdocDigestsConsistentWithMSO independently re-decodes an mso_mdoc
+// credential under the same hardened untrusted-CBOR gate as ParseCredential
+// (via decodeMdocIssuerSignedGated) and recomputes each presented
+// IssuerSignedItem's digest against the credential's own MSO valueDigests
+// via mdoc.VerifyValueDigests.
+//
+// This is NOT signature or issuer-trust verification, and must never be
+// described as such in a field name, a UI label, or docs text: it
+// establishes that the presented items hash to the values the MSO itself
+// declares -- internal self-consistency -- not that the MSO was produced by
+// a trusted issuer. An MSO with no valid signature at all, or no signature
+// checked at all, can still be perfectly self-consistent, because whoever
+// built the credential computed the items and the digests together from the
+// same source. Only ValidateIssuerSignature, checked against a real IACA
+// trust anchor, establishes authenticity.
+func MdocDigestsConsistentWithMSO(raw string) (bool, error) {
+	issuerSigned, err := decodeMdocIssuerSignedGated(raw)
+	if err != nil {
+		return false, err
+	}
+	msoBytes, _, err := mdoc.ParseIssuerAuth(issuerSigned.IssuerAuth)
+	if err != nil {
+		return false, fmt.Errorf("mdoc: parse IssuerAuth: %w", err)
+	}
+	mso, err := mdoc.DecodeMSOBytes(msoBytes)
+	if err != nil {
+		return false, fmt.Errorf("mdoc: decode MobileSecurityObject: %w", err)
+	}
+	if err := mdoc.VerifyValueDigests(issuerSigned.NameSpaces, mso.ValueDigests, mso.DigestAlgorithm); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// CredentialAssurance reports how much of a decoded credential has actually
+// been checked, kept structurally separate from CredentialEvidence so a
+// caller cannot read "what this artifact contains" and "what has been
+// verified about it" as the same fact. See InspectCredential.
+type CredentialAssurance struct {
+	// IssuerTrust is ValidateIssuerSignature's tri-state, carried verbatim
+	// rather than derived or hardcoded. InspectCredential supplies no
+	// IssuerKeys and no IssuerTrustAnchors, so this reads
+	// IssuerTrustNotEvaluated for every format today -- but it is computed
+	// by actually calling ValidateIssuerSignature, so a format whose check
+	// can resolve trust from the artifact alone (LDPVCFormat's did:key
+	// path) reports whatever it actually found rather than a value assumed
+	// ahead of time.
+	IssuerTrust IssuerTrustStatus
+	// IssuerTrustDetail is ValidateIssuerSignature's error text, if any.
+	IssuerTrustDetail string
+	// DigestsConsistentWithMSO is nil for every format except mso_mdoc,
+	// because mdoc is the only format with a self-contained per-item digest
+	// -- MSO valueDigests -- that can be recomputed from the artifact alone
+	// with no external trust material. Non-nil means the check in
+	// MdocDigestsConsistentWithMSO ran; the bool is its result. See that
+	// function's doc comment for why this is not authenticity.
+	DigestsConsistentWithMSO *bool
+	// DigestConsistencyDetail is the mismatch or decode error detail when
+	// DigestsConsistentWithMSO is non-nil and false.
+	DigestConsistencyDetail string
+}
+
+// CredentialInspectionResult is the shared body behind POST
+// /lookingglass/decode/credential: the same format-agnostic evidence every
+// other BuildCredentialEvidence caller uses, plus the assurance envelope
+// stating plainly how much of it has been checked.
+type CredentialInspectionResult struct {
+	Evidence  CredentialEvidence
+	Assurance CredentialAssurance
+}
+
+// InspectCredential decodes a pasted credential for the Looking Glass
+// credential-inspection endpoint. It is the "issued" lifecycle stage by
+// definition: whatever this function is given is being looked at as a
+// standalone artifact, never as what a holder chose to reveal in a
+// presentation.
+//
+// Every credential passed here is externally supplied -- this is the
+// paste-a-credential endpoint -- so the HTTP handler calling this must apply
+// a body-size cap before this is reached (a transport concern, per A2); the
+// mdoc-specific hardened CBOR decode limits apply unconditionally inside
+// MSOMdocFormat.ParseCredential regardless of that cap.
+//
+// This function never supplies IssuerKeys or IssuerTrustAnchors, so
+// Assurance.IssuerTrust reads not-evaluated for every format by default --
+// there is deliberately no IACA root or issuer JWK set for a pasted
+// credential from an arbitrary issuer to be checked against.
+func InspectCredential(raw string) (*CredentialInspectionResult, error) {
+	evidence, err := BuildCredentialEvidence(raw, LifecycleStageIssued)
+	if err != nil {
+		return nil, err
+	}
+
+	assurance := CredentialAssurance{IssuerTrust: IssuerTrustNotEvaluated}
+	if formatHandler, ok := DefaultCredentialFormatRegistry().Lookup(evidence.Format); ok {
+		trustStatus, trustErr := formatHandler.ValidateIssuerSignature(CredentialValidationInput{Credential: raw})
+		assurance.IssuerTrust = trustStatus
+		if trustErr != nil {
+			assurance.IssuerTrustDetail = trustErr.Error()
+		}
+	}
+
+	if strings.EqualFold(evidence.Format, "mso_mdoc") {
+		consistent, digestErr := MdocDigestsConsistentWithMSO(raw)
+		assurance.DigestsConsistentWithMSO = &consistent
+		if digestErr != nil {
+			assurance.DigestConsistencyDetail = digestErr.Error()
+		}
+	}
+
+	return &CredentialInspectionResult{Evidence: *evidence, Assurance: assurance}, nil
 }
 
 func ensureParsedCredential(format CredentialFormat, input PresentationBuildInput) (*ParsedCredential, error) {

--- a/backend/internal/vc/format_test.go
+++ b/backend/internal/vc/format_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	intcrypto "github.com/ParleSec/ProtocolSoup/internal/crypto"
+	"github.com/ParleSec/ProtocolSoup/internal/mdoc"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -73,6 +74,177 @@ func TestParseAnyCredentialDetectsFormats(t *testing.T) {
 	}
 	if parsedLDPVC.Format != "ldp_vc" {
 		t.Fatalf("unexpected ldp_vc format %q", parsedLDPVC.Format)
+	}
+
+	// jwt_vc_json is the same vc+jwt envelope as jwt_vc_json-ld above, minus
+	// @context on the vc object -- that absence is the sole discriminant
+	// parseJWTCredential uses to tell the two apart (see format.go), so this
+	// must be its own case rather than assumed to follow from the -ld one.
+	jwtVCJSON := signedTestJWT(t, jwt.SigningMethodHS256, []byte("jwt-secret"), "vc+jwt", jwt.MapClaims{
+		"sub": "did:example:holder",
+		"vc": map[string]interface{}{
+			"type": []string{"VerifiableCredential", "UniversityDegreeCredential"},
+			"credentialSubject": map[string]interface{}{
+				"id": "did:example:holder",
+			},
+		},
+	})
+	parsedJWTVCJSON, err := registry.ParseAnyCredential(jwtVCJSON)
+	if err != nil {
+		t.Fatalf("ParseAnyCredential(jwt_vc_json): %v", err)
+	}
+	if parsedJWTVCJSON.Format != "jwt_vc_json" {
+		t.Fatalf("unexpected jwt_vc_json format %q", parsedJWTVCJSON.Format)
+	}
+
+	// mso_mdoc is the default and lead credential profile, so it must parse
+	// through the same registry dispatch as the four JWT/JSON-LD formats
+	// above -- not through a special-cased path outside ParseAnyCredential.
+	mdocFixture := buildTestMdocCredential(t)
+	parsedMdoc, err := registry.ParseAnyCredential(mdocFixture.credential)
+	if err != nil {
+		t.Fatalf("ParseAnyCredential(mso_mdoc): %v", err)
+	}
+	if parsedMdoc.Format != "mso_mdoc" {
+		t.Fatalf("unexpected mso_mdoc format %q", parsedMdoc.Format)
+	}
+	if parsedMdoc.Doctype != mdoc.DocTypeMDL {
+		t.Fatalf("unexpected mso_mdoc doctype %q, want %q", parsedMdoc.Doctype, mdoc.DocTypeMDL)
+	}
+	nsClaims, ok := parsedMdoc.Claims["org.iso.18013.5.1"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected org.iso.18013.5.1 namespace claims, got %#v", parsedMdoc.Claims)
+	}
+	if len(nsClaims) != 2 {
+		t.Fatalf("expected 2 disclosed elements (family_name, age_over_18), got %d: %#v", len(nsClaims), nsClaims)
+	}
+}
+
+// TestCredentialFormatHandlersRejectForeignInput pins the claim in
+// MSOMdocFormat's doc comment that mdoc "can never shadow an earlier
+// format's input by accident, and does not need to run before one that
+// would otherwise mis-accept it": the mdoc handler must reject every other
+// format's credential, and every other format's handler must reject an
+// mdoc credential. Without this, mdoc's registration could silently swallow
+// another format's credential (or vice versa), and ParseAnyCredential's
+// first-match iteration would hide the collision as long as the true owner
+// still happened to run first.
+//
+// This deliberately checks only the mdoc-vs-others pairing, not a full
+// cross product of all five formats: jwt_vc_json and jwt_vc_json-ld share
+// JWTVCFormat.ParseCredential and are disambiguated only by the presence of
+// @context, which is a pre-existing, mdoc-unrelated discrimination detail
+// -- not the regression surface mso_mdoc registration introduces.
+func TestCredentialFormatHandlersRejectForeignInput(t *testing.T) {
+	registry := DefaultCredentialFormatRegistry()
+	samples := buildCredentialFormatSamples(t)
+
+	mdocHandler, ok := registry.Lookup("mso_mdoc")
+	if !ok {
+		t.Fatalf("registry.Lookup(%q) missing", "mso_mdoc")
+	}
+	if _, err := mdocHandler.ParseCredential(samples["mso_mdoc"]); err != nil {
+		t.Fatalf("mso_mdoc.ParseCredential rejected its own sample: %v", err)
+	}
+
+	for _, otherFormatID := range []string{"dc+sd-jwt", "jwt_vc_json-ld", "jwt_vc_json", "ldp_vc"} {
+		otherHandler, ok := registry.Lookup(otherFormatID)
+		if !ok {
+			t.Fatalf("registry.Lookup(%q) missing", otherFormatID)
+		}
+		if _, err := otherHandler.ParseCredential(samples[otherFormatID]); err != nil {
+			t.Fatalf("%s.ParseCredential rejected its own sample: %v", otherFormatID, err)
+		}
+
+		if _, err := mdocHandler.ParseCredential(samples[otherFormatID]); err == nil {
+			t.Fatalf("mso_mdoc.ParseCredential accepted a %s credential; mdoc must reject foreign input", otherFormatID)
+		}
+		if _, err := otherHandler.ParseCredential(samples["mso_mdoc"]); err == nil {
+			t.Fatalf("%s.ParseCredential accepted an mso_mdoc credential; every format must reject mdoc input", otherFormatID)
+		}
+	}
+}
+
+// TestDefaultCredentialFormatRegistryLookupCoversAllFormats pins that all
+// five formats -- including mso_mdoc -- are reachable via Lookup with the
+// exact ID each FormatID() reports, so a caller resolving a format handler
+// by string (as walletharness's PE/DCQL guards and validateImportedCredential
+// do) never silently misses one.
+func TestDefaultCredentialFormatRegistryLookupCoversAllFormats(t *testing.T) {
+	registry := DefaultCredentialFormatRegistry()
+	for _, formatID := range credentialFormatSampleIDs {
+		handler, ok := registry.Lookup(formatID)
+		if !ok {
+			t.Fatalf("registry.Lookup(%q) = not found", formatID)
+		}
+		if handler.FormatID() != formatID {
+			t.Fatalf("registry.Lookup(%q).FormatID() = %q", formatID, handler.FormatID())
+		}
+	}
+}
+
+// credentialFormatSampleIDs enumerates every registered format for the
+// cross-format tests above. mso_mdoc is included alongside the four
+// JWT/JSON-LD formats deliberately: this list is what makes "all five
+// formats" a checked fact rather than a comment.
+var credentialFormatSampleIDs = []string{"dc+sd-jwt", "jwt_vc_json-ld", "jwt_vc_json", "ldp_vc", "mso_mdoc"}
+
+// buildCredentialFormatSamples builds one valid raw credential per
+// registered format, keyed by FormatID, for the cross-format rejection and
+// registry coverage tests.
+func buildCredentialFormatSamples(t *testing.T) map[string]string {
+	t.Helper()
+	disclosure, err := CreateSDJWTDisclosure("family_name", "Doe", "fixed-salt")
+	if err != nil {
+		t.Fatalf("CreateSDJWTDisclosure: %v", err)
+	}
+	sdJWT := BuildSDJWTSerialization(
+		signedTestJWT(t, jwt.SigningMethodHS256, []byte("sd-secret"), "vc+sd-jwt", jwt.MapClaims{
+			"sub": "did:example:holder",
+			"vct": "https://example.org/credential",
+			"exp": time.Now().Add(5 * time.Minute).Unix(),
+			"vc": map[string]interface{}{
+				"type": []string{"VerifiableCredential", "UniversityDegreeCredential"},
+				"credentialSubject": map[string]interface{}{
+					"id": "did:example:holder",
+				},
+			},
+		}),
+		[]string{disclosure.Encoded},
+		"",
+	)
+
+	jwtVCLD := signedTestJWT(t, jwt.SigningMethodHS256, []byte("jwt-secret"), "vc+jwt", jwt.MapClaims{
+		"sub": "did:example:holder",
+		"vc": map[string]interface{}{
+			"@context": []string{"https://www.w3.org/2018/credentials/v1"},
+			"type":     []string{"VerifiableCredential", "UniversityDegreeCredential"},
+			"credentialSubject": map[string]interface{}{
+				"id": "did:example:holder",
+			},
+		},
+	})
+
+	jwtVCJSON := signedTestJWT(t, jwt.SigningMethodHS256, []byte("jwt-secret"), "vc+jwt", jwt.MapClaims{
+		"sub": "did:example:holder",
+		"vc": map[string]interface{}{
+			"type": []string{"VerifiableCredential", "UniversityDegreeCredential"},
+			"credentialSubject": map[string]interface{}{
+				"id": "did:example:holder",
+			},
+		},
+	})
+
+	ldpVC := `{"@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiableCredential","UniversityDegreeCredential"],"credentialSubject":{"id":"did:example:holder"},"proof":{"type":"Ed25519Signature2020"}}`
+
+	mdocFixture := buildTestMdocCredential(t)
+
+	return map[string]string{
+		"dc+sd-jwt":      sdJWT,
+		"jwt_vc_json-ld": jwtVCLD,
+		"jwt_vc_json":    jwtVCJSON,
+		"ldp_vc":         ldpVC,
+		"mso_mdoc":       mdocFixture.credential,
 	}
 }
 
@@ -199,12 +371,80 @@ func TestJWTVCFormatValidateIssuerSignatureWithEdDSA(t *testing.T) {
 		},
 	})
 
-	if err := format.ValidateIssuerSignature(CredentialValidationInput{
+	trustStatus, err := format.ValidateIssuerSignature(CredentialValidationInput{
 		Credential: credential,
 		IssuerKeys: []intcrypto.JWK{issuerJWK},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("ValidateIssuerSignature(EdDSA): %v", err)
 	}
+	if trustStatus != IssuerTrustVerified {
+		t.Fatalf("ValidateIssuerSignature(EdDSA) trust status = %v, want IssuerTrustVerified", trustStatus)
+	}
+}
+
+// TestMSOMdocFormatValidateIssuerSignatureTriState pins the three distinct
+// outcomes ValidateIssuerSignature must be able to report for mdoc: a real
+// signature check that passed, a real signature check that failed against
+// non-matching trust material, and no check having run at all because no
+// trust anchor was supplied. Collapsing the second and third into one
+// binary result is exactly what would make an endpoint report "verified"
+// or a blanket failure where the honest answer is "not evaluated".
+func TestMSOMdocFormatValidateIssuerSignatureTriState(t *testing.T) {
+	registry := DefaultCredentialFormatRegistry()
+	format, ok := registry.Lookup("mso_mdoc")
+	if !ok {
+		t.Fatalf("mso_mdoc format handler not found")
+	}
+	fixture := buildTestMdocCredential(t)
+
+	t.Run("verified", func(t *testing.T) {
+		trustStatus, err := format.ValidateIssuerSignature(CredentialValidationInput{
+			Credential:         fixture.credential,
+			IssuerTrustAnchors: fixture.trustAnchors,
+		})
+		if err != nil {
+			t.Fatalf("ValidateIssuerSignature(matching IACA root): %v", err)
+		}
+		if trustStatus != IssuerTrustVerified {
+			t.Fatalf("trust status = %v, want IssuerTrustVerified", trustStatus)
+		}
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		// A second, unrelated fixture's IACA root never signed the first
+		// fixture's document-signer certificate, so chain validation must
+		// fail -- this is a real check that ran against real trust
+		// material and did not succeed, which is IssuerTrustFailed, not
+		// IssuerTrustNotEvaluated.
+		unrelatedFixture := buildTestMdocCredential(t)
+		trustStatus, err := format.ValidateIssuerSignature(CredentialValidationInput{
+			Credential:         fixture.credential,
+			IssuerTrustAnchors: unrelatedFixture.trustAnchors,
+		})
+		if err == nil {
+			t.Fatalf("ValidateIssuerSignature(non-matching IACA root) unexpectedly succeeded")
+		}
+		if trustStatus != IssuerTrustFailed {
+			t.Fatalf("trust status = %v, want IssuerTrustFailed", trustStatus)
+		}
+	})
+
+	t.Run("not_evaluated_when_no_trust_anchor_supplied", func(t *testing.T) {
+		trustStatus, err := format.ValidateIssuerSignature(CredentialValidationInput{
+			Credential: fixture.credential,
+			// IssuerTrustAnchors intentionally omitted. A nil pool must
+			// read as "nothing was checked", never fall back to the host
+			// OS root store (which would misreport this as a chain
+			// failure for an unrelated reason).
+		})
+		if err == nil {
+			t.Fatalf("ValidateIssuerSignature(nil trust anchors) unexpectedly succeeded")
+		}
+		if trustStatus != IssuerTrustNotEvaluated {
+			t.Fatalf("trust status = %v, want IssuerTrustNotEvaluated", trustStatus)
+		}
+	})
 }
 
 func TestParseAnyCredentialFallsBackToCredentialSubjectID(t *testing.T) {

--- a/backend/internal/vc/mdoc_fixture_test.go
+++ b/backend/internal/vc/mdoc_fixture_test.go
@@ -1,0 +1,93 @@
+package vc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	intcose "github.com/ParleSec/ProtocolSoup/internal/cose"
+	"github.com/ParleSec/ProtocolSoup/internal/mdoc"
+)
+
+// testMdocFixture is a real, validly-signed ISO/IEC 18013-5 mso_mdoc
+// IssuerSigned (base64url CBOR), built through the same exported
+// internal/mdoc primitives production issuance uses -- mirroring
+// walletharness's issueMdocBoundTo -- rather than a hand-crafted CBOR blob.
+// It carries exactly two disclosed elements (family_name, age_over_18) in
+// the org.iso.18013.5.1 namespace, so tests asserting selective-disclosure
+// counts have a known-correct value to check against.
+type testMdocFixture struct {
+	credential   string
+	trustAnchors *x509.CertPool
+}
+
+// buildTestMdocCredential issues a fresh mdoc fixture with its own
+// single-use IACA root, so trustAnchors verifies this credential and no
+// other. elementCount lets callers vary the disclosed-element count (for
+// committed_count assertions) without duplicating this whole construction;
+// pass 0 for the standard 2-element (family_name, age_over_18) fixture.
+func buildTestMdocCredential(t *testing.T) testMdocFixture {
+	t.Helper()
+	return buildTestMdocCredentialBoundTo(t, nil)
+}
+
+// buildTestMdocCredentialBoundTo issues a fixture bound to a caller-supplied
+// device key, or a freshly generated one if boundKey is nil. Device binding
+// is irrelevant to format/evidence/trust-status tests, but BuildMSO requires
+// a DeviceKeyInfo, so every fixture needs one regardless.
+func buildTestMdocCredentialBoundTo(t *testing.T, boundKey *ecdsa.PublicKey) testMdocFixture {
+	t.Helper()
+	pki, err := mdoc.GenerateIssuerPKI(mdoc.DefaultPKIParams("https://issuer.example/oid4vci"))
+	if err != nil {
+		t.Fatalf("GenerateIssuerPKI: %v", err)
+	}
+	if boundKey == nil {
+		deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("GenerateKey(device): %v", err)
+		}
+		boundKey = &deviceKey.PublicKey
+	}
+	now := time.Now().Truncate(time.Second).UTC()
+	family, err := mdoc.NewIssuerSignedItem(0, "family_name", "Citizen")
+	if err != nil {
+		t.Fatalf("NewIssuerSignedItem(family_name): %v", err)
+	}
+	age, err := mdoc.NewIssuerSignedItem(1, "age_over_18", true)
+	if err != nil {
+		t.Fatalf("NewIssuerSignedItem(age_over_18): %v", err)
+	}
+	ns, err := mdoc.BuildIssuerNameSpaces(map[mdoc.NameSpace][]mdoc.IssuerSignedItem{mdoc.NameSpaceMDL: {family, age}})
+	if err != nil {
+		t.Fatalf("BuildIssuerNameSpaces: %v", err)
+	}
+	vd, err := mdoc.BuildValueDigests(ns, mdoc.DigestAlgorithmSHA256)
+	if err != nil {
+		t.Fatalf("BuildValueDigests: %v", err)
+	}
+	deviceCOSEKey, err := intcose.ECPublicKeyToCOSEKey(boundKey)
+	if err != nil {
+		t.Fatalf("ECPublicKeyToCOSEKey: %v", err)
+	}
+	mso := mdoc.BuildMSO(vd, deviceCOSEKey, mdoc.DocTypeMDL, mdoc.ValidityInfo{Signed: now, ValidFrom: now, ValidUntil: now.Add(48 * time.Hour)})
+	msoBytes, err := mdoc.EncodeMSOBytes(mso)
+	if err != nil {
+		t.Fatalf("EncodeMSOBytes: %v", err)
+	}
+	issuerAuth, err := mdoc.BuildIssuerAuth(msoBytes, pki.DocumentSignerKey(), pki.DocumentSignerChain())
+	if err != nil {
+		t.Fatalf("BuildIssuerAuth: %v", err)
+	}
+	encoded, err := mdoc.EncodeIssuerSigned(mdoc.IssuerSigned{NameSpaces: ns, IssuerAuth: issuerAuth})
+	if err != nil {
+		t.Fatalf("EncodeIssuerSigned: %v", err)
+	}
+	return testMdocFixture{
+		credential:   base64.RawURLEncoding.EncodeToString(encoded),
+		trustAnchors: pki.TrustAnchors(),
+	}
+}

--- a/backend/internal/vc/pe.go
+++ b/backend/internal/vc/pe.go
@@ -7,8 +7,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	intcrypto "github.com/ParleSec/ProtocolSoup/internal/crypto"
+	"github.com/ParleSec/ProtocolSoup/internal/mdoc"
 )
 
 // CredentialEvidence is a shared, format-agnostic credential view for query engines.
@@ -19,6 +21,103 @@ type CredentialEvidence struct {
 	CredentialTypes []string
 	FullClaims      map[string]interface{}
 	DisclosedClaims map[string]interface{}
+	// SelectiveDisclosure is nil for formats with no selective-disclosure
+	// mechanism (jwt_vc_json, jwt_vc_json-ld, ldp_vc always reveal every
+	// claim the credential carries) and populated for the two formats that
+	// have one (mso_mdoc, dc+sd-jwt), each with a different exactness
+	// property. See SelectiveDisclosureSummary.
+	SelectiveDisclosure *SelectiveDisclosureSummary
+	// IssuedAt and ExpiresAt mirror ParsedCredential's own fields verbatim
+	// (mso_mdoc: MSO ValidityInfo.Signed/ValidUntil; ldp_vc:
+	// issuanceDate/validFrom and expirationDate/validUntil; JWT-based
+	// formats: the exp claim only, since parseJWTCredential does not read
+	// iat). Each is the zero time.Time when the source credential does not
+	// carry that claim -- callers must check IsZero rather than assume
+	// presence, and this must never be back-filled with wall-clock time or
+	// any other value the credential itself did not assert.
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+}
+
+// CredentialLifecycleStage records whether a CredentialEvidence was captured
+// at issuance or at presentation. It is a required parameter on
+// BuildCredentialEvidence rather than a value the function infers, because it
+// cannot be inferred from the artifact: an mDL presented with all 11 elements
+// is byte-identical, in the respect that matters here, to the same mDL as
+// issued. Only the caller knows which lifecycle point it is looking at.
+type CredentialLifecycleStage string
+
+const (
+	LifecycleStageIssued    CredentialLifecycleStage = "issued"
+	LifecycleStagePresented CredentialLifecycleStage = "presented"
+)
+
+// NamespaceDisclosureCounts carries mdoc per-namespace committed/present
+// counts. mdoc only; SD-JWT has no namespace concept.
+type NamespaceDisclosureCounts struct {
+	CommittedCount int
+	PresentCount   int
+}
+
+// SelectiveDisclosureSummary replaces the old
+// ParsedCredential.HasKeyBindingJWT/DisclosureCount pair for evidence
+// purposes -- those assumed SD-JWT tilde-counting semantics unconditionally,
+// which is what let an mdoc render "disclosureCount: 0", a claim not sourced
+// from the artifact and wrong about the format's actual mechanism (mdoc has
+// no tildes; its selective disclosure lives in valueDigests). This shape is
+// numeric for every format that has selective disclosure, and forces the
+// caller to say which one it is rather than assume.
+//
+// CommittedCount cannot be read as "the true number of claims/elements this
+// credential contains" for every format, which is the second thing the old
+// single-number shape got wrong: it collapses two different epistemic
+// statuses into one type. CommittedCountIsExact and Mechanism exist so the
+// two never render identically.
+type SelectiveDisclosureSummary struct {
+	// Mechanism names what CommittedCount actually counts:
+	// "mso_valuedigests" for mdoc, "sd_jwt_disclosures" for SD-JWT.
+	Mechanism string
+	// CommittedCount is the element/digest count the mechanism commits to.
+	// For mdoc this is len(mso.ValueDigests[ns]) summed across namespaces --
+	// a genuine count, since ISO/IEC 18013-5 has no decoy-digest mechanism.
+	// For SD-JWT this is the count of digest strings found in "_sd" arrays
+	// in the issuer-signed JWT payload (at any nesting level reachable
+	// without decoding a disclosure) -- an upper bound, since SD-JWT
+	// deliberately permits decoy digests so a verifier cannot infer the true
+	// claim count from it.
+	CommittedCount int
+	// CommittedCountIsExact is true only for mso_valuedigests. False for
+	// sd_jwt_disclosures unconditionally, even when this particular
+	// credential happens to carry no decoys: the point is that the format
+	// permits them, so no SD-JWT's count can be asserted as exact from the
+	// digest count alone.
+	CommittedCountIsExact bool
+	// PresentCount is the element/disclosure count actually carried by this
+	// artifact: len(issuerSigned.NameSpaces[ns]) summed for mdoc, or the
+	// number of "~"-delimited Disclosures actually attached for SD-JWT.
+	PresentCount int
+	// LifecycleStage is carried verbatim from BuildCredentialEvidence's
+	// required parameter. At LifecycleStageIssued, PresentCount is a
+	// property of the format (an issuer sends every element/disclosure), not
+	// a holder decision, and must never be worded as a disclosure ratio.
+	// Only LifecycleStagePresented may use "N of M disclosed" phrasing.
+	LifecycleStage CredentialLifecycleStage
+	// DigestAlgorithm is mso.DigestAlgorithm ("SHA-256") for mdoc, or the
+	// SD-JWT "_sd_alg" claim (defaulting to "sha-256" per the SD-JWT spec
+	// when the claim is absent).
+	DigestAlgorithm string
+	// PerNamespace carries mdoc per-namespace committed/present counts. Nil
+	// for SD-JWT, which has no namespace concept.
+	PerNamespace map[string]NamespaceDisclosureCounts
+	// HasUnrepresentedDisclosureForms is true when an SD-JWT structure
+	// contains a disclosure form CommittedCount's flat "_sd" walk does not
+	// represent: an array-element redaction marker ({"...": "<digest>"}), or
+	// a disclosed claim whose own value contains a further "_sd" array
+	// (structured/nested disclosure, only visible once that claim is
+	// decoded). Always false for mdoc. When true, the UI must say the
+	// structure contains more disclosure forms than the count shows, rather
+	// than let the number stand as if it were complete.
+	HasUnrepresentedDisclosureForms bool
 }
 
 // PresentationDefinition is the parsed Presentation Exchange definition used by the wallet.
@@ -94,8 +193,17 @@ func ParsePresentationDefinition(raw map[string]interface{}) (*PresentationDefin
 	return definition, nil
 }
 
-// BuildCredentialEvidence parses a raw credential into the shared evidence model used by DCQL and PE.
-func BuildCredentialEvidence(rawCredential string) (*CredentialEvidence, error) {
+// BuildCredentialEvidence parses a raw credential into the shared evidence
+// model used by DCQL and PE. lifecycleStage is required (LifecycleStageIssued
+// or LifecycleStagePresented) and rejected on any other value, including the
+// zero value: it names a fact about the caller's context that cannot be
+// recovered from the credential bytes themselves, and Go's empty string
+// would otherwise compile fine at a new call site and silently default into
+// the wrong wording downstream. See CredentialLifecycleStage.
+func BuildCredentialEvidence(rawCredential string, lifecycleStage CredentialLifecycleStage) (*CredentialEvidence, error) {
+	if lifecycleStage != LifecycleStageIssued && lifecycleStage != LifecycleStagePresented {
+		return nil, fmt.Errorf("vc: lifecycle stage must be %q or %q, got %q", LifecycleStageIssued, LifecycleStagePresented, lifecycleStage)
+	}
 	parsed, err := DefaultCredentialFormatRegistry().ParseAnyCredential(strings.TrimSpace(rawCredential))
 	if err != nil {
 		return nil, err
@@ -105,11 +213,13 @@ func BuildCredentialEvidence(rawCredential string) (*CredentialEvidence, error) 
 	disclosedClaims := map[string]interface{}{}
 	aliasVerifiableCredentialClaimsPE(fullClaims, parsed.VCClaims)
 	aliasMSOMDocClaimsPE(fullClaims)
+	var selectiveDisclosure *SelectiveDisclosureSummary
 	if parsed.IsSDJWT {
 		envelope, err := ParseSDJWTEnvelope(parsed.Original)
 		if err != nil {
 			return nil, err
 		}
+		committedCount, hasUnrepresentedForms := countSDJWTCommittedDigestsPE(parsed.Claims)
 		for _, disclosure := range envelope.Disclosures {
 			decodedDisclosure, err := DecodeSDJWTDisclosure(disclosure)
 			if err != nil {
@@ -120,18 +230,142 @@ func BuildCredentialEvidence(rawCredential string) (*CredentialEvidence, error) 
 				continue
 			}
 			disclosedClaims[claimName] = deepCopyJSONValuePE(decodedDisclosure.ClaimValue)
+			// A disclosed claim's own value can carry a further "_sd" array
+			// (SD-JWT's structured/nested disclosure), which is invisible to
+			// countSDJWTCommittedDigestsPE above because it only walks the
+			// issuer-signed payload, not what decoding a disclosure reveals.
+			if claimValueMap, ok := decodedDisclosure.ClaimValue.(map[string]interface{}); ok {
+				if _, hasNestedSD := claimValueMap["_sd"]; hasNestedSD {
+					hasUnrepresentedForms = true
+				}
+			}
 		}
 		mergeDisclosedClaimsPE(fullClaims, disclosedClaims)
+		selectiveDisclosure = &SelectiveDisclosureSummary{
+			Mechanism:                       "sd_jwt_disclosures",
+			CommittedCount:                  committedCount,
+			CommittedCountIsExact:           false,
+			PresentCount:                    len(envelope.Disclosures),
+			LifecycleStage:                  lifecycleStage,
+			DigestAlgorithm:                 sdJWTDigestAlgorithmPE(parsed.Claims),
+			HasUnrepresentedDisclosureForms: hasUnrepresentedForms,
+		}
+	} else if strings.EqualFold(parsed.Format, "mso_mdoc") {
+		selectiveDisclosure, err = mdocSelectiveDisclosureSummaryPE(parsed.Original, lifecycleStage)
+		if err != nil {
+			return nil, err
+		}
 	}
 	flattenCredentialSubjectClaimsPE(fullClaims)
 
 	return &CredentialEvidence{
-		Format:          parsed.Format,
-		VCT:             parsed.VCT,
-		Doctype:         parsed.Doctype,
-		CredentialTypes: append([]string{}, parsed.CredentialTypes...),
-		FullClaims:      fullClaims,
-		DisclosedClaims: disclosedClaims,
+		Format:              parsed.Format,
+		VCT:                 parsed.VCT,
+		Doctype:             parsed.Doctype,
+		CredentialTypes:     append([]string{}, parsed.CredentialTypes...),
+		FullClaims:          fullClaims,
+		DisclosedClaims:     disclosedClaims,
+		SelectiveDisclosure: selectiveDisclosure,
+		IssuedAt:            parsed.IssuedAt,
+		ExpiresAt:           parsed.ExpiresAt,
+	}, nil
+}
+
+// sdJWTDigestAlgorithmPE reads the SD-JWT "_sd_alg" claim from the
+// issuer-signed payload, defaulting to "sha-256" per SD-JWT (draft-ietf-oauth
+// -selective-disclosure-jwt) Section 5.1.1's rule that a verifier MUST assume
+// sha-256 when the claim is absent.
+func sdJWTDigestAlgorithmPE(payload map[string]interface{}) string {
+	if alg, ok := payload["_sd_alg"].(string); ok {
+		if trimmed := strings.TrimSpace(alg); trimmed != "" {
+			return trimmed
+		}
+	}
+	return "sha-256"
+}
+
+// countSDJWTCommittedDigestsPE walks an SD-JWT issuer-signed payload (or a
+// value nested within it) and returns the total digest count across every
+// "_sd" array reachable without decoding a disclosure, plus whether an
+// array-element redaction marker ({"...": "<digest>"}) was found. Per
+// SelectiveDisclosureSummary.CommittedCount, this is an upper bound on the
+// claim count, not the count itself: SD-JWT permits decoy digests inside
+// "_sd" specifically so a verifier cannot infer how many claims exist, and
+// this function counts every entry in "_sd" without attempting to tell a
+// decoy from a real one, which is not possible from the payload alone.
+func countSDJWTCommittedDigestsPE(value interface{}) (count int, hasArrayElementMarker bool) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for key, val := range typed {
+			if key == "_sd" {
+				if sdArray, ok := val.([]interface{}); ok {
+					count += len(sdArray)
+				}
+				continue
+			}
+			nestedCount, nestedMarker := countSDJWTCommittedDigestsPE(val)
+			count += nestedCount
+			hasArrayElementMarker = hasArrayElementMarker || nestedMarker
+		}
+	case []interface{}:
+		for _, element := range typed {
+			if elementMap, ok := element.(map[string]interface{}); ok && len(elementMap) == 1 {
+				if _, ok := elementMap["..."]; ok {
+					hasArrayElementMarker = true
+					continue
+				}
+			}
+			nestedCount, nestedMarker := countSDJWTCommittedDigestsPE(element)
+			count += nestedCount
+			hasArrayElementMarker = hasArrayElementMarker || nestedMarker
+		}
+	}
+	return count, hasArrayElementMarker
+}
+
+// mdocSelectiveDisclosureSummaryPE recomputes the mdoc selective-disclosure
+// summary from the raw credential rather than from ParsedCredential, which is
+// deliberately format-agnostic and does not carry the MSO's ValueDigests --
+// the same reason the SD-JWT branch above re-parses the envelope rather than
+// reading it from ParsedCredential.
+func mdocSelectiveDisclosureSummaryPE(rawCredential string, lifecycleStage CredentialLifecycleStage) (*SelectiveDisclosureSummary, error) {
+	issuerSigned, err := decodeMdocIssuerSignedGated(rawCredential)
+	if err != nil {
+		return nil, err
+	}
+	msoBytes, _, err := mdoc.ParseIssuerAuth(issuerSigned.IssuerAuth)
+	if err != nil {
+		return nil, fmt.Errorf("mdoc: parse IssuerAuth: %w", err)
+	}
+	mso, err := mdoc.DecodeMSOBytes(msoBytes)
+	if err != nil {
+		return nil, fmt.Errorf("mdoc: decode MobileSecurityObject: %w", err)
+	}
+
+	perNamespace := make(map[string]NamespaceDisclosureCounts, len(mso.ValueDigests))
+	committedTotal := 0
+	for ns, digests := range mso.ValueDigests {
+		committedTotal += len(digests)
+		counts := perNamespace[ns]
+		counts.CommittedCount = len(digests)
+		perNamespace[ns] = counts
+	}
+	presentTotal := 0
+	for ns, items := range issuerSigned.NameSpaces {
+		presentTotal += len(items)
+		counts := perNamespace[ns]
+		counts.PresentCount = len(items)
+		perNamespace[ns] = counts
+	}
+
+	return &SelectiveDisclosureSummary{
+		Mechanism:             "mso_valuedigests",
+		CommittedCount:        committedTotal,
+		CommittedCountIsExact: true,
+		PresentCount:          presentTotal,
+		LifecycleStage:        lifecycleStage,
+		DigestAlgorithm:       mso.DigestAlgorithm,
+		PerNamespace:          perNamespace,
 	}, nil
 }
 
@@ -236,7 +470,9 @@ func ExtractPresentationCandidates(vpToken string) ([]PresentationCandidate, err
 
 	if envelope, err := ParseSDJWTEnvelope(normalized); err == nil {
 		_ = envelope
-		evidence, err := BuildCredentialEvidence(normalized)
+		// ExtractPresentationCandidates operates on a vp_token by definition,
+		// so every candidate it produces is LifecycleStagePresented.
+		evidence, err := BuildCredentialEvidence(normalized, LifecycleStagePresented)
 		if err != nil {
 			return nil, err
 		}
@@ -260,7 +496,7 @@ func ExtractPresentationCandidates(vpToken string) ([]PresentationCandidate, err
 				if err != nil {
 					return nil, err
 				}
-				evidence, err := BuildCredentialEvidence(credentialString)
+				evidence, err := BuildCredentialEvidence(credentialString, LifecycleStagePresented)
 				if err != nil {
 					return nil, err
 				}
@@ -292,7 +528,7 @@ func ExtractPresentationCandidates(vpToken string) ([]PresentationCandidate, err
 				if err != nil {
 					return nil, err
 				}
-				evidence, err := BuildCredentialEvidence(credentialString)
+				evidence, err := BuildCredentialEvidence(credentialString, LifecycleStagePresented)
 				if err != nil {
 					return nil, err
 				}

--- a/backend/internal/vc/pe_test.go
+++ b/backend/internal/vc/pe_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ParleSec/ProtocolSoup/internal/mdoc"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -37,7 +38,7 @@ func TestMatchCredentialToDescriptorSupportsJSONPathFilters(t *testing.T) {
 			},
 		},
 	})
-	evidence, err := BuildCredentialEvidence(rawCredential)
+	evidence, err := BuildCredentialEvidence(rawCredential, LifecycleStagePresented)
 	if err != nil {
 		t.Fatalf("BuildCredentialEvidence: %v", err)
 	}
@@ -209,5 +210,186 @@ func TestBuildPresentationSubmissionForSDJWT(t *testing.T) {
 	}
 	if _, hasPathNested := entry["path_nested"]; hasPathNested {
 		t.Fatalf("vc+sd-jwt descriptor map must not contain path_nested")
+	}
+}
+
+// TestBuildCredentialEvidenceRejectsZeroValueLifecycleStage pins that
+// lifecycleStage has no default: an empty CredentialLifecycleStage (Go's
+// zero value for the type, e.g. from an uninitialized field at a new call
+// site) must be rejected rather than silently accepted and rendered with
+// the wrong "issued" vs "presented" wording downstream.
+func TestBuildCredentialEvidenceRejectsZeroValueLifecycleStage(t *testing.T) {
+	rawCredential := signedTestJWT(t, jwt.SigningMethodHS256, []byte("jwt-secret"), "vc+jwt", jwt.MapClaims{
+		"vc": map[string]interface{}{
+			"type": []string{"VerifiableCredential", "UniversityDegreeCredential"},
+		},
+	})
+	if _, err := BuildCredentialEvidence(rawCredential, ""); err == nil {
+		t.Fatalf("BuildCredentialEvidence accepted a zero-value lifecycle stage")
+	}
+	if _, err := BuildCredentialEvidence(rawCredential, CredentialLifecycleStage("bogus")); err == nil {
+		t.Fatalf("BuildCredentialEvidence accepted an unrecognized lifecycle stage")
+	}
+}
+
+// TestBuildCredentialEvidenceForMdocReportsExactCommittedCount is the direct
+// regression pin for the fabrication-constraint breach this workstream
+// exists to fix: an issued mdoc must report a real, non-zero,
+// exactly-committed element count sourced from the MSO valueDigests, never
+// the old hasDisclosures:false/disclosureCount:0 SD-JWT-tilde-counting
+// artifact that mdoc could never produce a true answer for.
+func TestBuildCredentialEvidenceForMdocReportsExactCommittedCount(t *testing.T) {
+	fixture := buildTestMdocCredential(t)
+
+	evidence, err := BuildCredentialEvidence(fixture.credential, LifecycleStageIssued)
+	if err != nil {
+		t.Fatalf("BuildCredentialEvidence(mso_mdoc): %v", err)
+	}
+	if evidence.Format != "mso_mdoc" {
+		t.Fatalf("evidence.Format = %q, want mso_mdoc", evidence.Format)
+	}
+	if evidence.Doctype != mdoc.DocTypeMDL {
+		t.Fatalf("evidence.Doctype = %q, want %q", evidence.Doctype, mdoc.DocTypeMDL)
+	}
+	if evidence.IssuedAt.IsZero() {
+		t.Fatalf("evidence.IssuedAt is zero; MSO ValidityInfo.Signed should have populated it")
+	}
+	if evidence.ExpiresAt.IsZero() {
+		t.Fatalf("evidence.ExpiresAt is zero; MSO ValidityInfo.ValidUntil should have populated it")
+	}
+
+	sd := evidence.SelectiveDisclosure
+	if sd == nil {
+		t.Fatalf("evidence.SelectiveDisclosure is nil for mso_mdoc; mdoc always has a selective-disclosure mechanism")
+	}
+	if sd.Mechanism != "mso_valuedigests" {
+		t.Fatalf("sd.Mechanism = %q, want mso_valuedigests", sd.Mechanism)
+	}
+	// The fixture commits exactly 2 elements (family_name, age_over_18).
+	// Zero here, on a credential that genuinely committed to 2 elements,
+	// is exactly the fabrication this evidence shape replaces.
+	if sd.CommittedCount != 2 {
+		t.Fatalf("sd.CommittedCount = %d, want 2 (family_name, age_over_18)", sd.CommittedCount)
+	}
+	if !sd.CommittedCountIsExact {
+		t.Fatalf("sd.CommittedCountIsExact = false for mso_valuedigests; ISO/IEC 18013-5 has no decoy-digest mechanism, so this must always be true")
+	}
+	if sd.PresentCount != 2 {
+		t.Fatalf("sd.PresentCount = %d, want 2", sd.PresentCount)
+	}
+	if sd.LifecycleStage != LifecycleStageIssued {
+		t.Fatalf("sd.LifecycleStage = %q, want %q", sd.LifecycleStage, LifecycleStageIssued)
+	}
+	if sd.DigestAlgorithm != mdoc.DigestAlgorithmSHA256 {
+		t.Fatalf("sd.DigestAlgorithm = %q, want %q", sd.DigestAlgorithm, mdoc.DigestAlgorithmSHA256)
+	}
+	if sd.HasUnrepresentedDisclosureForms {
+		t.Fatalf("sd.HasUnrepresentedDisclosureForms = true for mdoc; mdoc has no nested or array-element disclosure forms")
+	}
+	nsCounts, ok := sd.PerNamespace[string(mdoc.NameSpaceMDL)]
+	if !ok {
+		t.Fatalf("sd.PerNamespace missing %q: %#v", mdoc.NameSpaceMDL, sd.PerNamespace)
+	}
+	if nsCounts.CommittedCount != 2 || nsCounts.PresentCount != 2 {
+		t.Fatalf("sd.PerNamespace[%q] = %+v, want {2, 2}", mdoc.NameSpaceMDL, nsCounts)
+	}
+}
+
+// TestBuildCredentialEvidenceLifecycleStageIsCallerProvidedNotInferred pins
+// that lifecycle_stage on CredentialEvidence reflects the caller's
+// parameter, not something inferred from the (byte-identical either way)
+// mdoc artifact -- BuildCredentialEvidence has no way to tell an issued mDL
+// from the same mDL presented with every element intact, so the same raw
+// credential must faithfully echo back whichever stage the caller asserts.
+func TestBuildCredentialEvidenceLifecycleStageIsCallerProvidedNotInferred(t *testing.T) {
+	fixture := buildTestMdocCredential(t)
+
+	issuedEvidence, err := BuildCredentialEvidence(fixture.credential, LifecycleStageIssued)
+	if err != nil {
+		t.Fatalf("BuildCredentialEvidence(issued): %v", err)
+	}
+	if issuedEvidence.SelectiveDisclosure.LifecycleStage != LifecycleStageIssued {
+		t.Fatalf("issued call: LifecycleStage = %q, want %q", issuedEvidence.SelectiveDisclosure.LifecycleStage, LifecycleStageIssued)
+	}
+
+	presentedEvidence, err := BuildCredentialEvidence(fixture.credential, LifecycleStagePresented)
+	if err != nil {
+		t.Fatalf("BuildCredentialEvidence(presented): %v", err)
+	}
+	if presentedEvidence.SelectiveDisclosure.LifecycleStage != LifecycleStagePresented {
+		t.Fatalf("presented call: LifecycleStage = %q, want %q", presentedEvidence.SelectiveDisclosure.LifecycleStage, LifecycleStagePresented)
+	}
+	// Every other field must be identical: only the caller-supplied stage
+	// differs, confirming it is not derived from anything in the artifact.
+	if issuedEvidence.SelectiveDisclosure.CommittedCount != presentedEvidence.SelectiveDisclosure.CommittedCount {
+		t.Fatalf("CommittedCount differed between lifecycle stages on the identical artifact: issued=%d presented=%d",
+			issuedEvidence.SelectiveDisclosure.CommittedCount, presentedEvidence.SelectiveDisclosure.CommittedCount)
+	}
+}
+
+// TestBuildCredentialEvidenceForSDJWTCommittedCountIsNeverExact pins the
+// asymmetry the mdoc fix must not re-introduce in a subtler form: SD-JWT
+// permits decoy digests specifically so a verifier cannot infer the true
+// claim count from the "_sd" digest count alone, so CommittedCountIsExact
+// must read false unconditionally for sd_jwt_disclosures -- even for this
+// credential, which happens to carry no decoys and whose digest count
+// exactly matches its disclosure count. The format's property, not this
+// instance's coincidence, is what CommittedCountIsExact reports.
+func TestBuildCredentialEvidenceForSDJWTCommittedCountIsNeverExact(t *testing.T) {
+	disclosure, err := CreateSDJWTDisclosure("family_name", "Doe", "fixed-salt")
+	if err != nil {
+		t.Fatalf("CreateSDJWTDisclosure: %v", err)
+	}
+	rawCredential := BuildSDJWTSerialization(
+		signedTestJWT(t, jwt.SigningMethodHS256, []byte("sd-secret"), "vc+sd-jwt", jwt.MapClaims{
+			"vct": "https://example.org/credential",
+			"_sd": []string{disclosure.Digest},
+			"vc": map[string]interface{}{
+				"type": []string{"VerifiableCredential", "UniversityDegreeCredential"},
+			},
+		}),
+		[]string{disclosure.Encoded},
+		"",
+	)
+
+	evidence, err := BuildCredentialEvidence(rawCredential, LifecycleStageIssued)
+	if err != nil {
+		t.Fatalf("BuildCredentialEvidence(dc+sd-jwt): %v", err)
+	}
+	sd := evidence.SelectiveDisclosure
+	if sd == nil {
+		t.Fatalf("evidence.SelectiveDisclosure is nil for dc+sd-jwt")
+	}
+	if sd.Mechanism != "sd_jwt_disclosures" {
+		t.Fatalf("sd.Mechanism = %q, want sd_jwt_disclosures", sd.Mechanism)
+	}
+	if sd.CommittedCountIsExact {
+		t.Fatalf("sd.CommittedCountIsExact = true for sd_jwt_disclosures; SD-JWT's decoy-digest allowance means this must always be false")
+	}
+	if sd.PresentCount != 1 {
+		t.Fatalf("sd.PresentCount = %d, want 1", sd.PresentCount)
+	}
+}
+
+// TestBuildCredentialEvidenceOmitsSelectiveDisclosureForFullDisclosureFormats
+// pins that jwt_vc_json, jwt_vc_json-ld, and ldp_vc -- which always reveal
+// every claim they carry, with no selective-disclosure mechanism at all --
+// get a nil SelectiveDisclosure rather than a zeroed-out summary. A zeroed
+// struct (CommittedCount: 0, Mechanism: "") would read as "this credential
+// committed to nothing", the same shape of false claim mdoc's old
+// disclosureCount:0 made.
+func TestBuildCredentialEvidenceOmitsSelectiveDisclosureForFullDisclosureFormats(t *testing.T) {
+	rawCredential := signedTestJWT(t, jwt.SigningMethodHS256, []byte("jwt-secret"), "vc+jwt", jwt.MapClaims{
+		"vc": map[string]interface{}{
+			"@context": []string{"https://www.w3.org/2018/credentials/v1"},
+			"type":     []string{"VerifiableCredential", "UniversityDegreeCredential"},
+		},
+	})
+	evidence, err := BuildCredentialEvidence(rawCredential, LifecycleStageIssued)
+	if err != nil {
+		t.Fatalf("BuildCredentialEvidence(jwt_vc_json-ld): %v", err)
+	}
+	if evidence.SelectiveDisclosure != nil {
+		t.Fatalf("evidence.SelectiveDisclosure = %+v, want nil for a format with no selective-disclosure mechanism", evidence.SelectiveDisclosure)
 	}
 }

--- a/docs/packages/oid4vci.md
+++ b/docs/packages/oid4vci.md
@@ -70,6 +70,7 @@ The default and lead `credential_configurations_supported` entry is the ISO/IEC 
 - Authorization-code and HAIP-related issuance controls are covered by backend
   HTTP tests; the Looking Glass flow list below exposes only pre-authorized
   issuance variants.
+- Issued credentials of any registered format, including `mso_mdoc`, are inspectable via the gateway's `POST /lookingglass/decode/credential` (see [Credential Inspection](../starlight/src/content/docs/protocols/oid4vci.mdx#credential-inspection-looking-glass)). It decodes through the same shared `CredentialFormat` registry and evidence shape issuance and OID4VP verification already use, and reports issuer trust plus (`mso_mdoc` only) MSO digest consistency in an assurance envelope kept structurally separate from the decoded evidence — never a blanket validity flag.
 
 ## Failure Semantics
 

--- a/docs/starlight/public/openapi/gateway.yaml
+++ b/docs/starlight/public/openapi/gateway.yaml
@@ -212,6 +212,72 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/lookingglass/decode/credential:
+    post:
+      tags: [LookingGlass]
+      summary: Decode a verifiable credential for Looking Glass inspection
+      description: >-
+        Decodes a pasted credential of any registered format -- including
+        mso_mdoc -- into the same shared evidence shape issuance and
+        verification already produce, wrapped in an assurance envelope. The
+        response keeps decoded-but-unverified evidence and checked assurance
+        as separate top-level objects: this endpoint supplies no issuer keys
+        or trust anchors, so `assurance.issuer_trust` reads `not_evaluated`
+        for every format, never a blanket validity flag. The request body is
+        capped at 64 KiB, and CBOR-based formats (mso_mdoc) are decoded under
+        hardened depth and collection limits because the input is
+        externally-supplied and untrusted.
+      operationId: decodeGatewayCredential
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DecodeCredentialRequest"
+            examples:
+              mso_mdoc:
+                value:
+                  credential: "omRkb2NUeXBldW9yZy5pc28uMTgwMTMuNS4xLm1ETA..."
+      responses:
+        "200":
+          description: Decoded credential evidence and assurance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DecodeCredentialResponse"
+              examples:
+                mso_mdoc:
+                  value:
+                    evidence:
+                      format: mso_mdoc
+                      doctype: "org.iso.18013.5.1.mDL"
+                      full_claims:
+                        "org.iso.18013.5.1":
+                          document_number: "D1234567"
+                          driving_privileges: []
+                      selective_disclosure:
+                        mechanism: mso_valuedigests
+                        committed_count: 11
+                        committed_count_is_exact: true
+                        present_count: 11
+                        lifecycle_stage: issued
+                        digest_algorithm: "SHA-256"
+                        has_unrepresented_disclosure_forms: false
+                    assurance:
+                      issuer_trust: not_evaluated
+                      digests_consistent_with_mso: true
+        "400":
+          description: Invalid, oversized, or unparseable credential.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Looking Glass is disabled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/lookingglass/sessions:
     get:
       tags: [LookingGlass]
@@ -456,4 +522,174 @@ components:
       required: [token]
       properties:
         token:
+          type: string
+    DecodeCredentialRequest:
+      type: object
+      required: [credential]
+      properties:
+        credential:
+          type: string
+          description: >-
+            A raw credential artifact: a compact SD-JWT VC, a JWT/JSON-LD VC,
+            or a base64url-encoded ISO/IEC 18013-5 mso_mdoc IssuerSigned
+            structure. The request body is capped at 64 KiB.
+    DecodeCredentialResponse:
+      type: object
+      required: [evidence, assurance]
+      description: >-
+        Evidence and assurance are separate top-level objects so a client
+        cannot merge "what this artifact contains" and "what has been
+        checked about it" into one register by accident.
+      properties:
+        evidence:
+          $ref: "#/components/schemas/CredentialEvidence"
+        assurance:
+          $ref: "#/components/schemas/CredentialAssurance"
+    CredentialEvidence:
+      type: object
+      description: >-
+        Format-agnostic view of the credential's own claims, shared verbatim
+        with the evidence shape issuance and OID4VP verification produce.
+        This is decoded content, not a trust statement -- see
+        CredentialAssurance for what has actually been checked.
+      properties:
+        format:
+          type: string
+          example: mso_mdoc
+        vct:
+          type: string
+          description: SD-JWT VC type (`vct` claim). Absent for other formats.
+        doctype:
+          type: string
+          description: >-
+            mdoc doctype, e.g. `org.iso.18013.5.1.mDL`, from the
+            MobileSecurityObject. Absent for other formats.
+        credential_types:
+          type: array
+          items:
+            type: string
+        full_claims:
+          type: object
+          additionalProperties: true
+          description: >-
+            Every claim the credential carries, namespace-nested for mdoc.
+        disclosed_claims:
+          type: object
+          additionalProperties: true
+          description: The subset of full_claims actually disclosed by this artifact.
+        selective_disclosure:
+          $ref: "#/components/schemas/SelectiveDisclosureSummary"
+        issued_at:
+          type: string
+          format: date-time
+          description: >-
+            Present only when the source credential itself carries this
+            claim (mdoc MSO validityInfo.signed; ldp_vc issuanceDate/
+            validFrom); never back-filled with wall-clock time.
+        expires_at:
+          type: string
+          format: date-time
+          description: >-
+            Present only when the source credential itself carries this
+            claim; never back-filled.
+    SelectiveDisclosureSummary:
+      type: object
+      description: >-
+        Present only for the two formats with a selective-disclosure
+        mechanism (mso_mdoc, dc+sd-jwt). Absent entirely -- not zeroed -- for
+        formats that always reveal every claim (jwt_vc_json, jwt_vc_json-ld,
+        ldp_vc).
+      required:
+        - mechanism
+        - committed_count
+        - committed_count_is_exact
+        - present_count
+        - lifecycle_stage
+        - has_unrepresented_disclosure_forms
+      properties:
+        mechanism:
+          type: string
+          enum: [mso_valuedigests, sd_jwt_disclosures]
+          description: Names what committed_count actually counts.
+        committed_count:
+          type: integer
+          description: >-
+            Exact element count for mso_valuedigests (ISO/IEC 18013-5 has no
+            decoy-digest mechanism). An upper bound for sd_jwt_disclosures,
+            since SD-JWT deliberately permits decoy digests so a verifier
+            cannot infer the true claim count from the digest count alone --
+            see committed_count_is_exact.
+        committed_count_is_exact:
+          type: boolean
+          description: >-
+            True only for mso_valuedigests. Always false for
+            sd_jwt_disclosures, even when a specific credential happens to
+            carry no decoys -- the point is that the format permits them.
+        present_count:
+          type: integer
+          description: >-
+            Element/disclosure count actually carried by this artifact. Its
+            meaning depends on lifecycle_stage: at "issued" this is a
+            property of the format (every element/disclosure the issuer
+            sent), not a holder decision, and must not be worded as a
+            disclosure ratio. Only "presented" may use "N of M disclosed"
+            phrasing.
+        lifecycle_stage:
+          type: string
+          enum: [issued, presented]
+        digest_algorithm:
+          type: string
+          example: "SHA-256"
+          description: mso.DigestAlgorithm for mdoc, or the SD-JWT _sd_alg claim.
+        per_namespace:
+          type: object
+          description: mdoc only. Absent for SD-JWT, which has no namespace concept.
+          additionalProperties:
+            $ref: "#/components/schemas/NamespaceDisclosureCounts"
+        has_unrepresented_disclosure_forms:
+          type: boolean
+          description: >-
+            True when an SD-JWT structure contains a disclosure form
+            committed_count's flat count does not represent -- a nested
+            disclosure or an array-element redaction marker. Always false
+            for mdoc. When true, present_count/committed_count must not be
+            presented as a complete picture.
+    NamespaceDisclosureCounts:
+      type: object
+      required: [committed_count, present_count]
+      properties:
+        committed_count:
+          type: integer
+        present_count:
+          type: integer
+    CredentialAssurance:
+      type: object
+      description: >-
+        What has actually been checked about the artifact. Kept structurally
+        separate from CredentialEvidence's decoded-but-unverified claims, and
+        never collapsed to a single validity flag.
+      required: [issuer_trust]
+      properties:
+        issuer_trust:
+          type: string
+          enum: [verified, failed, not_evaluated]
+          description: >-
+            Tri-state, computed by actually invoking issuer-signature
+            validation rather than hardcoded. This endpoint supplies no
+            issuer keys or trust anchors, so this reads "not_evaluated" for
+            every format today -- distinct from "failed", which means a
+            check ran against real trust material and did not succeed.
+        issuer_trust_detail:
+          type: string
+        digests_consistent_with_mso:
+          type: boolean
+          description: >-
+            mso_mdoc only; absent entirely (not false) for every other
+            format. True means each presented IssuerSignedItem's digest
+            matches the credential's own MSO valueDigests -- internal
+            self-consistency between the items and the MSO, NOT authenticity
+            of the MSO itself. An unauthenticated MSO with matching digests
+            is trivially forgeable. Must never be read or labelled as
+            "verified" or "ok".
+        digest_consistency_detail:
           type: string

--- a/docs/starlight/src/content/docs/developers/development-setup.mdx
+++ b/docs/starlight/src/content/docs/developers/development-setup.mdx
@@ -73,6 +73,7 @@ Run the smallest set that covers your change before requesting review.
 | Backend lint-sensitive changes | `cd backend && golangci-lint run ./...` |
 | Frontend UI or Looking Glass | `cd frontend && npm run lint && npx tsc --noEmit && npm run build` |
 | Frontend protocol references | `cd frontend && npm run verify-refs` |
+| `cnf.jkt` / JWK thumbprint helper (`src/utils/crypto.ts`) | `cd frontend && npm run verify-jwk-thumbprint` |
 | Wallet UI | `cd wallet-ui && npx tsc --noEmit && npm run build` |
 | Docs site | `cd docs/starlight && npm run build` |
 | OpenAPI contracts | `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1` |
@@ -81,7 +82,7 @@ Run the smallest set that covers your change before requesting review.
 | Palette content (`content/**`) | `cd backend && go run ./cmd/content-validate -content ../content && go test ./internal/palette/...` |
 | Palette indexer or query service | `cd backend && go test ./internal/palette/... && go run ./cmd/palette-indexer -content ../content -out ./dist/palette.db` |
 
-The protocol-reference verifier retries temporary upstream failures. Responses that do not prove a link is dead—such as bot-blocking `403`, rate-limiting `429`, and temporary `5xx` responses—are reported as warnings; definitive failures such as `404` or `410`, missing anchors, and section mismatches remain errors. Pass `--strict` to make warnings fail the command.
+The protocol-reference verifier retries temporary upstream failures. Responses that do not prove a link is dead such as bot-blocking `403`, rate-limiting `429`, and temporary `5xx` responses—are reported as warnings; definitive failures such as `404` or `410`, missing anchors, and section mismatches remain errors. Pass `--strict` to make warnings fail the command.
 
 The canonical contract for palette artefacts lives in [`content/SCHEMA.md`](https://github.com/ParleSec/ProtocolSoup/blob/master/content/SCHEMA.md). New axis values must be added to `content/taxonomy.yaml`, and synonyms to `content/aliases.yaml`. Both files are validated in CI by `cmd/content-validate`.
 

--- a/docs/starlight/src/content/docs/protocols/oid4vci.mdx
+++ b/docs/starlight/src/content/docs/protocols/oid4vci.mdx
@@ -168,6 +168,17 @@ As of the parity-then-flip change, the issuer's **default and lead** credential 
 
 Note that the mDL proof uses an EC P-256 device key signed with `ES256`: the proof `cnf.jwk` is bound into the MSO `deviceKeyInfo.deviceKey` as a COSE_Key, per ISO/IEC 18013-5.
 
+## Credential Inspection (Looking Glass)
+
+The Looking Glass credential inspector treats every registered credential format — including `mso_mdoc`, the default and lead configuration — as a first-class surface; there is no per-format branch in the UI. After the credential endpoint returns an issued credential, the Looking Glass flow calls `POST /lookingglass/decode/credential` to decode it through the same shared `CredentialFormat` registry and evidence shape that OID4VP presentation verification already produces, rather than a JWT-only decoder that would treat `mso_mdoc`'s CBOR encoding as opaque.
+
+The response keeps two things structurally separate, because they must never be rendered as if they were the same claim:
+
+- **Evidence** - the credential's own claims (namespace-nested for `mso_mdoc`), plus a selective-disclosure summary naming its mechanism (`mso_valuedigests` for `mso_mdoc`, `sd_jwt_disclosures` for `dc+sd-jwt`), a committed-element count, and whether that count is exact. The `mso_mdoc` MSO `valueDigests` count is exact — ISO/IEC 18013-5 has no decoy-digest mechanism. An SD-JWT `_sd` digest count is reported as an upper bound only, because the spec permits decoy digests specifically so a verifier cannot infer the true claim count from it. This replaces an earlier disclosure count that used SD-JWT tilde-counting semantics for every format, which was always zero for `mso_mdoc` regardless of how many elements the MSO actually committed to.
+- **Assurance** - what has actually been checked, never collapsed into a single validity flag. This endpoint supplies no issuer keys or IACA trust anchors, so `issuer_trust` reads `not_evaluated` for every format — distinct from `failed`, which means a signature check ran against real trust material and did not succeed. For `mso_mdoc` only, `digests_consistent_with_mso` independently recomputes each disclosed `IssuerSignedItem`'s digest against the credential's own MSO `valueDigests`. That proves internal consistency between the items and the MSO, **not authenticity of the MSO itself** — an unauthenticated MSO with matching digests is trivially forgeable.
+
+Both fields are part of the shared, format-agnostic evidence/assurance shape rather than `mso_mdoc`-specific additions: the same selective-disclosure summary and assurance envelope render for `dc+sd-jwt`, `jwt_vc_json`, `jwt_vc_json-ld`, and `ldp_vc`, with the fields that do not apply to a given format simply absent rather than zeroed.
+
 ## What To Validate
 
 - Credential offer envelope: exactly one of `credential_offer` or `credential_offer_uri`
@@ -181,3 +192,4 @@ Note that the mDL proof uses an EC P-256 device key signed with `ES256`: the pro
 - Client attestation (when configured): a request presenting `OAuth-Client-Attestation`/`-PoP` is authenticated by that mechanism, not silently downgraded on failure; replayed PoP `jti` is rejected
 - Key attestation (when a configuration requires it): credential requests without a valid `key_attestation` proof header are rejected with `invalid_proof`
 - Encrypted responses (when requested): `credential_response_encryption` is validated against advertised `alg`/`enc` values and the response is returned as a JWE
+- Credential inspection: `POST /lookingglass/decode/credential` on an issued `mso_mdoc` reports a non-zero, exact `committed_count` and `issuer_trust: not_evaluated` (never `failed`, since no trust anchor was supplied); the same call on `dc+sd-jwt` reports `committed_count_is_exact: false`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "start": "next start",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0",
     "verify-refs": "node scripts/verify-references.mjs",
+    "verify-jwk-thumbprint": "node --experimental-strip-types scripts/verify-jwk-thumbprint.mjs",
     "generate-og-image": "node scripts/generate-og-image.mjs"
   },
   "dependencies": {

--- a/frontend/scripts/verify-jwk-thumbprint.mjs
+++ b/frontend/scripts/verify-jwk-thumbprint.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Verifies src/utils/crypto.ts's jwkThumbprint() against RFC 7638 known-answer
+// vectors and its own documented edge-case contract.
+//
+// This imports the actual shipped implementation (not a reimplementation
+// local to this script) via Node's native TypeScript type-stripping, so a
+// regression in jwkThumbprint itself -- a wrong member order, a dropped kty
+// branch, a hash/encoding mistake -- fails this check. The TokenInspector
+// cnf.jkt panel (backend/internal/crypto/keys.go's Go Thumbprint(), mirrored
+// here) renders a match/mismatch verdict entirely on this function's output,
+// so a silently-wrong thumbprint would render a false verdict rather than an
+// error the PR checklist's self-attestation can't be relied on alone to catch
+// for external contributions -- see CONTRIBUTING.md and the CI step that runs
+// this alongside verify-refs.
+//
+// Vector provenance (each computed independently against the cited RFC's own
+// published test key before being pinned as an expected constant below; the
+// RSA vector's expected value is the RFC's own published thumbprint, which
+// both confirms this script's method and pins the shipped implementation
+// against it):
+//   - RSA:  RFC 7638 Section 3.1 example key and its published thumbprint.
+//   - EC:   RFC 7515 Appendix A.3 ES256 example public key (P-256).
+//   - OKP:  RFC 8037 Appendix A.1 Ed25519 example public key.
+//
+// The same three vectors, with the identical expected constants, are also
+// pinned in backend/internal/crypto/keys_test.go's TestThumbprintSpecVectors
+// against Go's Thumbprint(). That test and this script are the cross-check:
+// TypeScript and Go are asserted against the same known answers rather than
+// each being merely self-consistent, so a canonicalization or encoding
+// mismatch between the two implementations fails on whichever side
+// regressed instead of passing silently because nothing compares them to
+// each other.
+//
+// Usage: npm run verify-jwk-thumbprint
+
+import { jwkThumbprint } from '../src/utils/crypto.ts'
+
+const KNOWN_ANSWER_VECTORS = [
+  {
+    name: 'RSA (RFC 7638 §3.1 example key)',
+    jwk: {
+      kty: 'RSA',
+      n: '0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw',
+      e: 'AQAB',
+    },
+    // Published verbatim in RFC 7638 Section 3.1: "the value ... base64url
+    // encoded ... is: NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs".
+    expected: 'NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs',
+  },
+  {
+    name: 'EC P-256 (RFC 7515 Appendix A.3 public key)',
+    jwk: {
+      kty: 'EC',
+      crv: 'P-256',
+      x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+      y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+    },
+    expected: 'oKIywvGUpTVTyxMQ3bwIIeQUudfr_CkLMjCE19ECD-U',
+  },
+  {
+    name: 'OKP Ed25519 (RFC 8037 Appendix A.1 public key)',
+    jwk: {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+    },
+    expected: 'kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k',
+  },
+  {
+    name: 'EC P-256 with extra members and scrambled field order',
+    // Same key as the RFC 7515 vector above, but with alg/use/kid noise
+    // mixed in and the source object's own member order scrambled (x
+    // before crv, kty last). RFC 7638 Section 3.2 defines the thumbprint
+    // over exactly {crv, kty, x, y} for an EC key, nothing else, in that
+    // lexicographic order -- this must still produce the identical digest
+    // as the clean vector above. It would not if a future change stopped
+    // explicitly destructuring the required members into a fresh object
+    // and instead forwarded the caller's object (e.g. via spread), which
+    // would let extra members and input order leak into what gets hashed.
+    jwk: {
+      x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+      alg: 'ES256',
+      y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+      use: 'sig',
+      crv: 'P-256',
+      kid: 'test-key-1',
+      kty: 'EC',
+    },
+    expected: 'oKIywvGUpTVTyxMQ3bwIIeQUudfr_CkLMjCE19ECD-U',
+  },
+]
+
+// Edge cases from jwkThumbprint's own doc comment: an unsupported or
+// malformed key must return null (a distinct "cannot compute" state), never
+// throw and never guess a value that could render as a false match or
+// mismatch in the TokenInspector panel.
+const NULL_RESULT_CASES = [
+  { name: 'unsupported kty (oct)', jwk: { kty: 'oct', k: 'GawgguFyGrWKav7AX4VKUg' } },
+  { name: 'missing kty', jwk: { n: 'abc', e: 'AQAB' } },
+  { name: 'RSA missing n', jwk: { kty: 'RSA', e: 'AQAB' } },
+  { name: 'RSA missing e', jwk: { kty: 'RSA', n: 'abc' } },
+  { name: 'EC missing y', jwk: { kty: 'EC', crv: 'P-256', x: 'abc' } },
+  { name: 'OKP missing x', jwk: { kty: 'OKP', crv: 'Ed25519' } },
+]
+
+async function main() {
+  const failures = []
+
+  for (const vector of KNOWN_ANSWER_VECTORS) {
+    const computed = await jwkThumbprint(vector.jwk)
+    if (computed === vector.expected) {
+      console.log(`[PASS] ${vector.name}`)
+    } else {
+      failures.push(vector.name)
+      console.log(`[FAIL] ${vector.name}`)
+      console.log(`       expected: ${vector.expected}`)
+      console.log(`       computed: ${computed}`)
+    }
+  }
+
+  for (const testCase of NULL_RESULT_CASES) {
+    const computed = await jwkThumbprint(testCase.jwk)
+    if (computed === null) {
+      console.log(`[PASS] ${testCase.name} -> null`)
+    } else {
+      failures.push(testCase.name)
+      console.log(`[FAIL] ${testCase.name}`)
+      console.log(`       expected: null (cannot compute)`)
+      console.log(`       computed: ${computed}`)
+    }
+  }
+
+  console.log(`\n${KNOWN_ANSWER_VECTORS.length + NULL_RESULT_CASES.length} checks run, ${failures.length} failure(s).`)
+  if (failures.length > 0) {
+    console.log(`Failed: ${failures.join(', ')}`)
+    process.exit(1)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(2)
+})

--- a/frontend/src/lookingglass/components/StepCards.tsx
+++ b/frontend/src/lookingglass/components/StepCards.tsx
@@ -770,7 +770,7 @@ function TokenBlock({ event, decoded }: { event: FlowEvent; decoded: DecodedToke
   )
 }
 
-const KEY_CLAIMS = ['sub', 'iss', 'aud', 'exp', 'iat', 'scope', 'nonce', 'azp', 'client_id'] as const
+const KEY_CLAIMS = ['sub', 'iss', 'aud', 'exp', 'iat', 'scope', 'nonce', 'azp', 'client_id', 'cnf'] as const
 
 function TokenClaimsSummary({
   header,

--- a/frontend/src/lookingglass/components/inspectors/TokenInspector.tsx
+++ b/frontend/src/lookingglass/components/inspectors/TokenInspector.tsx
@@ -1,14 +1,23 @@
-import { useMemo, useState, type ElementType, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ElementType, type ReactNode } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   Shield, AlertTriangle, CheckCircle, XCircle, Clock,
   User, Key, Lock, Globe, Info, ChevronDown, Copy, Check,
-  FileText, Fingerprint, Calendar
+  FileText, Fingerprint, Calendar, ShieldQuestion
 } from 'lucide-react'
-import { decodeJWTWithoutValidation } from '../../../utils/crypto'
+import { decodeJWTWithoutValidation, jwkThumbprint } from '../../../utils/crypto'
+import { FieldRow } from '../shared'
 
 interface TokenInspectorProps {
   token: string
+  /**
+   * OAuth 2.0 token_type (RFC 6749 Section 5.1), e.g. "Bearer" or "DPoP".
+   * Only meaningful for an access token, so callers pass this only when
+   * `token` is the currently-held access token -- id_token, refresh_token,
+   * client_assertion, and manually-pasted tokens have no token_type and
+   * must leave this undefined rather than guessing "Bearer".
+   */
+  tokenType?: string
 }
 
 interface DecodedToken {
@@ -18,6 +27,24 @@ interface DecodedToken {
   isValid: boolean
   error?: string
 }
+
+// KeyBindingInfo mirrors TLSInspector's TokenBindingInfo pattern (compute a
+// real thumbprint, compare, report match/mismatch/missing) but as its own
+// type rather than a shared one, because RFC 7800 cnf.jwk/cnf.jkt has more
+// partial-data shapes than RFC 8705's cnf.x5t#S256 (which only ever
+// compares against a TLS-layer certificate thumbprint that either exists
+// or doesn't): a token can carry jwk without jkt, jkt without jwk, or a
+// jwk whose kty this codebase's thumbprint helper cannot compute for.
+// 'unsupported_kty' is deliberately its own state, never folded into
+// 'mismatch': an unknown future kty must never render as a failed
+// comparison when no comparison was actually possible.
+type KeyBindingInfo =
+  | { status: 'not_bound' }
+  | { status: 'jwk_only'; jwk: Record<string, unknown> }
+  | { status: 'jkt_only'; jkt: string }
+  | { status: 'unsupported_kty'; jwk: Record<string, unknown>; jkt: string; kty: string }
+  | { status: 'match'; jwk: Record<string, unknown>; jkt: string; computedThumbprint: string }
+  | { status: 'mismatch'; jwk: Record<string, unknown>; jkt: string; computedThumbprint: string }
 
 // Standard JWT claim explanations
 const claimInfo: Record<string, { label: string; description: string; icon: ElementType }> = {
@@ -35,9 +62,10 @@ const claimInfo: Record<string, { label: string; description: string; icon: Elem
   name: { label: 'Name', description: "User's full name", icon: User },
   preferred_username: { label: 'Username', description: "User's preferred username", icon: User },
   email_verified: { label: 'Email Verified', description: 'Whether email has been verified', icon: CheckCircle },
+  cnf: { label: 'Confirmation Key', description: 'Proof-of-possession key binding (RFC 7800)', icon: Fingerprint },
 }
 
-export function TokenInspector({ token }: TokenInspectorProps) {
+export function TokenInspector({ token, tokenType }: TokenInspectorProps) {
   const [expandedSection, setExpandedSection] = useState<'header' | 'payload' | 'signature' | null>('payload')
   const [copiedClaim, setCopiedClaim] = useState<string | null>(null)
 
@@ -87,6 +115,72 @@ export function TokenInspector({ token }: TokenInspectorProps) {
       }
     }
   }, [token])
+
+  const [keyBinding, setKeyBinding] = useState<KeyBindingInfo | null>(null)
+
+  // jwkThumbprint is async (crypto.subtle.digest), so the RFC 7638 compare
+  // cannot live in the useMemo above. `cancelled` guards against a stale
+  // computation from a previous token resolving after a newer one has
+  // already started, which would otherwise render the wrong verdict for a
+  // moment.
+  useEffect(() => {
+    let cancelled = false
+    const cnf = decoded?.payload.cnf as Record<string, unknown> | undefined
+    const jwk = cnf?.jwk && typeof cnf.jwk === 'object' ? (cnf.jwk as Record<string, unknown>) : undefined
+    const jkt = typeof cnf?.jkt === 'string' ? cnf.jkt : undefined
+
+    if (!cnf) {
+      setKeyBinding(null)
+      return
+    }
+    if (!jwk && !jkt) {
+      setKeyBinding({ status: 'not_bound' })
+      return
+    }
+    if (!jwk || !jkt) {
+      // Exactly one of the two is present: "both absent" already
+      // returned above, so this is jwk-only or jkt-only. TypeScript can
+      // narrow a single `!a || !b` condition; it cannot deduce "both
+      // present" from three separate prior if-statements the way a human
+      // reader can, which is why this is one combined check rather than
+      // a third `if (jwk && !jkt) ... if (jkt && !jwk) ...` pair.
+      if (jwk) {
+        setKeyBinding({ status: 'jwk_only', jwk })
+      } else if (jkt) {
+        setKeyBinding({ status: 'jkt_only', jkt })
+      }
+      return
+    }
+
+    // Both present here. Rebinding to new consts (rather than relying on
+    // jwk/jkt directly) keeps them narrowed to defined inside the .then()
+    // closure below without a non-null assertion at each use.
+    const boundJwk = jwk
+    const boundJkt = jkt
+
+    jwkThumbprint(boundJwk).then((computed) => {
+      if (cancelled) return
+      if (computed === null) {
+        setKeyBinding({
+          status: 'unsupported_kty',
+          jwk: boundJwk,
+          jkt: boundJkt,
+          kty: typeof boundJwk.kty === 'string' ? boundJwk.kty : 'unknown',
+        })
+      } else {
+        setKeyBinding({
+          status: computed === boundJkt ? 'match' : 'mismatch',
+          jwk: boundJwk,
+          jkt: boundJkt,
+          computedThumbprint: computed,
+        })
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [decoded])
 
   const copyToClipboard = (text: string, claim: string) => {
     navigator.clipboard.writeText(text)
@@ -167,12 +261,22 @@ export function TokenInspector({ token }: TokenInspectorProps) {
             </p>
           )}
         </div>
-        {decoded.header.alg !== undefined && (
-          <span className="px-2 sm:px-3 py-1 rounded-full bg-white/10 text-xs font-medium text-white flex-shrink-0">
-            {String(decoded.header.alg)}
-          </span>
-        )}
+        <div className="flex flex-col items-end gap-1 flex-shrink-0">
+          {tokenType && (
+            <span className="px-2 sm:px-3 py-1 rounded-full bg-indigo-500/20 text-xs font-medium text-indigo-300">
+              {tokenType}
+            </span>
+          )}
+          {decoded.header.alg !== undefined && (
+            <span className="px-2 sm:px-3 py-1 rounded-full bg-white/10 text-xs font-medium text-white">
+              {String(decoded.header.alg)}
+            </span>
+          )}
+        </div>
       </div>
+
+      {/* Key Binding (RFC 7800) */}
+      <KeyBindingBlock binding={keyBinding} />
 
       {/* Visual Token Breakdown */}
       <div className="p-3 sm:p-4 rounded-xl bg-surface-900/50 border border-white/5">
@@ -297,6 +401,86 @@ export function TokenInspector({ token }: TokenInspectorProps) {
       </div>
     </div>
   )
+}
+
+// KeyBindingBlock renders RFC 7800 confirmation-key binding, modelled on
+// TLSInspector's Certificate Binding (RFC 8705) treatment: a real
+// thumbprint is computed from cnf.jwk and compared against the claimed
+// cnf.jkt rather than the panel trusting either value on its own. Renders
+// nothing for a token with no cnf claim at all -- a token that was never
+// meant to be key-bound gets no block, rather than a block reporting
+// "not bound" as if that were itself a finding.
+function KeyBindingBlock({ binding }: { binding: KeyBindingInfo | null }) {
+  if (!binding || binding.status === 'not_bound') {
+    return null
+  }
+
+  const { icon: Icon, tone, label } = keyBindingStatusDisplay(binding.status)
+  const kty = keyBindingKty(binding)
+
+  return (
+    <div className="p-3 sm:p-4 rounded-xl bg-surface-900/50 border border-white/5">
+      <div className="flex items-center gap-2 mb-2">
+        <Fingerprint className="w-4 h-4 text-surface-400" />
+        <h4 className="text-xs font-semibold text-surface-400 uppercase tracking-wider">Key Binding (RFC 7800)</h4>
+      </div>
+      <div className="rounded-lg bg-surface-950 p-2.5 text-xs space-y-1.5">
+        <div className={`flex items-center gap-1.5 font-medium ${tone}`}>
+          <Icon className="w-3.5 h-3.5" />
+          {label}
+        </div>
+        {kty && <FieldRow label="cnf.jwk.kty" value={kty} />}
+        {binding.status === 'jkt_only' && <FieldRow label="cnf.jkt" value={binding.jkt} mono />}
+        {(binding.status === 'unsupported_kty' || binding.status === 'match' || binding.status === 'mismatch') && (
+          <FieldRow label="cnf.jkt (claimed)" value={binding.jkt} mono />
+        )}
+        {(binding.status === 'match' || binding.status === 'mismatch') && (
+          <FieldRow
+            label="Computed thumbprint"
+            value={binding.computedThumbprint}
+            mono
+            valueClassName={binding.status === 'match' ? 'text-green-300' : 'text-red-300'}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// keyBindingKty reads kty for display: 'unsupported_kty' carries it as its
+// own field (computed before the jwkThumbprint call, since that call is
+// exactly what failed to produce a usable kty branch), every other
+// jwk-bearing state reads it straight off the jwk, and 'jkt_only' has no
+// jwk at all to read one from.
+function keyBindingKty(binding: KeyBindingInfo): string | undefined {
+  switch (binding.status) {
+    case 'not_bound':
+    case 'jkt_only':
+      return undefined
+    case 'unsupported_kty':
+      return binding.kty
+    case 'jwk_only':
+    case 'match':
+    case 'mismatch':
+      return typeof binding.jwk.kty === 'string' ? binding.jwk.kty : 'unknown'
+  }
+}
+
+function keyBindingStatusDisplay(status: KeyBindingInfo['status']): { icon: ElementType; tone: string; label: string } {
+  switch (status) {
+    case 'match':
+      return { icon: CheckCircle, tone: 'text-green-400', label: 'jkt matches the jwk thumbprint' }
+    case 'mismatch':
+      return { icon: XCircle, tone: 'text-red-400', label: 'jkt does not match the jwk thumbprint' }
+    case 'unsupported_kty':
+      return { icon: ShieldQuestion, tone: 'text-yellow-400', label: 'Cannot compute a thumbprint for this key type' }
+    case 'jwk_only':
+      return { icon: AlertTriangle, tone: 'text-yellow-400', label: 'cnf.jwk present, no cnf.jkt to compare against' }
+    case 'jkt_only':
+      return { icon: AlertTriangle, tone: 'text-yellow-400', label: 'cnf.jkt present, no cnf.jwk to verify against' }
+    case 'not_bound':
+      return { icon: Info, tone: 'text-surface-400', label: 'Not key-bound' }
+  }
 }
 
 // Token Section Component

--- a/frontend/src/lookingglass/components/inspectors/VCInspector.tsx
+++ b/frontend/src/lookingglass/components/inspectors/VCInspector.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState, type ElementType } from 'react'
+import { useMemo, useState, type ElementType, type JSX } from 'react'
 import {
   Activity,
+  AlertTriangle,
   Check,
   Clock,
   Copy,
@@ -8,11 +9,13 @@ import {
   FileText,
   KeyRound,
   QrCode,
+  ShieldAlert,
   ShieldCheck,
   ShieldX,
 } from 'lucide-react'
-import type { VCArtifact } from '../../flows/base'
+import type { CredentialInspectionMetadata, VCArtifact } from '../../flows/base'
 import { decodeJWTWithoutValidation } from '../../../utils/crypto'
+import type { DecodeCredentialEvidence, DecodeCredentialSelectiveDisclosure } from '../../../utils/api'
 
 interface VCInspectorProps {
   artifacts: VCArtifact[]
@@ -52,7 +55,7 @@ export function VCInspector({ artifacts }: VCInspectorProps) {
         const checks = getCheckList(metadata)
         const reasons = getReasonList(metadata)
         const reasonCodes = getReasonCodeList(metadata)
-        const credentialEvidence = getCredentialEvidence(metadata)
+        const credentialEvidenceDisplay = getCredentialEvidence(metadata)
         const deferredIssuance = getDeferredIssuance(metadata)
         const deferredStatus = deferredIssuance ? deferredStatusConfig(deferredIssuance.status) : null
 
@@ -151,67 +154,7 @@ export function VCInspector({ artifacts }: VCInspectorProps) {
                 </div>
               )}
 
-              {credentialEvidence && (
-                <div className="p-2 rounded bg-surface-950 border border-white/5 space-y-2">
-                  <div className="text-xs text-surface-300">Credential evidence (full vs disclosed)</div>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-[11px]">
-                    <div className="p-2 rounded bg-surface-900 border border-white/5">
-                      <div className="text-surface-400 mb-1">Subject</div>
-                      <div className="text-surface-200 font-mono break-all">{credentialEvidence.subject || 'n/a'}</div>
-                    </div>
-                    <div className="p-2 rounded bg-surface-900 border border-white/5">
-                      <div className="text-surface-400 mb-1">Format</div>
-                      <div className="text-surface-200 font-mono break-all">{credentialEvidence.format || 'n/a'}</div>
-                    </div>
-                    <div className="p-2 rounded bg-surface-900 border border-white/5">
-                      <div className="text-surface-400 mb-1">Issuer</div>
-                      <div className="text-surface-200 font-mono break-all">{credentialEvidence.issuer || 'n/a'}</div>
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-[11px]">
-                    <div className="p-2 rounded bg-surface-900 border border-white/5">
-                      <div className="text-surface-400 mb-1">VCT</div>
-                      <div className="text-surface-200 font-mono break-all">{credentialEvidence.vct || 'n/a'}</div>
-                    </div>
-                    <div className="p-2 rounded bg-surface-900 border border-white/5">
-                      <div className="text-surface-400 mb-1">doctype</div>
-                      <div className="text-surface-200 font-mono break-all">{credentialEvidence.doctype || 'n/a'}</div>
-                    </div>
-                    <div className="p-2 rounded bg-surface-900 border border-white/5">
-                      <div className="text-surface-400 mb-1">credential types</div>
-                      <div className="text-surface-200 font-mono break-all">
-                        {credentialEvidence.credentialTypes.length > 0 ? credentialEvidence.credentialTypes.join(', ') : 'n/a'}
-                      </div>
-                    </div>
-                  </div>
-                  {credentialEvidence.requiredClaimPaths.length > 0 && (
-                    <div className="space-y-1">
-                      <div className="text-[11px] text-surface-400">Required claim paths</div>
-                      <div className="flex flex-wrap gap-1">
-                        {credentialEvidence.requiredClaimPaths.map((path) => (
-                          <code key={path} className="px-1.5 py-0.5 rounded bg-surface-900 border border-white/10 text-[10px] text-surface-300">
-                            {path}
-                          </code>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                    <div className="space-y-1">
-                      <div className="text-[11px] text-cyan-300">Disclosed claims</div>
-                      <pre className="p-2 rounded bg-surface-900 text-[11px] text-surface-300 overflow-x-auto">
-                        {JSON.stringify(credentialEvidence.disclosedClaims, null, 2)}
-                      </pre>
-                    </div>
-                    <div className="space-y-1">
-                      <div className="text-[11px] text-violet-300">Full reconstructed claims</div>
-                      <pre className="p-2 rounded bg-surface-900 text-[11px] text-surface-300 overflow-x-auto">
-                        {JSON.stringify(credentialEvidence.fullClaims, null, 2)}
-                      </pre>
-                    </div>
-                  </div>
-                </div>
-              )}
+              {credentialEvidenceDisplay && renderCredentialEvidenceDisplay(credentialEvidenceDisplay)}
 
               {Object.keys(metadata).length > 0 && (
                 <pre className="p-2 rounded bg-surface-950 text-[11px] text-surface-300 overflow-x-auto">
@@ -301,6 +244,18 @@ function getReasonCodeList(metadata: Record<string, unknown>): string[] {
   return reasonCodes.map((code) => String(code))
 }
 
+// CredentialEvidenceView is the one shape both evidence sources render
+// through. metadata.credentialEvidence (post-verification, set by
+// oid4vp-direct-post) and metadata.credentialInspection (the decode
+// endpoint, set by oid4vci-pre-authorized's captureCredential) are
+// different backend DTOs with only partial field overlap -- subject,
+// issuer, requiredClaimPaths and credentialConfigurationID exist only on
+// the verification-path DTO (models.OID4VPCredentialEvidence), because
+// InspectCredential has no presentation-exchange or DCQL context for a
+// pasted/freshly-issued credential; selectiveDisclosure, issuedAt and
+// expiresAt exist on both but are populated from vc.CredentialEvidence
+// either way. Fields absent from a given source are '' / [] / undefined
+// here, never fabricated, and render as "n/a" or are omitted entirely.
 interface CredentialEvidenceView {
   subject: string
   format: string
@@ -311,7 +266,33 @@ interface CredentialEvidenceView {
   requiredClaimPaths: string[]
   disclosedClaims: Record<string, unknown>
   fullClaims: Record<string, unknown>
+  selectiveDisclosure?: DecodeCredentialSelectiveDisclosure
+  issuedAt?: string
+  expiresAt?: string
 }
+
+// CredentialEvidenceDisplay is the structural enforcement for "unverified
+// evidence must render in the unverified register": there is no frontend
+// test runner (confirmed alongside the Node-script fallback used for
+// verify-jwk-thumbprint.mjs), so this guarantee is carried by the type
+// checker instead of a test. kind is derived exactly once, in
+// getCredentialEvidence, from vc.IssuerTrustStatus -- never from format,
+// and never re-derived downstream. renderCredentialEvidenceDisplay is the
+// only function that reads `kind`, and each of VerifiedRegister /
+// UnverifiedRegister's prop types is narrowed with Extract<> so passing a
+// mismatched variant into either is a compile error, not a runtime
+// styling choice that can silently drift.
+type CredentialEvidenceDisplay =
+  | { kind: 'verified'; evidence: CredentialEvidenceView; note: string }
+  | {
+      kind: 'unverified'
+      evidence: CredentialEvidenceView
+      issuerTrust: 'failed' | 'not_evaluated'
+      issuerTrustDetail?: string
+      digestsConsistentWithMSO?: boolean
+      digestConsistencyDetail?: string
+    }
+  | { kind: 'decode_failed'; reason: string }
 
 interface DeferredIssuanceView {
   transactionId: string
@@ -389,13 +370,38 @@ function toOptionalInt(value: unknown): number | undefined {
   return undefined
 }
 
-function getCredentialEvidence(metadata: Record<string, unknown>): CredentialEvidenceView | null {
-  const evidence = metadata.credentialEvidence
-  if (!evidence || typeof evidence !== 'object') {
-    return null
+// getCredentialEvidence reads whichever of the two evidence sources is
+// present and returns one shared display shape. There is deliberately no
+// `if (format === 'mso_mdoc')` branch anywhere in this file: mso_mdoc goes
+// through vc.MSOMdocFormat into the same vc.CredentialEvidence /
+// vc.SelectiveDisclosureSummary shape as every other registered format, so
+// the same code path renders it.
+function getCredentialEvidence(metadata: Record<string, unknown>): CredentialEvidenceDisplay | null {
+  const inspection = metadata.credentialInspection
+  if (inspection && typeof inspection === 'object' && typeof (inspection as { status?: unknown }).status === 'string') {
+    return credentialEvidenceDisplayFromInspection(inspection as CredentialInspectionMetadata)
   }
 
-  const evidenceMap = evidence as Record<string, unknown>
+  // metadata.credentialEvidence is the OID4VP verification-path DTO
+  // (models.OID4VPCredentialEvidence). validatePresentedCredentialEnvelopes
+  // hard-fails the whole request on any IssuerTrustStatus other than
+  // Verified (see its ValidateIssuerSignature call) before this evidence is
+  // ever constructed, so reaching this branch at all is itself proof of a
+  // verified issuer signature -- 'verified' is not inferred here, it is a
+  // fact already established upstream.
+  const legacyEvidence = metadata.credentialEvidence
+  if (legacyEvidence && typeof legacyEvidence === 'object') {
+    return {
+      kind: 'verified',
+      evidence: credentialEvidenceViewFromLegacy(legacyEvidence as Record<string, unknown>),
+      note: 'Issuer signature verified against stored issuance lineage',
+    }
+  }
+
+  return null
+}
+
+function credentialEvidenceViewFromLegacy(evidenceMap: Record<string, unknown>): CredentialEvidenceView {
   const requiredClaimPaths = Array.isArray(evidenceMap.required_claim_paths)
     ? evidenceMap.required_claim_paths.map((path) => String(path))
     : []
@@ -420,5 +426,329 @@ function getCredentialEvidence(metadata: Record<string, unknown>): CredentialEvi
     requiredClaimPaths,
     disclosedClaims,
     fullClaims,
+    // The verification-path DTO carries no selective-disclosure summary or
+    // validity timestamps today (models.OID4VPCredentialEvidence predates
+    // both). Leaving these undefined renders as "not shown", never a
+    // fabricated zero or "n/a" count.
   }
+}
+
+function credentialEvidenceViewFromDecoded(evidence: DecodeCredentialEvidence): CredentialEvidenceView {
+  return {
+    subject: '',
+    format: evidence.format || '',
+    vct: evidence.vct || '',
+    doctype: evidence.doctype || '',
+    credentialTypes: evidence.credential_types || [],
+    issuer: '',
+    requiredClaimPaths: [],
+    disclosedClaims: evidence.disclosed_claims || {},
+    fullClaims: evidence.full_claims || {},
+    selectiveDisclosure: evidence.selective_disclosure,
+    issuedAt: evidence.issued_at,
+    expiresAt: evidence.expires_at,
+  }
+}
+
+// credentialEvidenceDisplayFromInspection is the one place `kind` gets
+// decided for decode-endpoint evidence, straight from
+// vc.IssuerTrustStatus's tri-state via assurance.issuer_trust -- 'verified'
+// only when the backend actually verified a signature against real trust
+// material, which InspectCredential today never supplies (see its doc
+// comment), so every decode-endpoint result renders unverified in
+// practice. digestsConsistentWithMSO/digestConsistencyDetail are carried
+// through untouched either way: they prove internal consistency between
+// presented items and the credential's own MSO, never authenticity, and
+// must keep that wording downstream.
+function credentialEvidenceDisplayFromInspection(inspection: CredentialInspectionMetadata): CredentialEvidenceDisplay {
+  if (inspection.status === 'decode_failed') {
+    return { kind: 'decode_failed', reason: inspection.reason }
+  }
+
+  const evidence = credentialEvidenceViewFromDecoded(inspection.evidence)
+  const { assurance } = inspection
+  if (assurance.issuer_trust === 'verified') {
+    return { kind: 'verified', evidence, note: 'Issuer signature verified against supplied trust material' }
+  }
+  return {
+    kind: 'unverified',
+    evidence,
+    issuerTrust: assurance.issuer_trust,
+    issuerTrustDetail: assurance.issuer_trust_detail,
+    digestsConsistentWithMSO: assurance.digests_consistent_with_mso,
+    digestConsistencyDetail: assurance.digest_consistency_detail,
+  }
+}
+
+// renderCredentialEvidenceDisplay is the only function in this file that
+// reads CredentialEvidenceDisplay.kind. The switch is exhaustive over the
+// three variants with a `never`-typed default: adding a fourth kind to the
+// union without adding a case here is a compile error, not a silently
+// unhandled state. Every case returns a real element (never null/undefined
+// implicitly) because the declared return type is JSX.Element rather than
+// ReactNode -- there is no arm that can quietly render nothing.
+function renderCredentialEvidenceDisplay(display: CredentialEvidenceDisplay): JSX.Element {
+  switch (display.kind) {
+    case 'verified':
+      return <VerifiedRegister display={display} />
+    case 'unverified':
+      return <UnverifiedRegister display={display} />
+    case 'decode_failed':
+      return <DecodeFailedPanel reason={display.reason} />
+    default: {
+      const unhandled: never = display
+      throw new Error(`VCInspector: unhandled credential evidence display kind: ${JSON.stringify(unhandled)}`)
+    }
+  }
+}
+
+// EvidenceAssurance is CredentialEvidenceRegister's required `assurance`
+// prop -- deliberately its own type rather than a boolean, and with no
+// default value anywhere in this file, so a new call site is forced to
+// state which register applies rather than silently inheriting "verified"
+// by omission.
+type EvidenceAssurance =
+  | { kind: 'verified'; note: string }
+  | {
+      kind: 'unverified'
+      issuerTrust: 'failed' | 'not_evaluated'
+      issuerTrustDetail?: string
+      digestsConsistentWithMSO?: boolean
+      digestConsistencyDetail?: string
+    }
+
+// VerifiedRegister is the counterpart to UnverifiedRegister below, kept as
+// its own component (rather than a shared component with an internal
+// verified/unverified if-branch) so the register is chosen by which
+// component the exhaustive switch above selects, not by a condition
+// evaluated inside a shared render path.
+function VerifiedRegister({ display }: { display: Extract<CredentialEvidenceDisplay, { kind: 'verified' }> }): JSX.Element {
+  return <CredentialEvidenceRegister evidence={display.evidence} assurance={{ kind: 'verified', note: display.note }} />
+}
+
+// UnverifiedRegister is the only component in this file that can produce a
+// rendered unverified value: its prop type is narrowed with Extract<> to
+// exactly `{ kind: 'unverified' }`, so there is no way to obtain a
+// renderable unverified value that is not already inside it, and no other
+// function constructs an EvidenceAssurance with kind: 'unverified'.
+function UnverifiedRegister({ display }: { display: Extract<CredentialEvidenceDisplay, { kind: 'unverified' }> }): JSX.Element {
+  return (
+    <CredentialEvidenceRegister
+      evidence={display.evidence}
+      assurance={{
+        kind: 'unverified',
+        issuerTrust: display.issuerTrust,
+        issuerTrustDetail: display.issuerTrustDetail,
+        digestsConsistentWithMSO: display.digestsConsistentWithMSO,
+        digestConsistencyDetail: display.digestConsistencyDetail,
+      }}
+    />
+  )
+}
+
+function DecodeFailedPanel({ reason }: { reason: string }): JSX.Element {
+  return (
+    <div className="p-2 rounded bg-surface-950 border border-red-500/30 space-y-1">
+      <div className="flex items-center gap-1.5 text-xs text-red-300 font-medium">
+        <AlertTriangle className="w-3.5 h-3.5" />
+        Credential decode failed
+      </div>
+      <div className="text-[11px] text-surface-400">{reason}</div>
+    </div>
+  )
+}
+
+// CredentialEvidenceRegister is "the evidence renderer": assurance is
+// required with no default, so border colour, badge icon and label are
+// always derived from assurance.kind rather than from a caller-supplied
+// style choice. VerifiedRegister and UnverifiedRegister are its only
+// callers, each already committed to its own register before calling in.
+function CredentialEvidenceRegister({
+  evidence,
+  assurance,
+}: {
+  evidence: CredentialEvidenceView
+  assurance: EvidenceAssurance
+}): JSX.Element {
+  const verified = assurance.kind === 'verified'
+  const failed = assurance.kind === 'unverified' && assurance.issuerTrust === 'failed'
+  const borderClass = verified ? 'border-emerald-500/20' : failed ? 'border-red-500/30' : 'border-amber-500/30'
+  const BadgeIcon = verified ? ShieldCheck : failed ? ShieldX : ShieldAlert
+  const badgeTextClass = verified ? 'text-emerald-300' : failed ? 'text-red-300' : 'text-amber-200'
+  const badgeLabel = verified
+    ? `Verified — ${assurance.note}`
+    : failed
+      ? 'Signature verification failed'
+      : 'Not verified — no issuer trust material evaluated'
+
+  return (
+    <div className={`p-2 rounded bg-surface-950 border space-y-2 ${borderClass}`}>
+      <div className={`flex items-center gap-1.5 text-xs font-medium ${badgeTextClass}`}>
+        <BadgeIcon className="w-3.5 h-3.5" />
+        {badgeLabel}
+      </div>
+      {assurance.kind === 'unverified' && assurance.issuerTrustDetail && (
+        <div className="text-[11px] text-surface-400">{assurance.issuerTrustDetail}</div>
+      )}
+      {assurance.kind === 'unverified' && assurance.digestsConsistentWithMSO !== undefined && (
+        <div className="text-[11px] text-surface-400">
+          Digests consistent with MSO (internal consistency, not authenticity):{' '}
+          <span className={assurance.digestsConsistentWithMSO ? 'text-surface-200' : 'text-red-300'}>
+            {assurance.digestsConsistentWithMSO ? 'yes' : 'no'}
+          </span>
+          {assurance.digestConsistencyDetail ? ` — ${assurance.digestConsistencyDetail}` : ''}
+        </div>
+      )}
+      {!verified && (
+        <div className="text-[11px] text-amber-200/80">
+          Everything below is what this artifact contains, unverified. Do not treat it as authenticated.
+        </div>
+      )}
+      <CredentialEvidenceFields evidence={evidence} />
+    </div>
+  )
+}
+
+// CredentialEvidenceFields is a private detail of CredentialEvidenceRegister
+// (not called from anywhere else in this file): the neutral claims/counts
+// grid that looks the same regardless of register, with all register
+// chrome -- border, badge, warning copy -- owned by its one caller above.
+function CredentialEvidenceFields({ evidence }: { evidence: CredentialEvidenceView }) {
+  const validityLine = formatValidityLine(evidence.issuedAt, evidence.expiresAt)
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-[11px]">
+        <EvidenceField label="Subject" value={evidence.subject} />
+        <EvidenceField label="Format" value={evidence.format} />
+        <EvidenceField label="Issuer" value={evidence.issuer} />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-[11px]">
+        <EvidenceField label="VCT" value={evidence.vct} />
+        <EvidenceField label="doctype" value={evidence.doctype} />
+        <EvidenceField label="credential types" value={evidence.credentialTypes.join(', ')} />
+      </div>
+      {validityLine && <div className="text-[11px] text-surface-400">{validityLine}</div>}
+      {evidence.requiredClaimPaths.length > 0 && (
+        <div className="space-y-1">
+          <div className="text-[11px] text-surface-400">Required claim paths</div>
+          <div className="flex flex-wrap gap-1">
+            {evidence.requiredClaimPaths.map((path) => (
+              <code key={path} className="px-1.5 py-0.5 rounded bg-surface-900 border border-white/10 text-[10px] text-surface-300">
+                {path}
+              </code>
+            ))}
+          </div>
+        </div>
+      )}
+      {evidence.selectiveDisclosure && <SelectiveDisclosureBlock summary={evidence.selectiveDisclosure} />}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <div className="text-[11px] text-cyan-300">Disclosed claims</div>
+          <pre className="p-2 rounded bg-surface-900 text-[11px] text-surface-300 overflow-x-auto">
+            {JSON.stringify(evidence.disclosedClaims, null, 2)}
+          </pre>
+        </div>
+        <div className="space-y-1">
+          <div className="text-[11px] text-violet-300">Full reconstructed claims</div>
+          <pre className="p-2 rounded bg-surface-900 text-[11px] text-surface-300 overflow-x-auto">
+            {JSON.stringify(evidence.fullClaims, null, 2)}
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EvidenceField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="p-2 rounded bg-surface-900 border border-white/5">
+      <div className="text-surface-400 mb-1">{label}</div>
+      <div className="text-surface-200 font-mono break-all">{value || 'n/a'}</div>
+    </div>
+  )
+}
+
+// SelectiveDisclosureBlock is the mdoc/SD-JWT-agnostic rendering of A4's
+// disclosure summary: committed-count wording branches on
+// committed_count_is_exact (mdoc's valueDigests count is genuine; SD-JWT's
+// _sd count is a decoy-inclusive upper bound and must never be shown with
+// the same confidence), and present-count wording branches on
+// lifecycle_stage so an issued credential is never described as though a
+// holder had made a disclosure decision about it.
+function SelectiveDisclosureBlock({ summary }: { summary: DecodeCredentialSelectiveDisclosure }) {
+  const namespaceEntries = Object.entries(summary.per_namespace || {})
+  return (
+    <div className="p-2 rounded bg-surface-900 border border-white/5 space-y-1.5">
+      <div className="text-[11px] text-surface-300">Selective disclosure — {describeMechanism(summary.mechanism)}</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-1 text-[11px] text-surface-300">
+        <div>{describeCommittedCount(summary)}</div>
+        <div>{describePresentCount(summary)}</div>
+      </div>
+      {summary.digest_algorithm && (
+        <div className="text-[11px] text-surface-400">
+          Digest algorithm: <span className="text-surface-200 font-mono">{summary.digest_algorithm}</span>
+        </div>
+      )}
+      {namespaceEntries.length > 0 && (
+        <div className="space-y-1">
+          <div className="text-[11px] text-surface-400">Per namespace (present / committed)</div>
+          <div className="flex flex-wrap gap-1">
+            {namespaceEntries.map(([namespace, counts]) => (
+              <code
+                key={namespace}
+                className="px-1.5 py-0.5 rounded bg-surface-950 border border-white/10 text-[10px] text-surface-300"
+              >
+                {namespace}: {counts.present_count}/{counts.committed_count}
+              </code>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function describeMechanism(mechanism: string): string {
+  switch (mechanism) {
+    case 'mso_valuedigests':
+      return 'ISO/IEC 18013-5 MSO valueDigests'
+    case 'sd_jwt_disclosures':
+      return 'SD-JWT disclosures (draft-ietf-oauth-selective-disclosure-jwt)'
+    default:
+      return mechanism || 'unknown mechanism'
+  }
+}
+
+function describeCommittedCount(summary: DecodeCredentialSelectiveDisclosure): string {
+  if (summary.committed_count_is_exact) {
+    return `Committed: ${summary.committed_count} (exact)`
+  }
+  const caveats = ['may include decoy digests']
+  if (summary.has_unrepresented_disclosure_forms) {
+    caveats.push('may undercount nested or array-element disclosures')
+  }
+  return `Committed: ≤${summary.committed_count} (upper bound — ${caveats.join('; ')})`
+}
+
+function describePresentCount(summary: DecodeCredentialSelectiveDisclosure): string {
+  if (summary.lifecycle_stage === 'issued') {
+    return `Present at issuance: ${summary.present_count} of ${summary.committed_count} committed elements`
+  }
+  return `Disclosed: ${summary.present_count} of ${summary.committed_count} committed elements`
+}
+
+function formatValidityLine(issuedAt?: string, expiresAt?: string): string {
+  const parts: string[] = []
+  if (issuedAt) {
+    parts.push(`Issued ${formatTimestamp(issuedAt)}`)
+  }
+  if (expiresAt) {
+    parts.push(`Expires ${formatTimestamp(expiresAt)}`)
+  }
+  return parts.join(' · ')
+}
+
+function formatTimestamp(iso: string): string {
+  const parsed = new Date(iso)
+  return Number.isNaN(parsed.getTime()) ? iso : parsed.toLocaleString()
 }

--- a/frontend/src/lookingglass/flows/base.ts
+++ b/frontend/src/lookingglass/flows/base.ts
@@ -5,6 +5,8 @@
  * Each executor implements a specific OAuth 2.0 or OIDC flow per RFC.
  */
 
+import type { DecodeCredentialAssurance, DecodeCredentialEvidence } from '../../utils/api'
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -142,6 +144,28 @@ export interface VCArtifact {
   metadata?: Record<string, unknown>
   timestamp: Date
 }
+
+/**
+ * Result of decoding a just-issued credential through
+ * POST /lookingglass/decode/credential, stored under
+ * VCArtifact.metadata.credentialInspection. Shared between the flow that
+ * produces it (oid4vci-pre-authorized's captureCredential) and the
+ * inspector that consumes it (VCInspector), so the two cannot drift apart
+ * on the shape of "decoded" vs "the call itself failed" -- a decode
+ * failure (network error, non-2xx, timeout, or malformed body) must render
+ * as an explicit failure state, never a silent fallback to the pre-decode
+ * raw-blob-only view.
+ */
+export type CredentialInspectionMetadata =
+  | {
+      status: 'decoded'
+      evidence: DecodeCredentialEvidence
+      assurance: DecodeCredentialAssurance
+    }
+  | {
+      status: 'decode_failed'
+      reason: string
+    }
 
 export type FlowStateListener = (state: FlowExecutorState) => void
 

--- a/frontend/src/lookingglass/flows/oid4vci-pre-authorized.ts
+++ b/frontend/src/lookingglass/flows/oid4vci-pre-authorized.ts
@@ -9,13 +9,14 @@
  * - Optionally poll deferred endpoint
  */
 
-import { FlowExecutorBase, type FlowExecutorConfig } from './base'
+import { FlowExecutorBase, type FlowExecutorConfig, type CredentialInspectionMetadata } from './base'
 import {
   decodeJWTWithoutValidation,
   generateRS256SigningMaterial,
   signRS256JWT,
   type RS256SigningMaterial,
 } from '../../utils/crypto'
+import { api } from '../../utils/api'
 
 export interface OID4VCIPreAuthorizedConfig extends FlowExecutorConfig {
   txCodeRequired?: boolean
@@ -126,7 +127,7 @@ export class OID4VCIPreAuthorizedExecutor extends FlowExecutorBase {
       }
 
       if (typeof credentialResponse.credential === 'string') {
-        this.captureCredential(credentialResponse.credential, {
+        await this.captureCredential(credentialResponse.credential, {
           format: this.selectedCredentialFormat(credentialResponse),
           credentialConfigurationID: this.selectedCredentialConfigurationID(),
         })
@@ -456,7 +457,7 @@ export class OID4VCIPreAuthorizedExecutor extends FlowExecutorBase {
           transactionId,
         },
       })
-      this.captureCredential(payload.credential, {
+      await this.captureCredential(payload.credential, {
         format: this.selectedCredentialFormat(payload),
         credentialConfigurationID: this.selectedCredentialConfigurationID(),
         deferredFlow: true,
@@ -489,7 +490,7 @@ export class OID4VCIPreAuthorizedExecutor extends FlowExecutorBase {
     throw new Error('Deferred credential response missing credential')
   }
 
-  private captureCredential(rawCredential: string, additionalMetadata?: Record<string, unknown>): void {
+  private async captureCredential(rawCredential: string, additionalMetadata?: Record<string, unknown>): Promise<void> {
     const credentialFormat = String(additionalMetadata?.format || this.selectedCredentialFormat()).trim() || 'mso_mdoc'
     // mso_mdoc credentials are a base64url-encoded CBOR IssuerSigned structure
     // (ISO/IEC 18013-5), not a JOSE JWT. They have no "~" disclosure tail and
@@ -506,7 +507,35 @@ export class OID4VCIPreAuthorizedExecutor extends FlowExecutorBase {
       })
       decodedCredentialJWT = decodeJWTWithoutValidation(issuerJWT)
     }
-    const disclosureCount = rawCredential.split('~').filter(Boolean).length - 1
+
+    // hasDisclosures/disclosureCount used to be computed here by counting
+    // "~" characters -- an SD-JWT-only mechanism that is affirmatively wrong
+    // for mdoc (whose selective disclosure lives in salted IssuerSignedItems
+    // committed through MSO valueDigests, never zero for an issued mDL) and
+    // only crudely right for SD-JWT (it cannot see decoy digests, nested
+    // disclosures, or array-element disclosures). credentialInspection below
+    // replaces both fields for every format with the backend's
+    // format-accurate selective-disclosure summary, so those two fields are
+    // gone rather than fixed only for mdoc.
+    //
+    // This is a side-channel decode of an artifact this flow already
+    // produced, not a new fabricated protocol event -- the same shape of
+    // call as the existing /lookingglass/decode precedent for JWTs. A
+    // failure here (network error, non-2xx, timeout, or a malformed body)
+    // must render as an explicit failure state in the inspector, never a
+    // silent fallback to a raw-blob-only view, so the failure is captured
+    // into the same metadata field rather than swallowed.
+    let credentialInspection: CredentialInspectionMetadata
+    try {
+      const inspection = await api.decodeCredential(rawCredential)
+      credentialInspection = { status: 'decoded', evidence: inspection.evidence, assurance: inspection.assurance }
+    } catch (error) {
+      credentialInspection = {
+        status: 'decode_failed',
+        reason: error instanceof Error ? error.message : 'Unknown error decoding credential',
+      }
+    }
+
     this.addVCArtifact({
       type: 'credential',
       title: `Issued ${credentialFormat} Credential`,
@@ -517,8 +546,7 @@ export class OID4VCIPreAuthorizedExecutor extends FlowExecutorBase {
         ? { header: decodedCredentialJWT.header, payload: decodedCredentialJWT.payload }
         : {},
       metadata: {
-        hasDisclosures: rawCredential.includes('~'),
-        disclosureCount: disclosureCount > 0 ? disclosureCount : 0,
+        credentialInspection,
         ...(additionalMetadata || {}),
       },
     })
@@ -528,7 +556,7 @@ export class OID4VCIPreAuthorizedExecutor extends FlowExecutorBase {
       description: `Issued ${credentialFormat} credential captured from credential endpoint`,
       data: {
         format: credentialFormat,
-        hasDisclosures: rawCredential.includes('~'),
+        ...(isMdoc ? {} : { hasDisclosures: rawCredential.includes('~') }),
       },
     })
   }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -110,6 +110,75 @@ export async function apiPostForm<T>(
 }
 
 /**
+ * Wire shape of vc.NamespaceDisclosureCounts from the backend
+ * (POST /lookingglass/decode/credential). mdoc only.
+ */
+export interface DecodeCredentialNamespaceCounts {
+  committed_count: number
+  present_count: number
+}
+
+/**
+ * Wire shape of vc.SelectiveDisclosureSummary. Present only for formats with
+ * a selective-disclosure mechanism (mso_mdoc, dc+sd-jwt); absent otherwise.
+ * committed_count_is_exact distinguishes mdoc's genuine valueDigests count
+ * from SD-JWT's decoy-inclusive upper bound -- the two must never be
+ * rendered with the same confidence.
+ */
+export interface DecodeCredentialSelectiveDisclosure {
+  mechanism: string
+  committed_count: number
+  committed_count_is_exact: boolean
+  present_count: number
+  lifecycle_stage: 'issued' | 'presented'
+  digest_algorithm?: string
+  per_namespace?: Record<string, DecodeCredentialNamespaceCounts>
+  has_unrepresented_disclosure_forms: boolean
+}
+
+/**
+ * Wire shape of vc.CredentialAssurance. issuer_trust is the tri-state
+ * verbatim ("verified" / "failed" / "not_evaluated") -- never collapse it to
+ * a boolean. digests_consistent_with_mso is present only for mso_mdoc, and
+ * proves internal consistency between the presented items and the MSO, not
+ * authenticity of the MSO -- it must never be relabelled "verified" or "ok".
+ */
+export interface DecodeCredentialAssurance {
+  issuer_trust: 'verified' | 'failed' | 'not_evaluated'
+  issuer_trust_detail?: string
+  digests_consistent_with_mso?: boolean
+  digest_consistency_detail?: string
+}
+
+/**
+ * Wire shape of vc.CredentialEvidence. issued_at/expires_at are RFC3339 and
+ * present only when the credential itself carried the corresponding claim
+ * (mso_mdoc: MSO ValidityInfo.signed/validUntil; ldp_vc: issuanceDate or
+ * validFrom, expirationDate or validUntil; JWT-based formats: exp only, iat
+ * is not read). Absence must render as "not stated by the credential", not
+ * as a fallback to any other time source.
+ */
+export interface DecodeCredentialEvidence {
+  format?: string
+  vct?: string
+  doctype?: string
+  credential_types?: string[]
+  full_claims?: Record<string, unknown>
+  disclosed_claims?: Record<string, unknown>
+  selective_disclosure?: DecodeCredentialSelectiveDisclosure
+  issued_at?: string
+  expires_at?: string
+}
+
+/**
+ * Response body for POST /lookingglass/decode/credential.
+ */
+export interface DecodeCredentialResponse {
+  evidence: DecodeCredentialEvidence
+  assurance: DecodeCredentialAssurance
+}
+
+/**
  * Token response type
  */
 export interface TokenResponse {
@@ -219,6 +288,24 @@ export const api = {
     errors?: string[]
   }> {
     return apiPost('/lookingglass/decode', { token })
+  },
+
+  /**
+   * Decode a pasted credential (any registered vc.CredentialFormat,
+   * including mso_mdoc) into the same shared evidence shape issuance and
+   * verification use, wrapped in an assurance envelope. This is a
+   * side-channel decode of an artifact the flow already produced -- the
+   * same shape of call as decodeToken above, which already does this for
+   * JWTs -- not a new fabricated protocol event. A 10s client-side timeout
+   * is set so a hung request surfaces as an explicit decode failure rather
+   * than leaving the caller waiting indefinitely.
+   */
+  decodeCredential(credential: string): Promise<DecodeCredentialResponse> {
+    return apiFetch<DecodeCredentialResponse>('/lookingglass/decode/credential', {
+      method: 'POST',
+      body: JSON.stringify({ credential }),
+      signal: AbortSignal.timeout(10_000),
+    })
   },
 
   /**

--- a/frontend/src/utils/crypto.ts
+++ b/frontend/src/utils/crypto.ts
@@ -117,6 +117,57 @@ export async function generateCodeChallenge(verifier: string): Promise<string> {
 }
 
 /**
+ * Compute the RFC 7638 JWK SHA-256 thumbprint ("jkt") for the three key
+ * types this codebase actually mints: RSA, EC, and OKP -- Ed25519 holder
+ * keys reach this on the wallet's did:key path, so omitting OKP would
+ * either throw or silently compute a wrong digest and render a false
+ * mismatch against a correct jkt in the panel this exists to keep honest.
+ *
+ * Mirrors crypto.JWK.Thumbprint() in backend/internal/crypto/keys.go
+ * exactly: same three kty branches, same canonical member ordering per
+ * RFC 7638 Section 3.2 (crv,kty,x,y for EC; e,kty,n for RSA; crv,kty,x for
+ * OKP -- each already alphabetical, which is what makes plain object
+ * literal key order equivalent to Go's alphabetically-sorted map-key JSON
+ * marshalling), and the same refusal for anything else: the Go function
+ * returns "" for an unsupported kty rather than guessing, so this returns
+ * null for the same case. "Cannot compute for this key type" must be
+ * rendered as its own state wherever this is used, never as a mismatch --
+ * an unknown future kty must not produce a false verdict.
+ */
+export async function jwkThumbprint(jwk: Record<string, unknown>): Promise<string | null> {
+  const kty = typeof jwk.kty === 'string' ? jwk.kty : ''
+  let canonical: Record<string, string>
+
+  switch (kty) {
+    case 'RSA': {
+      const { e, n } = jwk
+      if (typeof e !== 'string' || typeof n !== 'string') return null
+      canonical = { e, kty, n }
+      break
+    }
+    case 'EC': {
+      const { crv, x, y } = jwk
+      if (typeof crv !== 'string' || typeof x !== 'string' || typeof y !== 'string') return null
+      canonical = { crv, kty, x, y }
+      break
+    }
+    case 'OKP': {
+      const { crv, x } = jwk
+      if (typeof crv !== 'string' || typeof x !== 'string') return null
+      canonical = { crv, kty, x }
+      break
+    }
+    default:
+      return null
+  }
+
+  const encoder = new TextEncoder()
+  const data = encoder.encode(JSON.stringify(canonical))
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64URLEncode(new Uint8Array(digest))
+}
+
+/**
  * Generate a state parameter for CSRF protection
  */
 export function generateState(): string {

--- a/frontend/src/views/LookingGlass.tsx
+++ b/frontend/src/views/LookingGlass.tsx
@@ -2067,7 +2067,19 @@ export function LookingGlass() {
 
             <div className="p-4 sm:p-5">
               {inspectedToken ? (
-                <TokenInspector token={inspectedToken} />
+                <TokenInspector
+                  token={inspectedToken}
+                  tokenType={
+                    // token_type (RFC 6749 Section 5.1) describes the access
+                    // token specifically, so it is only passed when the
+                    // token currently being inspected is that access token --
+                    // not for id_token/refresh_token/client_assertion or a
+                    // manually-pasted token, none of which have a token_type.
+                    inspectedToken === realExecutor.state?.tokens.accessToken
+                      ? realExecutor.state?.tokens.tokenType
+                      : undefined
+                  }
+                />
               ) : (
                 <div className="text-center py-6 text-surface-400 text-sm">
                   Select a token above to decode

--- a/openapi/v1/gateway.yaml
+++ b/openapi/v1/gateway.yaml
@@ -212,6 +212,72 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/lookingglass/decode/credential:
+    post:
+      tags: [LookingGlass]
+      summary: Decode a verifiable credential for Looking Glass inspection
+      description: >-
+        Decodes a pasted credential of any registered format -- including
+        mso_mdoc -- into the same shared evidence shape issuance and
+        verification already produce, wrapped in an assurance envelope. The
+        response keeps decoded-but-unverified evidence and checked assurance
+        as separate top-level objects: this endpoint supplies no issuer keys
+        or trust anchors, so `assurance.issuer_trust` reads `not_evaluated`
+        for every format, never a blanket validity flag. The request body is
+        capped at 64 KiB, and CBOR-based formats (mso_mdoc) are decoded under
+        hardened depth and collection limits because the input is
+        externally-supplied and untrusted.
+      operationId: decodeGatewayCredential
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DecodeCredentialRequest"
+            examples:
+              mso_mdoc:
+                value:
+                  credential: "omRkb2NUeXBldW9yZy5pc28uMTgwMTMuNS4xLm1ETA..."
+      responses:
+        "200":
+          description: Decoded credential evidence and assurance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DecodeCredentialResponse"
+              examples:
+                mso_mdoc:
+                  value:
+                    evidence:
+                      format: mso_mdoc
+                      doctype: "org.iso.18013.5.1.mDL"
+                      full_claims:
+                        "org.iso.18013.5.1":
+                          document_number: "D1234567"
+                          driving_privileges: []
+                      selective_disclosure:
+                        mechanism: mso_valuedigests
+                        committed_count: 11
+                        committed_count_is_exact: true
+                        present_count: 11
+                        lifecycle_stage: issued
+                        digest_algorithm: "SHA-256"
+                        has_unrepresented_disclosure_forms: false
+                    assurance:
+                      issuer_trust: not_evaluated
+                      digests_consistent_with_mso: true
+        "400":
+          description: Invalid, oversized, or unparseable credential.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Looking Glass is disabled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/lookingglass/sessions:
     get:
       tags: [LookingGlass]
@@ -456,4 +522,174 @@ components:
       required: [token]
       properties:
         token:
+          type: string
+    DecodeCredentialRequest:
+      type: object
+      required: [credential]
+      properties:
+        credential:
+          type: string
+          description: >-
+            A raw credential artifact: a compact SD-JWT VC, a JWT/JSON-LD VC,
+            or a base64url-encoded ISO/IEC 18013-5 mso_mdoc IssuerSigned
+            structure. The request body is capped at 64 KiB.
+    DecodeCredentialResponse:
+      type: object
+      required: [evidence, assurance]
+      description: >-
+        Evidence and assurance are separate top-level objects so a client
+        cannot merge "what this artifact contains" and "what has been
+        checked about it" into one register by accident.
+      properties:
+        evidence:
+          $ref: "#/components/schemas/CredentialEvidence"
+        assurance:
+          $ref: "#/components/schemas/CredentialAssurance"
+    CredentialEvidence:
+      type: object
+      description: >-
+        Format-agnostic view of the credential's own claims, shared verbatim
+        with the evidence shape issuance and OID4VP verification produce.
+        This is decoded content, not a trust statement -- see
+        CredentialAssurance for what has actually been checked.
+      properties:
+        format:
+          type: string
+          example: mso_mdoc
+        vct:
+          type: string
+          description: SD-JWT VC type (`vct` claim). Absent for other formats.
+        doctype:
+          type: string
+          description: >-
+            mdoc doctype, e.g. `org.iso.18013.5.1.mDL`, from the
+            MobileSecurityObject. Absent for other formats.
+        credential_types:
+          type: array
+          items:
+            type: string
+        full_claims:
+          type: object
+          additionalProperties: true
+          description: >-
+            Every claim the credential carries, namespace-nested for mdoc.
+        disclosed_claims:
+          type: object
+          additionalProperties: true
+          description: The subset of full_claims actually disclosed by this artifact.
+        selective_disclosure:
+          $ref: "#/components/schemas/SelectiveDisclosureSummary"
+        issued_at:
+          type: string
+          format: date-time
+          description: >-
+            Present only when the source credential itself carries this
+            claim (mdoc MSO validityInfo.signed; ldp_vc issuanceDate/
+            validFrom); never back-filled with wall-clock time.
+        expires_at:
+          type: string
+          format: date-time
+          description: >-
+            Present only when the source credential itself carries this
+            claim; never back-filled.
+    SelectiveDisclosureSummary:
+      type: object
+      description: >-
+        Present only for the two formats with a selective-disclosure
+        mechanism (mso_mdoc, dc+sd-jwt). Absent entirely -- not zeroed -- for
+        formats that always reveal every claim (jwt_vc_json, jwt_vc_json-ld,
+        ldp_vc).
+      required:
+        - mechanism
+        - committed_count
+        - committed_count_is_exact
+        - present_count
+        - lifecycle_stage
+        - has_unrepresented_disclosure_forms
+      properties:
+        mechanism:
+          type: string
+          enum: [mso_valuedigests, sd_jwt_disclosures]
+          description: Names what committed_count actually counts.
+        committed_count:
+          type: integer
+          description: >-
+            Exact element count for mso_valuedigests (ISO/IEC 18013-5 has no
+            decoy-digest mechanism). An upper bound for sd_jwt_disclosures,
+            since SD-JWT deliberately permits decoy digests so a verifier
+            cannot infer the true claim count from the digest count alone --
+            see committed_count_is_exact.
+        committed_count_is_exact:
+          type: boolean
+          description: >-
+            True only for mso_valuedigests. Always false for
+            sd_jwt_disclosures, even when a specific credential happens to
+            carry no decoys -- the point is that the format permits them.
+        present_count:
+          type: integer
+          description: >-
+            Element/disclosure count actually carried by this artifact. Its
+            meaning depends on lifecycle_stage: at "issued" this is a
+            property of the format (every element/disclosure the issuer
+            sent), not a holder decision, and must not be worded as a
+            disclosure ratio. Only "presented" may use "N of M disclosed"
+            phrasing.
+        lifecycle_stage:
+          type: string
+          enum: [issued, presented]
+        digest_algorithm:
+          type: string
+          example: "SHA-256"
+          description: mso.DigestAlgorithm for mdoc, or the SD-JWT _sd_alg claim.
+        per_namespace:
+          type: object
+          description: mdoc only. Absent for SD-JWT, which has no namespace concept.
+          additionalProperties:
+            $ref: "#/components/schemas/NamespaceDisclosureCounts"
+        has_unrepresented_disclosure_forms:
+          type: boolean
+          description: >-
+            True when an SD-JWT structure contains a disclosure form
+            committed_count's flat count does not represent -- a nested
+            disclosure or an array-element redaction marker. Always false
+            for mdoc. When true, present_count/committed_count must not be
+            presented as a complete picture.
+    NamespaceDisclosureCounts:
+      type: object
+      required: [committed_count, present_count]
+      properties:
+        committed_count:
+          type: integer
+        present_count:
+          type: integer
+    CredentialAssurance:
+      type: object
+      description: >-
+        What has actually been checked about the artifact. Kept structurally
+        separate from CredentialEvidence's decoded-but-unverified claims, and
+        never collapsed to a single validity flag.
+      required: [issuer_trust]
+      properties:
+        issuer_trust:
+          type: string
+          enum: [verified, failed, not_evaluated]
+          description: >-
+            Tri-state, computed by actually invoking issuer-signature
+            validation rather than hardcoded. This endpoint supplies no
+            issuer keys or trust anchors, so this reads "not_evaluated" for
+            every format today -- distinct from "failed", which means a
+            check ran against real trust material and did not succeed.
+        issuer_trust_detail:
+          type: string
+        digests_consistent_with_mso:
+          type: boolean
+          description: >-
+            mso_mdoc only; absent entirely (not false) for every other
+            format. True means each presented IssuerSignedItem's digest
+            matches the credential's own MSO valueDigests -- internal
+            self-consistency between the items and the MSO, NOT authenticity
+            of the MSO itself. An unauthenticated MSO with matching digests
+            is trivially forgeable. Must never be read or labelled as
+            "verified" or "ok".
+        digest_consistency_detail:
           type: string


### PR DESCRIPTION
## What does this PR do?

<!-- Briefly describe the change and its motivation. Link to the related issue if one exists. -->

Makes `mso_mdoc` a first-class credential format instead of a special-cased path around the shared `vc.CredentialFormat` abstraction. Today's default OID4VCI flow issues an mdoc and the Looking Glass credential inspector renders `hasDisclosures: false, disclosureCount: 0` for it - those numbers aren't sourced from the artifact and are actively wrong: mdoc's selective disclosure is real, expressed as salted `IssuerSignedItem`s committed through MSO `valueDigests`. The root cause was structural, not a UI gap: `mso_mdoc` was never registered in `DefaultCredentialFormatRegistry`, so `BuildCredentialEvidence` simply failed to parse it and every downstream caller fell back to ad hoc handling.


- Registers `MSOMdocFormat` as a real `CredentialFormat` (parse, tri-state issuer signature validation, presentation refusal with a documented rationale), so `BuildCredentialEvidence` produces real evidence for mdoc the same way it already does for SD-JWT/JWT-VC/LDP-VC.
- Replaces the false `hasDisclosures`/`disclosureCount` fields with a format-accurate selective-disclosure summary (`mso_valuedigests` vs `sd_jwt_disclosures`, with an explicit `committed_count_is_exact` flag since SD-JWT decoy digests make its count an upper bound, never a true claim count) and a required `lifecycle_stage` so `present_count` is never worded as a disclosure ratio for an issued-but-not-yet-presented credential.
- Makes `ValidateIssuerSignature` return a tri-state (verified / failed / not evaluated) instead of a binary error, so "no trust anchor was supplied" can never be reported or silently treated as "checked and failed" or, worse, as passing.
- Adds a hardened, explicitly-limited CBOR decode gate (`mdoc.CheckUntrustedCBOR`, 16 nesting levels / 1024 array elements / 1024 map pairs, recursing into CBOR tag-24 content so nesting can't be hidden inside it) for every path that accepts an externally-supplied credential: the new decode endpoint and the wallet harness's external-import endpoint.
- Adds `POST /lookingglass/decode/credential`, returning the same evidence shape inside an assurance envelope that carries the issuer-trust tri-state verbatim and names digest recompute for what it actually proves - consistency with the MSO, not authenticity of it.
- Makes `VCInspector` consume that evidence uniformly with no `format === 'mso_mdoc'` branch, and makes the verified/unverified/decode-failed distinction a structural TypeScript union (there's no frontend test runner, so this is enforced by `tsc --noEmit` instead: the unverified variant is only constructible inside `UnverifiedRegister`, and the failure branch can't return `null`).
- Adds an RFC 7800 Key Binding block to `TokenInspector` (`cnf.jwk`/`cnf.jkt` match against a real RFC 7638 thumbprint, covering RSA/EC/OKP), plus a known-answer verification script for the thumbprint helper that's cross-checked against the Go backend's own `Thumbprint()` implementation and enforced in CI.
- Audits every call site whose behaviour inverts once mdoc actually parses (Presentation Exchange matching, the wallet credential summary, external import) so none of them silently degrade or accept an unverified credential now that the format handler no longer errors out.


Fixes #97 

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] New protocol implementation

## How was this tested?

<!-- Describe how you verified your changes work correctly. -->

- [x] Ran the affected flow in Looking Glass and verified real-time events
- [x] Tested locally with `cd backend && go run ./cmd/server` and `cd frontend && npm run dev`
- [ ] Other (describe below)

## Validation checklist

<!-- Run the checks that match your change. Mark not applicable items as N/A in the PR description. -->

- [x] Backend: `cd backend && go build ./... && go test ./...`
- [x] Backend lint: `cd backend && golangci-lint run ./...`
- [x] Frontend: `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- [x] Frontend references: `cd frontend && npm run verify-refs`
- [x] Wallet UI: `cd wallet-ui && npx tsc --noEmit && npm run build`
- [x] Docs: `cd docs/starlight && npm run build`
- [x] OpenAPI: `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1`
- [x] Docker/topology: `cd docker && docker compose config`
- [x] OID4VCI/OID4VP conformance: `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1`

## Checklist

<!-- Complete all items before requesting review. -->

- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] I have read the [CONTRIBUTING](https://github.com/ParleSec/ProtocolSoup/blob/master/CONTRIBUTING.md) guide
- [x] I selected the relevant validation checks above
- [x] I have updated documentation if needed
- [x] I have not committed secrets, credentials, or `.env` files

## Screenshots / Looking Glass output

<!-- If this is a UI change or protocol change, include screenshots or Looking Glass timeline output. -->
