### PR TITLE
Feature/vc dcql

### DIFF
--- a/backend/cmd/walletharness/main.go
+++ b/backend/cmd/walletharness/main.go
@@ -2945,82 +2945,141 @@ func formatToDefaultConfigurationID(format string) string {
 	}
 }
 
+// matchWalletCredentialsToDCQL reports which stored wallet credentials are
+// eligible to be presented for a DCQL query. This wallet harness presents
+// exactly one credential per request/response (see createVPToken, which
+// takes a single presentedCredentialJWT and never combines credentials into
+// one vp_token), so:
+//
+//   - Without credential_sets (OID4VP 1.0 Section 6.1 credential_sets is
+//     absent): a credential is eligible if it satisfies at least one
+//     Credential Query in the DCQL query, exactly as before credential_sets
+//     support existed. (A DCQL query with more than one Credential Query and
+//     no credential_sets technically requires all of them per Section 6.4.2,
+//     but presenting all of them at once is the pre-existing architectural
+//     limit this function has always had; that is unrelated to credential_sets
+//     and out of scope here.)
+//   - With credential_sets present: a credential is only eligible if
+//     presenting it ALONE would satisfy the whole query -- every
+//     unconditionally-required Credential Query (one not referenced by any
+//     credential_sets option) plus vc.EvaluateCredentialSets. This can only
+//     ever be true for a credential_sets option of size one; a required
+//     option needing two or more distinct Credential Query ids together is
+//     structurally unsatisfiable by this single-credential wallet, and is
+//     reported via reasons rather than silently claimed as a match.
 func matchWalletCredentialsToDCQL(credentials map[string]walletCredentialMaterial, dcqlQueryRaw string) ([]walletCredentialMaterial, []string) {
-	requirements := vc.ParseDCQLCredentialRequirements(dcqlQueryRaw)
+	query := vc.ParseDCQLQuery(dcqlQueryRaw)
+	requirements := query.Credentials
 	if len(requirements) == 0 {
 		return nil, nil
 	}
+	referencedByCredentialSets := vc.CredentialIDsReferencedByCredentialSets(query)
+
 	var matched []walletCredentialMaterial
 	var reasons []string
 	for credID, cred := range credentials {
-		// mso_mdoc credentials are base64url CBOR (not a JWT/SD-JWT), so they take
-		// the mdoc DCQL matcher (doctype + [namespace, elementIdentifier] paths)
-		// rather than vc.BuildCredentialEvidence. vc.MSOMdocFormat means
-		// BuildCredentialEvidence now parses mdoc successfully rather than
-		// failing, but its CredentialEvidence.FullClaims is still the flat
-		// JWT/SD-JWT claim shape, not [namespace, elementIdentifier] paths --
-		// the wrong shape for vc.RequirementMatchesMdoc below, so mdoc still
-		// needs this separate branch even though the parse no longer fails.
-		if strings.EqualFold(strings.TrimSpace(cred.Format), credentialFormatMsoMdoc) {
-			mdocEvidence, err := mdocMatchEvidence(cred)
-			if err != nil {
-				reasons = append(reasons, fmt.Sprintf("credential %s: %v", credID, err))
+		matchedRequirementIDs, credReasons := matchedDCQLRequirementIDsForCredential(credID, cred, requirements)
+		reasons = append(reasons, credReasons...)
+		if len(matchedRequirementIDs) == 0 {
+			continue
+		}
+		if len(query.CredentialSets) == 0 {
+			matched = append(matched, cred)
+			continue
+		}
+		eligible := true
+		for _, requirement := range requirements {
+			id := strings.TrimSpace(requirement.ID)
+			if referencedByCredentialSets[id] {
 				continue
 			}
-			anyMatch := false
-			for _, req := range requirements {
-				ok, _, reason := vc.RequirementMatchesMdoc(req, mdocEvidence)
-				if ok {
-					anyMatch = true
-					break
-				}
-				reasons = append(reasons, fmt.Sprintf("credential %s: %s", credID, reason))
-			}
-			if anyMatch {
-				matched = append(matched, cred)
-			}
-			continue
-		}
-		// The wallet's own stored copy of an issued credential is being
-		// checked for eligibility here, not something the holder has
-		// presented, so this is LifecycleStageIssued.
-		evidence, err := vc.BuildCredentialEvidence(cred.CredentialJWT, vc.LifecycleStageIssued)
-		if err != nil {
-			reasons = append(reasons, fmt.Sprintf("credential %s: %v", credID, err))
-			continue
-		}
-		if normalizedFormat := strings.TrimSpace(cred.Format); normalizedFormat != "" {
-			evidence.Format = normalizedFormat
-		}
-		if normalizedVCT := strings.TrimSpace(cred.VCT); normalizedVCT != "" {
-			evidence.VCT = normalizedVCT
-		}
-		if normalizedDoctype := strings.TrimSpace(cred.Doctype); normalizedDoctype != "" {
-			evidence.Doctype = normalizedDoctype
-		}
-		if len(evidence.CredentialTypes) == 0 {
-			summary := summarizeCredential(cred.CredentialJWT)
-			if summary != nil {
-				evidence.CredentialTypes = append([]string{}, summary.CredentialTypes...)
-			}
-		}
-		anyMatch := false
-		for _, req := range requirements {
-			ok, _, reason := vc.RequirementMatchesEvidence(req, *evidence)
-			if ok {
-				anyMatch = true
+			if !matchedRequirementIDs[id] {
+				eligible = false
 				break
 			}
-			reasons = append(reasons, fmt.Sprintf("credential %s: %s", credID, reason))
 		}
-		if anyMatch {
-			matched = append(matched, cred)
+		if eligible {
+			if satisfied, _ := vc.EvaluateCredentialSets(query, matchedRequirementIDs); !satisfied {
+				eligible = false
+			}
 		}
+		if !eligible {
+			reasons = append(reasons, fmt.Sprintf("credential %s: cannot alone satisfy the requested credential_sets combination(s); this wallet presents one credential per request", credID))
+			continue
+		}
+		matched = append(matched, cred)
 	}
 	sort.Slice(matched, func(i, j int) bool {
 		return matched[i].UpdatedAt.After(matched[j].UpdatedAt)
 	})
 	return matched, reasons
+}
+
+// matchedDCQLRequirementIDsForCredential evaluates a single stored wallet
+// credential against every Credential Query in a DCQL query's `credentials`
+// array (mso_mdoc and JWT/SD-JWT credentials use different DCQL matchers,
+// mirroring the two branches matchWalletCredentialsToDCQL had before it
+// needed per-requirement-id granularity for credential_sets) and returns the
+// set of Credential Query `id`s the credential individually satisfies.
+func matchedDCQLRequirementIDsForCredential(credID string, cred walletCredentialMaterial, requirements []vc.DCQLCredentialRequirement) (map[string]bool, []string) {
+	matchedIDs := make(map[string]bool, len(requirements))
+	var reasons []string
+	// mso_mdoc credentials are base64url CBOR (not a JWT/SD-JWT), so they take
+	// the mdoc DCQL matcher (doctype + [namespace, elementIdentifier] paths)
+	// rather than vc.BuildCredentialEvidence. vc.MSOMdocFormat means
+	// BuildCredentialEvidence now parses mdoc successfully rather than
+	// failing, but its CredentialEvidence.FullClaims is still the flat
+	// JWT/SD-JWT claim shape, not [namespace, elementIdentifier] paths --
+	// the wrong shape for vc.RequirementMatchesMdoc below, so mdoc still
+	// needs this separate branch even though the parse no longer fails.
+	if strings.EqualFold(strings.TrimSpace(cred.Format), credentialFormatMsoMdoc) {
+		mdocEvidence, err := mdocMatchEvidence(cred)
+		if err != nil {
+			reasons = append(reasons, fmt.Sprintf("credential %s: %v", credID, err))
+			return matchedIDs, reasons
+		}
+		for _, req := range requirements {
+			ok, _, reason := vc.RequirementMatchesMdoc(req, mdocEvidence)
+			if ok {
+				matchedIDs[strings.TrimSpace(req.ID)] = true
+				continue
+			}
+			reasons = append(reasons, fmt.Sprintf("credential %s: %s", credID, reason))
+		}
+		return matchedIDs, reasons
+	}
+	// The wallet's own stored copy of an issued credential is being checked
+	// for eligibility here, not something the holder has presented, so this
+	// is LifecycleStageIssued.
+	evidence, err := vc.BuildCredentialEvidence(cred.CredentialJWT, vc.LifecycleStageIssued)
+	if err != nil {
+		reasons = append(reasons, fmt.Sprintf("credential %s: %v", credID, err))
+		return matchedIDs, reasons
+	}
+	if normalizedFormat := strings.TrimSpace(cred.Format); normalizedFormat != "" {
+		evidence.Format = normalizedFormat
+	}
+	if normalizedVCT := strings.TrimSpace(cred.VCT); normalizedVCT != "" {
+		evidence.VCT = normalizedVCT
+	}
+	if normalizedDoctype := strings.TrimSpace(cred.Doctype); normalizedDoctype != "" {
+		evidence.Doctype = normalizedDoctype
+	}
+	if len(evidence.CredentialTypes) == 0 {
+		summary := summarizeCredential(cred.CredentialJWT)
+		if summary != nil {
+			evidence.CredentialTypes = append([]string{}, summary.CredentialTypes...)
+		}
+	}
+	for _, req := range requirements {
+		ok, _, reason := vc.RequirementMatchesEvidence(req, *evidence)
+		if ok {
+			matchedIDs[strings.TrimSpace(req.ID)] = true
+			continue
+		}
+		reasons = append(reasons, fmt.Sprintf("credential %s: %s", credID, reason))
+	}
+	return matchedIDs, reasons
 }
 
 func matchWalletCredentialsToPresentationDefinition(credentials map[string]walletCredentialMaterial, presentationDefinition map[string]interface{}) ([]walletCredentialMaterial, []string) {

--- a/backend/cmd/walletharness/main_test.go
+++ b/backend/cmd/walletharness/main_test.go
@@ -445,6 +445,135 @@ func TestMatchWalletCredentialsToDCQLSupportsNormalizedJWTAndLDPFormats(t *testi
 	}
 }
 
+// walletCredentialSetsFixture returns a single stored jwt_vc_json credential
+// plus a DCQL query builder with two Credential Queries -- "degree_requirement"
+// (satisfiable by that credential) and "unused_requirement" (a vct the
+// fixture credential never carries) -- so tests can attach different
+// top-level credential_sets arrays (OID4VP 1.0 Section 6.2) and exercise
+// matchWalletCredentialsToDCQL's single-credential-aware credential_sets
+// handling.
+func walletCredentialSetsFixture(t *testing.T) (map[string]walletCredentialMaterial, func(credentialSets string) string) {
+	t.Helper()
+	subject := "did:key:zExampleHolder"
+	const universityDegreeVCT = "https://protocolsoup.com/credentials/university_degree"
+	credentials := map[string]walletCredentialMaterial{
+		"cred-1": {
+			CredentialID:              "cred-1",
+			CredentialJWT:             signedCredentialJWTWithClaims(t, subject, false),
+			Format:                    "jwt_vc_json",
+			CredentialConfigurationID: "UniversityDegreeCredential",
+			VCT:                       universityDegreeVCT,
+			UpdatedAt:                 time.Now().UTC(),
+		},
+	}
+	buildQuery := func(credentialSets string) string {
+		return `{
+			"credentials": [
+				{
+					"id": "degree_requirement",
+					"format": "jwt_vc_json",
+					"meta": {"vct_values": ["` + universityDegreeVCT + `"], "type_values": ["UniversityDegreeCredential"]},
+					"claims": [{"path": ["degree"]}]
+				},
+				{
+					"id": "unused_requirement",
+					"format": "jwt_vc_json",
+					"meta": {"vct_values": ["https://protocolsoup.com/credentials/never_issued"]}
+				}
+			],
+			"credential_sets": [` + credentialSets + `]
+		}`
+	}
+	return credentials, buildQuery
+}
+
+// TestMatchWalletCredentialsToDCQLCredentialSetSatisfiedByOneAlternative
+// proves the stored credential is still recommended when a required
+// credential_sets option references it, even though a second Credential
+// Query ("unused_requirement") in the same query is never satisfied -- the
+// pre-credential_sets behaviour of requiring every entry in `credentials`
+// does not apply once credential_sets is present (OID4VP 1.0 Section 6.4.2).
+func TestMatchWalletCredentialsToDCQLCredentialSetSatisfiedByOneAlternative(t *testing.T) {
+	credentials, buildQuery := walletCredentialSetsFixture(t)
+	dcql := buildQuery(`{"options": [["unused_requirement"], ["degree_requirement"]], "required": true}`)
+
+	matched, reasons := matchWalletCredentialsToDCQL(credentials, dcql)
+	if len(matched) != 1 {
+		t.Fatalf("expected the credential to be recommended via the degree_requirement option, got %d matched (reasons=%v)", len(matched), reasons)
+	}
+}
+
+// TestMatchWalletCredentialsToDCQLDeniesUnsatisfiedRequiredCredentialSet
+// proves the credential is NOT recommended when a required credential_sets
+// entry's only option needs a Credential Query the credential cannot satisfy
+// -- this wallet harness presents exactly one credential per request
+// (createVPToken), so it can never single-handedly satisfy both
+// "degree_requirement" and "unused_requirement" together.
+func TestMatchWalletCredentialsToDCQLDeniesUnsatisfiedRequiredCredentialSet(t *testing.T) {
+	credentials, _ := walletCredentialSetsFixture(t)
+	// The fixture's buildQuery helper only supports a single credential_sets
+	// entry per call; this test needs two, so it's built directly here.
+	dcql := `{
+		"credentials": [
+			{
+				"id": "degree_requirement",
+				"format": "jwt_vc_json",
+				"meta": {"vct_values": ["https://protocolsoup.com/credentials/university_degree"], "type_values": ["UniversityDegreeCredential"]},
+				"claims": [{"path": ["degree"]}]
+			},
+			{
+				"id": "unused_requirement",
+				"format": "jwt_vc_json",
+				"meta": {"vct_values": ["https://protocolsoup.com/credentials/never_issued"]}
+			}
+		],
+		"credential_sets": [
+			{"options": [["degree_requirement"]], "required": true},
+			{"options": [["unused_requirement"]], "required": true}
+		]
+	}`
+
+	matched, reasons := matchWalletCredentialsToDCQL(credentials, dcql)
+	if len(matched) != 0 {
+		t.Fatalf("expected no match since the credential cannot alone satisfy every required credential_sets entry, got %d matched", len(matched))
+	}
+	if len(reasons) == 0 {
+		t.Fatal("expected a reason explaining why the credential was not recommended")
+	}
+}
+
+// TestMatchWalletCredentialsToDCQLAllowsUnsatisfiedOptionalCredentialSet
+// proves a credential_sets entry marked required:false does not prevent the
+// credential from being recommended even though that entry's only option is
+// unsatisfiable.
+func TestMatchWalletCredentialsToDCQLAllowsUnsatisfiedOptionalCredentialSet(t *testing.T) {
+	credentials, _ := walletCredentialSetsFixture(t)
+	dcql := `{
+		"credentials": [
+			{
+				"id": "degree_requirement",
+				"format": "jwt_vc_json",
+				"meta": {"vct_values": ["https://protocolsoup.com/credentials/university_degree"], "type_values": ["UniversityDegreeCredential"]},
+				"claims": [{"path": ["degree"]}]
+			},
+			{
+				"id": "unused_requirement",
+				"format": "jwt_vc_json",
+				"meta": {"vct_values": ["https://protocolsoup.com/credentials/never_issued"]}
+			}
+		],
+		"credential_sets": [
+			{"options": [["degree_requirement"]], "required": true},
+			{"options": [["unused_requirement"]], "required": false}
+		]
+	}`
+
+	matched, reasons := matchWalletCredentialsToDCQL(credentials, dcql)
+	if len(matched) != 1 {
+		t.Fatalf("expected the credential to still be recommended, got %d matched (reasons=%v)", len(matched), reasons)
+	}
+}
+
 func TestExtractPublicKeyFromMethodSupportsOKP(t *testing.T) {
 	keySet, err := intcrypto.NewKeySet()
 	if err != nil {

--- a/backend/internal/protocols/oid4vp/handlers.go
+++ b/backend/internal/protocols/oid4vp/handlers.go
@@ -898,8 +898,13 @@ func (p *Plugin) evaluateSDJWTPresentation(session *requestSession, vpToken stri
 				} else {
 					result.NonceValidated = true
 				}
-				if _, hasIAT := kbClaims["iat"]; !hasIAT {
+				if issuedAt, err := kbClaims.GetIssuedAt(); err != nil || issuedAt == nil {
 					addPolicyReason(result, "kb_jwt_invalid", "kb-jwt missing iat")
+				} else {
+					now := time.Now().UTC()
+					if issuedAt.Time.Before(now.Add(-kbJWTFreshnessSkew)) || issuedAt.Time.After(now.Add(kbJWTFreshnessSkew)) {
+						addPolicyReason(result, "kb_jwt_invalid", "kb-jwt iat is outside the acceptable freshness window")
+					}
 				}
 				// Verify sd_hash
 				sdJWTWithoutKB := vc.BuildSDJWTSerialization(envelope.IssuerSignedJWT, envelope.Disclosures, "")
@@ -1480,10 +1485,17 @@ func (p *Plugin) validatePresentedCredentialEnvelopes(
 		return nil, newVerifierPolicyError("credential_missing", "presented credential is missing", nil)
 	}
 
-	var requirements []dcqlCredentialRequirement
+	var dcqlQuery vc.DCQLQuery
 	if session != nil {
-		requirements = parseDCQLCredentialRequirements(session.DCQLQuery)
+		dcqlQuery = vc.ParseDCQLQuery(session.DCQLQuery)
 	}
+	requirements := dcqlQuery.Credentials
+	// referencedByCredentialSets is nil when the query has no credential_sets
+	// (OID4VP 1.0 Section 6.2), so every requirement below is unconditionally
+	// required exactly as it was before credential_sets support existed --
+	// this is the backward-compatibility bar for this loop.
+	referencedByCredentialSets := vc.CredentialIDsReferencedByCredentialSets(dcqlQuery)
+	matchedRequirementIDs := make(map[string]bool, len(requirements))
 	for _, requirement := range requirements {
 		matched := false
 		failureCode := "dcql_format_mismatch"
@@ -1502,9 +1514,24 @@ func (p *Plugin) validatePresentedCredentialEnvelopes(
 				failureMessage = message
 			}
 		}
-		if !matched {
+		if matched {
+			if id := strings.TrimSpace(requirement.ID); id != "" {
+				matchedRequirementIDs[id] = true
+			}
+			continue
+		}
+		// A requirement referenced by a credential_sets option is only
+		// required as part of satisfying that option (Section 6.4.2: with
+		// credential_sets present, the Wallet returns presentations for the
+		// required Credential Set Queries' options, not unconditionally every
+		// entry in `credentials`); its failure to match is adjudicated below
+		// by vc.EvaluateCredentialSets, not here.
+		if !referencedByCredentialSets[strings.TrimSpace(requirement.ID)] {
 			return nil, newVerifierPolicyError(failureCode, failureMessage, nil)
 		}
+	}
+	if satisfied, unsatisfiedSets := vc.EvaluateCredentialSets(dcqlQuery, matchedRequirementIDs); !satisfied {
+		return nil, newVerifierPolicyError("dcql_credential_set_unsatisfied", fmt.Sprintf("presented credentials do not satisfy required dcql credential_sets %v", unsatisfiedSets), nil)
 	}
 
 	return evidenceSet, nil
@@ -1672,10 +1699,6 @@ func findStoredCredentialLineage(
 		return record, true
 	}
 	return vc.WalletCredentialRecord{}, false
-}
-
-func parseDCQLCredentialRequirements(rawDCQLQuery string) []dcqlCredentialRequirement {
-	return vc.ParseDCQLCredentialRequirements(rawDCQLQuery)
 }
 
 func requirementMatchesEvidence(requirement dcqlCredentialRequirement, evidence models.OID4VPCredentialEvidence) (bool, string, string) {

--- a/backend/internal/protocols/oid4vp/handlers.go
+++ b/backend/internal/protocols/oid4vp/handlers.go
@@ -902,7 +902,7 @@ func (p *Plugin) evaluateSDJWTPresentation(session *requestSession, vpToken stri
 					addPolicyReason(result, "kb_jwt_invalid", "kb-jwt missing iat")
 				} else {
 					now := time.Now().UTC()
-					if issuedAt.Time.Before(now.Add(-kbJWTFreshnessSkew)) || issuedAt.Time.After(now.Add(kbJWTFreshnessSkew)) {
+					if issuedAt.Before(now.Add(-kbJWTFreshnessSkew)) || issuedAt.After(now.Add(kbJWTFreshnessSkew)) {
 						addPolicyReason(result, "kb_jwt_invalid", "kb-jwt iat is outside the acceptable freshness window")
 					}
 				}

--- a/backend/internal/protocols/oid4vp/handlers.go
+++ b/backend/internal/protocols/oid4vp/handlers.go
@@ -26,6 +26,13 @@ const (
 	credentialFormatJWTVCJSON  = "jwt_vc_json"
 	credentialFormatJWTVCJSONL = "jwt_vc_json-ld"
 	credentialFormatLDPVC      = "ldp_vc"
+
+	// kbJWTFreshnessSkew bounds how far from "now" a Key Binding JWT's iat may
+	// be (SD-JWT RFC 9901 §7.3 step 5.e: the Verifier MUST "check that the
+	// creation time of the Key Binding JWT, as determined by the iat claim,
+	// is within an acceptable window"); applied symmetrically since clocks can
+	// also run fast.
+	kbJWTFreshnessSkew = 5 * time.Minute
 )
 
 type createAuthorizationRequest struct {

--- a/backend/internal/protocols/oid4vp/mdoc_presentation.go
+++ b/backend/internal/protocols/oid4vp/mdoc_presentation.go
@@ -246,7 +246,8 @@ func (p *Plugin) matchMdocAgainstDCQL(session *requestSession, verified []verifi
 	if session == nil {
 		return evidenceSet, nil
 	}
-	requirements := vc.ParseDCQLCredentialRequirements(session.DCQLQuery)
+	dcqlQuery := vc.ParseDCQLQuery(session.DCQLQuery)
+	requirements := dcqlQuery.Credentials
 	requirementsByID := make(map[string]struct{}, len(requirements))
 	for _, requirement := range requirements {
 		requirementID := strings.TrimSpace(requirement.ID)
@@ -265,6 +266,12 @@ func (p *Plugin) matchMdocAgainstDCQL(session *requestSession, verified []verifi
 			}
 		}
 	}
+	// referencedByCredentialSets is nil when the query has no credential_sets
+	// (OID4VP 1.0 Section 6.2), so every requirement below is unconditionally
+	// required exactly as it was before credential_sets support existed --
+	// this is the backward-compatibility bar for this loop.
+	referencedByCredentialSets := vc.CredentialIDsReferencedByCredentialSets(dcqlQuery)
+	matchedRequirementIDs := make(map[string]bool, len(requirements))
 	for _, requirement := range requirements {
 		matched := false
 		failureCode := "dcql_format_mismatch"
@@ -286,9 +293,19 @@ func (p *Plugin) matchMdocAgainstDCQL(session *requestSession, verified []verifi
 				failureMessage = message
 			}
 		}
-		if !matched {
+		if matched {
+			matchedRequirementIDs[strings.TrimSpace(requirement.ID)] = true
+			continue
+		}
+		// A requirement referenced by a credential_sets option is only
+		// required as part of satisfying that option; its failure to match
+		// is adjudicated below by vc.EvaluateCredentialSets, not here.
+		if !referencedByCredentialSets[strings.TrimSpace(requirement.ID)] {
 			return nil, newVerifierPolicyError(failureCode, failureMessage, nil)
 		}
+	}
+	if satisfied, unsatisfiedSets := vc.EvaluateCredentialSets(dcqlQuery, matchedRequirementIDs); !satisfied {
+		return nil, newVerifierPolicyError("dcql_credential_set_unsatisfied", fmt.Sprintf("presented mso_mdoc credentials do not satisfy required dcql credential_sets %v", unsatisfiedSets), nil)
 	}
 	return evidenceSet, nil
 }

--- a/backend/internal/protocols/oid4vp/mdoc_presentation_test.go
+++ b/backend/internal/protocols/oid4vp/mdoc_presentation_test.go
@@ -262,6 +262,142 @@ func TestEvaluateMdocPresentationRejectsDCQLMismatch(t *testing.T) {
 	}
 }
 
+// mdocCredentialSetsDCQLQuery builds an mso_mdoc DCQL query with two
+// Credential Queries -- "mdl" (satisfiable by the mDL DeviceResponse these
+// tests build via buildMdocVPToken) and "unused_pid" (a distinct doctype the
+// tests never present) -- plus the given top-level credential_sets array
+// (OID4VP 1.0 Section 6.2), for exercising vc.EvaluateCredentialSets on the
+// mdoc verification path (matchMdocAgainstDCQL).
+func mdocCredentialSetsDCQLQuery(t *testing.T, credentialSets []map[string]interface{}) string {
+	t.Helper()
+	query := map[string]interface{}{
+		"credentials": []map[string]interface{}{
+			{
+				"id":     "mdl",
+				"format": "mso_mdoc",
+				"meta":   map[string]interface{}{"doctype_values": []string{"org.iso.18013.5.1.mDL"}},
+				"claims": []map[string]interface{}{
+					{"path": []string{"org.iso.18013.5.1", "family_name"}},
+					{"path": []string{"org.iso.18013.5.1", "document_number"}},
+				},
+			},
+			{
+				"id":     "unused_pid",
+				"format": "mso_mdoc",
+				"meta":   map[string]interface{}{"doctype_values": []string{"eu.europa.ec.eudi.pid.1"}},
+			},
+		},
+		"credential_sets": credentialSets,
+	}
+	raw, err := json.Marshal(query)
+	if err != nil {
+		t.Fatalf("marshal mdoc credential_sets dcql query: %v", err)
+	}
+	return string(raw)
+}
+
+// TestEvaluateMdocPresentationCredentialSetSatisfiedByOneAlternative proves a
+// required credential_sets entry on the mdoc path succeeds when the presented
+// DeviceResponse satisfies at least one of its options, even though
+// "unused_pid" (a different Credential Query in the same `credentials` array)
+// was never presented.
+func TestEvaluateMdocPresentationCredentialSetSatisfiedByOneAlternative(t *testing.T) {
+	deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("device key: %v", err)
+	}
+	issuerSigned, pki := issueMdocForVerifier(t, deviceKey)
+
+	p := NewPlugin()
+	p.mdocTrustAnchors = pki.TrustAnchors()
+
+	handover := realHandover(t, "verifier-client-1", "nonce-xyz", "https://verifier.example/response", nil)
+	vpToken := buildMdocVPToken(t, deviceKey, issuerSigned, handover)
+	session := &requestSession{
+		ID:          "req-cs-1",
+		ClientID:    "verifier-client-1",
+		Nonce:       "nonce-xyz",
+		ResponseURI: "https://verifier.example/response",
+		DCQLQuery: mdocCredentialSetsDCQLQuery(t, []map[string]interface{}{
+			{"options": [][]string{{"unused_pid"}, {"mdl"}}, "required": true},
+		}),
+	}
+
+	result := p.evaluateVPToken(session, vpToken)
+	if !result.Policy.Allowed {
+		t.Fatalf("expected credential_sets satisfied by mdl alone, got code=%q reasons=%v", result.Policy.Code, result.Policy.Reasons)
+	}
+}
+
+// TestEvaluateMdocPresentationDeniesUnsatisfiedRequiredCredentialSet proves a
+// required credential_sets entry whose only option references a Credential
+// Query the wallet never presented is denied with the new
+// dcql_credential_set_unsatisfied reason code, even though a different,
+// independently-satisfied credential_sets entry exists for "mdl".
+func TestEvaluateMdocPresentationDeniesUnsatisfiedRequiredCredentialSet(t *testing.T) {
+	deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("device key: %v", err)
+	}
+	issuerSigned, pki := issueMdocForVerifier(t, deviceKey)
+
+	p := NewPlugin()
+	p.mdocTrustAnchors = pki.TrustAnchors()
+
+	handover := realHandover(t, "verifier-client-1", "nonce-xyz", "https://verifier.example/response", nil)
+	vpToken := buildMdocVPToken(t, deviceKey, issuerSigned, handover)
+	session := &requestSession{
+		ID:          "req-cs-2",
+		ClientID:    "verifier-client-1",
+		Nonce:       "nonce-xyz",
+		ResponseURI: "https://verifier.example/response",
+		DCQLQuery: mdocCredentialSetsDCQLQuery(t, []map[string]interface{}{
+			{"options": [][]string{{"mdl"}}, "required": true},
+			{"options": [][]string{{"unused_pid"}}, "required": true},
+		}),
+	}
+
+	result := p.evaluateVPToken(session, vpToken)
+	if result.Policy.Allowed {
+		t.Fatal("expected denial when a required credential_sets entry has no satisfiable option")
+	}
+	if !containsPolicyCode(result, "dcql_credential_set_unsatisfied") {
+		t.Fatalf("expected dcql_credential_set_unsatisfied reason, got %v", result.Policy.ReasonCodes)
+	}
+}
+
+// TestEvaluateMdocPresentationAllowsUnsatisfiedOptionalCredentialSet proves a
+// credential_sets entry marked required:false does not block the overall mdoc
+// query from succeeding even when none of its options are satisfiable.
+func TestEvaluateMdocPresentationAllowsUnsatisfiedOptionalCredentialSet(t *testing.T) {
+	deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("device key: %v", err)
+	}
+	issuerSigned, pki := issueMdocForVerifier(t, deviceKey)
+
+	p := NewPlugin()
+	p.mdocTrustAnchors = pki.TrustAnchors()
+
+	handover := realHandover(t, "verifier-client-1", "nonce-xyz", "https://verifier.example/response", nil)
+	vpToken := buildMdocVPToken(t, deviceKey, issuerSigned, handover)
+	session := &requestSession{
+		ID:          "req-cs-3",
+		ClientID:    "verifier-client-1",
+		Nonce:       "nonce-xyz",
+		ResponseURI: "https://verifier.example/response",
+		DCQLQuery: mdocCredentialSetsDCQLQuery(t, []map[string]interface{}{
+			{"options": [][]string{{"mdl"}}, "required": true},
+			{"options": [][]string{{"unused_pid"}}, "required": false},
+		}),
+	}
+
+	result := p.evaluateVPToken(session, vpToken)
+	if !result.Policy.Allowed {
+		t.Fatalf("expected optional unsatisfied credential_sets entry to not block, got code=%q reasons=%v", result.Policy.Code, result.Policy.Reasons)
+	}
+}
+
 // TestEvaluateMdocPresentationRequiresHandover confirms the verifier does not
 // guess a handover: without one bound to the session it reports a clear reason
 // (the OID4VP handover is fixed by the online profile).

--- a/backend/internal/protocols/oid4vp/plugin_test.go
+++ b/backend/internal/protocols/oid4vp/plugin_test.go
@@ -719,6 +719,102 @@ func TestDirectPostPolicyDeniesDCQLFormatMismatch(t *testing.T) {
 	}
 }
 
+// credentialSetsDCQLQuery builds a DCQL query with two Credential Queries --
+// "degree_sd_jwt" (satisfiable by the wallet fixture's actual dc+sd-jwt
+// credential) and "unused_ldp_vc" (an ldp_vc requirement the single-credential
+// wallet fixture never presents) -- plus the given top-level credential_sets
+// array (OID4VP 1.0 Section 6.2), for exercising the verifier-side
+// vc.EvaluateCredentialSets wiring end to end.
+func credentialSetsDCQLQuery(credentialSets []map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"credentials": []map[string]interface{}{
+			{
+				"id": "degree_sd_jwt",
+				"meta": map[string]interface{}{
+					"vct_values": []string{testCredentialVCT},
+				},
+				"claims": []map[string]interface{}{
+					{"path": []string{"degree"}},
+				},
+			},
+			{
+				"id":     "unused_ldp_vc",
+				"format": "ldp_vc",
+				"meta": map[string]interface{}{
+					"type_values": []string{"UniversityDegreeCredential"},
+				},
+			},
+		},
+		"credential_sets": credentialSets,
+	}
+}
+
+// TestDirectPostPolicyAllowsCredentialSetSatisfiedByOneAlternative proves a
+// required credential_sets entry succeeds when the presented credential
+// satisfies at least one of its options, even though it does not satisfy
+// every entry in `credentials` (the pre-credential_sets behaviour) -- the
+// wallet's real dc+sd-jwt credential only ever matches "degree_sd_jwt", never
+// "unused_ldp_vc".
+func TestDirectPostPolicyAllowsCredentialSetSatisfiedByOneAlternative(t *testing.T) {
+	env := newCombinedVCServer(t)
+	defer env.Server.Close()
+
+	wallet := issueCredentialForWallet(t, env.Server.URL, "alice")
+	createPayload := createVPRequestWithDCQL(t, env.Server.URL, "direct_post", credentialSetsDCQLQuery([]map[string]interface{}{
+		{"options": [][]string{{"unused_ldp_vc"}, {"degree_sd_jwt"}}, "required": true},
+	}))
+	postWalletResponse(t, env.Server.URL, env.KeySet, createPayload, wallet, "")
+
+	resultPayload := fetchVerificationResult(t, env.Server.URL, asVPString(createPayload["request_id"]))
+	assertPolicyAllowed(t, resultPayload)
+}
+
+// TestDirectPostPolicyDeniesUnsatisfiedRequiredCredentialSet proves a
+// required credential_sets entry whose only option references a Credential
+// Query the wallet never satisfies is denied with the new
+// dcql_credential_set_unsatisfied reason code, even though a different,
+// independently-satisfied credential_sets entry exists for the credential
+// that was actually presented.
+func TestDirectPostPolicyDeniesUnsatisfiedRequiredCredentialSet(t *testing.T) {
+	env := newCombinedVCServer(t)
+	defer env.Server.Close()
+
+	wallet := issueCredentialForWallet(t, env.Server.URL, "alice")
+	createPayload := createVPRequestWithDCQL(t, env.Server.URL, "direct_post", credentialSetsDCQLQuery([]map[string]interface{}{
+		{"options": [][]string{{"degree_sd_jwt"}}, "required": true},
+		{"options": [][]string{{"unused_ldp_vc"}}, "required": true},
+	}))
+	postWalletResponse(t, env.Server.URL, env.KeySet, createPayload, wallet, "")
+
+	resultPayload := fetchVerificationResult(t, env.Server.URL, asVPString(createPayload["request_id"]))
+	policyObj := extractVPPolicy(t, resultPayload)
+	if allowed, ok := policyObj["allowed"].(bool); !ok || allowed {
+		t.Fatalf("expected denied policy decision, got %v", policyObj)
+	}
+	reasonCodes, _ := policyObj["reason_codes"].([]interface{})
+	if !containsVPReasonCode(reasonCodes, "dcql_credential_set_unsatisfied") {
+		t.Fatalf("expected dcql_credential_set_unsatisfied reason code, got %v", reasonCodes)
+	}
+}
+
+// TestDirectPostPolicyAllowsUnsatisfiedOptionalCredentialSet proves a
+// credential_sets entry marked required:false does not block the overall
+// query from succeeding even when none of its options are satisfiable.
+func TestDirectPostPolicyAllowsUnsatisfiedOptionalCredentialSet(t *testing.T) {
+	env := newCombinedVCServer(t)
+	defer env.Server.Close()
+
+	wallet := issueCredentialForWallet(t, env.Server.URL, "alice")
+	createPayload := createVPRequestWithDCQL(t, env.Server.URL, "direct_post", credentialSetsDCQLQuery([]map[string]interface{}{
+		{"options": [][]string{{"degree_sd_jwt"}}, "required": true},
+		{"options": [][]string{{"unused_ldp_vc"}}, "required": false},
+	}))
+	postWalletResponse(t, env.Server.URL, env.KeySet, createPayload, wallet, "")
+
+	resultPayload := fetchVerificationResult(t, env.Server.URL, asVPString(createPayload["request_id"]))
+	assertPolicyAllowed(t, resultPayload)
+}
+
 func TestDirectPostPolicyAllowsDCQLAcrossSupportedFormats(t *testing.T) {
 	testCases := []struct {
 		name                      string
@@ -1283,6 +1379,115 @@ func createVPTokenWithExpiry(
 		t.Fatalf("sign vp token: %v", err)
 	}
 	return signed
+}
+
+// buildRawSDJWTKBVPToken builds a genuine SD-JWT+KB compact serialization
+// ("issuer-signed-jwt~disclosure~...~kb-jwt") signed over the wallet's real
+// credential, for tests that need to exercise the raw KB-JWT validation path
+// in evaluateSDJWTPresentation (aud/nonce/iat/sd_hash) directly, rather than
+// the vp+jwt-wrapped credential_jwt path createVPToken produces.
+func buildRawSDJWTKBVPToken(t *testing.T, createPayload map[string]interface{}, wallet *walletFixture, kbIssuedAt time.Time) string {
+	t.Helper()
+	envelope, err := vc.ParseSDJWTEnvelope(wallet.CredentialJWT)
+	if err != nil {
+		t.Fatalf("parse sd-jwt envelope: %v", err)
+	}
+	sdJWTWithoutKB := vc.BuildSDJWTSerialization(envelope.IssuerSignedJWT, envelope.Disclosures, "")
+	if !strings.HasSuffix(sdJWTWithoutKB, "~") {
+		sdJWTWithoutKB += "~"
+	}
+	sdHashRaw := sha256.Sum256([]byte(sdJWTWithoutKB))
+
+	kbClaims := jwt.MapClaims{
+		"aud":     asVPString(createPayload["client_id"]),
+		"nonce":   asVPString(createPayload["nonce"]),
+		"iat":     kbIssuedAt.Unix(),
+		"sd_hash": base64.RawURLEncoding.EncodeToString(sdHashRaw[:]),
+	}
+	kbToken := jwt.NewWithClaims(jwt.SigningMethodRS256, kbClaims)
+	kbToken.Header["typ"] = "kb+jwt"
+	kbToken.Header["kid"] = wallet.KeySet.RSAKeyID()
+	signedKB, err := kbToken.SignedString(wallet.KeySet.RSAPrivateKey())
+	if err != nil {
+		t.Fatalf("sign kb-jwt: %v", err)
+	}
+	return vc.BuildSDJWTSerialization(envelope.IssuerSignedJWT, envelope.Disclosures, signedKB)
+}
+
+func postRawSDJWTKBResponse(t *testing.T, serverURL string, createPayload map[string]interface{}, vpToken string) {
+	t.Helper()
+	formResp, err := http.PostForm(serverURL+"/oid4vp/response", url.Values{
+		"state":    {asVPString(createPayload["state"])},
+		"vp_token": {vpToken},
+	})
+	if err != nil {
+		t.Fatalf("post raw sd-jwt+kb wallet response failed: %v", err)
+	}
+	assertVPStatus(t, formResp, http.StatusOK)
+}
+
+// TestDirectPostPolicyAllowsFreshKBJWTIat proves a raw SD-JWT+KB presentation
+// (as opposed to the vp+jwt-wrapped credential_jwt path most tests in this
+// file exercise) with a KB-JWT iat inside the freshness window is accepted.
+func TestDirectPostPolicyAllowsFreshKBJWTIat(t *testing.T) {
+	env := newCombinedVCServer(t)
+	defer env.Server.Close()
+
+	wallet := issueCredentialForWallet(t, env.Server.URL, "alice")
+	createPayload := createVPRequest(t, env.Server.URL, "direct_post")
+	vpToken := buildRawSDJWTKBVPToken(t, createPayload, wallet, time.Now().UTC())
+	postRawSDJWTKBResponse(t, env.Server.URL, createPayload, vpToken)
+
+	resultPayload := fetchVerificationResult(t, env.Server.URL, asVPString(createPayload["request_id"]))
+	assertPolicyAllowed(t, resultPayload)
+}
+
+// TestDirectPostPolicyDeniesStaleKBJWTIat proves a KB-JWT whose iat is further
+// in the past than kbJWTFreshnessSkew is rejected (SD-JWT RFC 9901 Section 7.3
+// step 5.e).
+func TestDirectPostPolicyDeniesStaleKBJWTIat(t *testing.T) {
+	env := newCombinedVCServer(t)
+	defer env.Server.Close()
+
+	wallet := issueCredentialForWallet(t, env.Server.URL, "alice")
+	createPayload := createVPRequest(t, env.Server.URL, "direct_post")
+	staleIat := time.Now().UTC().Add(-(kbJWTFreshnessSkew + time.Minute))
+	vpToken := buildRawSDJWTKBVPToken(t, createPayload, wallet, staleIat)
+	postRawSDJWTKBResponse(t, env.Server.URL, createPayload, vpToken)
+
+	resultPayload := fetchVerificationResult(t, env.Server.URL, asVPString(createPayload["request_id"]))
+	policyObj := extractVPPolicy(t, resultPayload)
+	if allowed, ok := policyObj["allowed"].(bool); !ok || allowed {
+		t.Fatalf("expected denied policy decision for stale kb-jwt iat")
+	}
+	reasonCodes, _ := policyObj["reason_codes"].([]interface{})
+	if !containsVPReasonCode(reasonCodes, "kb_jwt_invalid") {
+		t.Fatalf("expected kb_jwt_invalid reason code, got %v", reasonCodes)
+	}
+}
+
+// TestDirectPostPolicyDeniesFutureKBJWTIat proves a KB-JWT whose iat is
+// further in the future than kbJWTFreshnessSkew is rejected symmetrically
+// (clocks can run fast as well as slow).
+func TestDirectPostPolicyDeniesFutureKBJWTIat(t *testing.T) {
+	env := newCombinedVCServer(t)
+	defer env.Server.Close()
+
+	wallet := issueCredentialForWallet(t, env.Server.URL, "alice")
+	createPayload := createVPRequest(t, env.Server.URL, "direct_post")
+	futureIat := time.Now().UTC().Add(kbJWTFreshnessSkew + time.Minute)
+	vpToken := buildRawSDJWTKBVPToken(t, createPayload, wallet, futureIat)
+	postRawSDJWTKBResponse(t, env.Server.URL, createPayload, vpToken)
+
+	resultPayload := fetchVerificationResult(t, env.Server.URL, asVPString(createPayload["request_id"]))
+	policyObj := extractVPPolicy(t, resultPayload)
+	if allowed, ok := policyObj["allowed"].(bool); !ok || allowed {
+		t.Fatalf("expected denied policy decision for future kb-jwt iat")
+	}
+	reasonCodes, _ := policyObj["reason_codes"].([]interface{})
+	if !containsVPReasonCode(reasonCodes, "kb_jwt_invalid") {
+		t.Fatalf("expected kb_jwt_invalid reason code, got %v", reasonCodes)
+	}
 }
 
 func createEncryptedResponseJWT(

--- a/backend/internal/protocols/oid4vp/plugin_test.go
+++ b/backend/internal/protocols/oid4vp/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"

--- a/backend/internal/vc/dcql.go
+++ b/backend/internal/vc/dcql.go
@@ -26,6 +26,38 @@ type DCQLCredentialRequirement struct {
 	// will accept. HAIP 1.0 Section 5 mandates support for the "aki" (Authority
 	// Key Identifier) type on the mso_mdoc path.
 	TrustedAuthorities []DCQLTrustedAuthority
+	// ClaimSets is the DCQL claim_sets array (OID4VP 1.0 Section 6.1/6.4.1):
+	// each inner slice is a set of claim `id`s (Section 6.3) that must ALL be
+	// present together for that alternative to satisfy the requirement.
+	// Evaluated in order; the first fully-satisfied set wins. An empty
+	// ClaimSets preserves today's behaviour exactly: every entry in
+	// RequiredClaimPaths/RequiredClaimPathSegments is required, unconditionally.
+	ClaimSets [][]string
+	// claimsByID maps each claim `id` declared in this credential query's
+	// `claims` array to its path, for resolving ClaimSets entries. It is kept
+	// as an id-keyed map rather than a third slice index-aligned with
+	// RequiredClaimPaths/RequiredClaimPathSegments: those two are already
+	// independently deduplicated (and, for RequiredClaimPaths, sorted) for
+	// the pre-claim_sets matching path below, and a map has no ordering for
+	// that dedup/sort to disturb. This keeps the non-claim_sets matching path
+	// byte-for-byte identical to before claim_sets support was added.
+	claimsByID map[string]dcqlClaimPath
+	// unclaimedRequiredPaths/unclaimedRequiredPathSegments are the claims from
+	// this query's `claims` array that were not assigned a DCQL `id`. Per
+	// OID4VP 1.0 Section 6.3, `id` is REQUIRED once claim_sets is present, so
+	// conformant queries should never populate these; they exist purely to
+	// fail safe (treat an id-less claim as unconditionally required rather
+	// than silently unenforceable) if ClaimSets is non-empty anyway.
+	unclaimedRequiredPaths        []string
+	unclaimedRequiredPathSegments [][]string
+}
+
+// dcqlClaimPath is the resolved path (in both the dot-joined and raw-segment
+// forms used by RequirementMatchesEvidence and RequirementMatchesMdoc
+// respectively) for one claim `id` referenced by ClaimSets.
+type dcqlClaimPath struct {
+	path     string
+	segments []string
 }
 
 // DCQLTrustedAuthority is one entry of a DCQL Trusted Authorities Query

--- a/backend/internal/vc/dcql.go
+++ b/backend/internal/vc/dcql.go
@@ -97,80 +97,273 @@ type MdocCredentialEvidence struct {
 // DCQLCredentialEvidence reuses the shared credential evidence model used by PE matching.
 type DCQLCredentialEvidence = CredentialEvidence
 
+// DCQLQuery is a full DCQL query object (OID4VP 1.0 Section 6): the per-
+// credential Credential Queries plus the top-level Credential Set Queries
+// (Section 6.2) that constrain which combinations of them are needed.
+type DCQLQuery struct {
+	Credentials    []DCQLCredentialRequirement
+	CredentialSets []DCQLCredentialSet
+}
+
+// DCQLCredentialSet is one entry of the top-level `credential_sets` array
+// (OID4VP 1.0 Section 6.2, "Credential Set Query").
+type DCQLCredentialSet struct {
+	// Options is the REQUIRED, ordered list of alternative combinations; each
+	// inner slice is a set of Credential Query `id`s (matching
+	// DCQLCredentialRequirement.ID) that must ALL be satisfied together for
+	// that option to count. The Verifier's preference order runs from the
+	// first (most preferred) to the last (least preferred) option; a Wallet
+	// SHOULD return the first option it can satisfy. Evaluated here in the
+	// same order; the first fully-satisfied option wins.
+	Options [][]string
+	// Required defaults to true per spec (OPTIONAL, default value true).
+	// When false, this set being unsatisfied does not fail the overall query.
+	Required bool
+}
+
 // ParseDCQLCredentialRequirements parses a raw DCQL JSON query into structured requirements.
 func ParseDCQLCredentialRequirements(rawDCQLQuery string) []DCQLCredentialRequirement {
+	return ParseDCQLQuery(rawDCQLQuery).Credentials
+}
+
+// ParseDCQLQuery parses a raw DCQL JSON query into both its per-credential
+// Credential Queries (`credentials`) and its top-level Credential Set Queries
+// (`credential_sets`, OID4VP 1.0 Section 6.2). Callers that only need
+// per-credential requirements (unaffected by credential_sets) can keep using
+// ParseDCQLCredentialRequirements, which is now a thin wrapper around this;
+// callers that must enforce credential_sets semantics use this directly.
+func ParseDCQLQuery(rawDCQLQuery string) DCQLQuery {
 	trimmed := strings.TrimSpace(rawDCQLQuery)
 	if trimmed == "" {
-		return nil
+		return DCQLQuery{}
 	}
 	var payload map[string]interface{}
 	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
-		return nil
+		return DCQLQuery{}
 	}
 	rawCredentials, _ := payload["credentials"].([]interface{})
 	requirements := make([]DCQLCredentialRequirement, 0, len(rawCredentials))
 	for _, rawCredential := range rawCredentials {
 		credentialObject, _ := rawCredential.(map[string]interface{})
-		requirement := DCQLCredentialRequirement{
-			ID:     strings.TrimSpace(stringValue(credentialObject["id"])),
-			Format: strings.TrimSpace(stringValue(credentialObject["format"])),
+		requirements = append(requirements, parseDCQLCredentialRequirement(credentialObject))
+	}
+
+	var credentialSets []DCQLCredentialSet
+	if rawSets, ok := payload["credential_sets"].([]interface{}); ok {
+		for _, rawSet := range rawSets {
+			setObject, _ := rawSet.(map[string]interface{})
+			credentialSets = append(credentialSets, parseDCQLCredentialSet(setObject))
 		}
-		if meta, ok := credentialObject["meta"].(map[string]interface{}); ok {
-			requirement.VCTValues = normalizeStringSliceDCQL(meta["vct_values"])
-			requirement.DoctypeValues = normalizeStringSliceDCQL(meta["doctype_values"])
-			if len(requirement.DoctypeValues) == 0 {
-				if singleDoctype := strings.TrimSpace(stringValue(meta["doctype"])); singleDoctype != "" {
-					requirement.DoctypeValues = []string{singleDoctype}
-				}
-			}
-			requirement.CredentialTypeValues = normalizeStringSliceDCQL(meta["type_values"])
-		}
-		rawClaims, _ := credentialObject["claims"].([]interface{})
-		requiredPaths := make([]string, 0, len(rawClaims))
-		segmentLists := make([][]string, 0, len(rawClaims))
-		seenSegmentKeys := make(map[string]struct{}, len(rawClaims))
-		for _, rawClaim := range rawClaims {
-			claimObject, _ := rawClaim.(map[string]interface{})
-			rawPath, _ := claimObject["path"].([]interface{})
-			segments := make([]string, 0, len(rawPath))
-			for _, rawSegment := range rawPath {
-				segment := strings.TrimSpace(stringValue(rawSegment))
-				if segment == "" {
-					continue
-				}
-				segments = append(segments, segment)
-			}
-			if len(segments) == 0 {
+	}
+
+	return DCQLQuery{Credentials: requirements, CredentialSets: credentialSets}
+}
+
+// parseDCQLCredentialSet parses one entry of the top-level `credential_sets`
+// array (OID4VP 1.0 Section 6.2). `required` defaults to true when omitted or
+// not a boolean, per spec.
+func parseDCQLCredentialSet(setObject map[string]interface{}) DCQLCredentialSet {
+	set := DCQLCredentialSet{Required: true}
+	if requiredValue, ok := setObject["required"].(bool); ok {
+		set.Required = requiredValue
+	}
+	rawOptions, _ := setObject["options"].([]interface{})
+	for _, rawOption := range rawOptions {
+		rawIDs, _ := rawOption.([]interface{})
+		ids := make([]string, 0, len(rawIDs))
+		for _, rawID := range rawIDs {
+			id := strings.TrimSpace(stringValue(rawID))
+			if id == "" {
 				continue
 			}
-			joined := strings.Join(segments, ".")
-			requiredPaths = append(requiredPaths, joined)
-			// Preserve the raw segments once per distinct path so mdoc can match
-			// [namespace, elementIdentifier] without re-splitting on dots.
-			if _, ok := seenSegmentKeys["\x00"+strings.Join(segments, "\x00")]; !ok {
-				seenSegmentKeys["\x00"+strings.Join(segments, "\x00")] = struct{}{}
-				segmentLists = append(segmentLists, segments)
+			ids = append(ids, id)
+		}
+		if len(ids) == 0 {
+			continue
+		}
+		set.Options = append(set.Options, ids)
+	}
+	return set
+}
+
+// EvaluateCredentialSets checks whether the overall DCQL query's
+// credential_sets requirement (OID4VP 1.0 Section 6.2/6.4.2) is satisfied,
+// given which Credential Query IDs (DCQLCredentialRequirement.ID) were
+// actually matched by presented/held credentials. Returns (satisfied,
+// unsatisfiedRequiredSetIndexes), the latter naming (by index into
+// query.CredentialSets) every REQUIRED set for which no option was fully
+// matched.
+//
+// A query with no CredentialSets is always satisfied by this function --
+// callers must still separately confirm every entry in DCQLQuery.Credentials
+// was matched, exactly as before credential_sets support existed.
+//
+// When CredentialSets is non-empty, Section 6.4.2 changes what "required"
+// means for the Credential Queries it references: a Credential Query id
+// that appears in any CredentialSets option is only required as part of
+// satisfying that option (adjudicated here), not unconditionally on its
+// own -- only Credential Queries NOT referenced by any CredentialSets
+// option remain unconditionally required. Callers should use
+// CredentialIDsReferencedByCredentialSets to tell the two apart before
+// hard-failing on an individual non-match.
+func EvaluateCredentialSets(query DCQLQuery, matchedRequirementIDs map[string]bool) (bool, []int) {
+	if len(query.CredentialSets) == 0 {
+		return true, nil
+	}
+	var unsatisfiedRequired []int
+	for index, set := range query.CredentialSets {
+		satisfied := credentialSetOptionSatisfied(set, matchedRequirementIDs)
+		if !satisfied && set.Required {
+			unsatisfiedRequired = append(unsatisfiedRequired, index)
+		}
+	}
+	return len(unsatisfiedRequired) == 0, unsatisfiedRequired
+}
+
+// credentialSetOptionSatisfied reports whether at least one option in set is
+// fully covered by matchedRequirementIDs.
+func credentialSetOptionSatisfied(set DCQLCredentialSet, matchedRequirementIDs map[string]bool) bool {
+	for _, option := range set.Options {
+		allMatched := true
+		for _, id := range option {
+			if !matchedRequirementIDs[id] {
+				allMatched = false
+				break
 			}
 		}
-		requirement.RequiredClaimPaths = dedupeStringsDCQL(requiredPaths)
-		sort.Strings(requirement.RequiredClaimPaths)
-		requirement.RequiredClaimPathSegments = segmentLists
-		if rawAuthorities, ok := credentialObject["trusted_authorities"].([]interface{}); ok {
-			for _, rawAuthority := range rawAuthorities {
-				authorityObject, _ := rawAuthority.(map[string]interface{})
-				authority := DCQLTrustedAuthority{
-					Type:   strings.TrimSpace(stringValue(authorityObject["type"])),
-					Values: normalizeStringSliceDCQL(authorityObject["values"]),
-				}
-				if authority.Type == "" && len(authority.Values) == 0 {
+		if allMatched {
+			return true
+		}
+	}
+	return false
+}
+
+// CredentialIDsReferencedByCredentialSets returns the set of Credential Query
+// `id`s referenced by any option of any entry in query.CredentialSets. It
+// lets a verifier-side matcher tell a Credential Query that is unconditionally
+// required (not referenced by credential_sets at all, so it must always be
+// matched, exactly as before credential_sets support existed) apart from one
+// that is only required via a credential_sets alternative (so an individual
+// match failure should not fail the whole query by itself -- only
+// EvaluateCredentialSets' verdict, computed over every attempted match,
+// decides that).
+func CredentialIDsReferencedByCredentialSets(query DCQLQuery) map[string]bool {
+	if len(query.CredentialSets) == 0 {
+		return nil
+	}
+	referenced := make(map[string]bool)
+	for _, set := range query.CredentialSets {
+		for _, option := range set.Options {
+			for _, id := range option {
+				referenced[id] = true
+			}
+		}
+	}
+	return referenced
+}
+
+// parseDCQLCredentialRequirement parses one entry of the DCQL `credentials`
+// array (OID4VP 1.0 Section 6.1, "Credential Query") into a
+// DCQLCredentialRequirement. Shared by ParseDCQLQuery (and, through it,
+// ParseDCQLCredentialRequirements) so the per-credential parsing logic is
+// never duplicated between the two entry points.
+func parseDCQLCredentialRequirement(credentialObject map[string]interface{}) DCQLCredentialRequirement {
+	requirement := DCQLCredentialRequirement{
+		ID:     strings.TrimSpace(stringValue(credentialObject["id"])),
+		Format: strings.TrimSpace(stringValue(credentialObject["format"])),
+	}
+	if meta, ok := credentialObject["meta"].(map[string]interface{}); ok {
+		requirement.VCTValues = normalizeStringSliceDCQL(meta["vct_values"])
+		requirement.DoctypeValues = normalizeStringSliceDCQL(meta["doctype_values"])
+		if len(requirement.DoctypeValues) == 0 {
+			if singleDoctype := strings.TrimSpace(stringValue(meta["doctype"])); singleDoctype != "" {
+				requirement.DoctypeValues = []string{singleDoctype}
+			}
+		}
+		requirement.CredentialTypeValues = normalizeStringSliceDCQL(meta["type_values"])
+	}
+	rawClaims, _ := credentialObject["claims"].([]interface{})
+	requiredPaths := make([]string, 0, len(rawClaims))
+	segmentLists := make([][]string, 0, len(rawClaims))
+	seenSegmentKeys := make(map[string]struct{}, len(rawClaims))
+	claimsByID := make(map[string]dcqlClaimPath, len(rawClaims))
+	var unclaimedPaths []string
+	var unclaimedSegments [][]string
+	for _, rawClaim := range rawClaims {
+		claimObject, _ := rawClaim.(map[string]interface{})
+		rawPath, _ := claimObject["path"].([]interface{})
+		segments := make([]string, 0, len(rawPath))
+		for _, rawSegment := range rawPath {
+			segment := strings.TrimSpace(stringValue(rawSegment))
+			if segment == "" {
+				continue
+			}
+			segments = append(segments, segment)
+		}
+		if len(segments) == 0 {
+			continue
+		}
+		joined := strings.Join(segments, ".")
+		requiredPaths = append(requiredPaths, joined)
+		// Preserve the raw segments once per distinct path so mdoc can match
+		// [namespace, elementIdentifier] without re-splitting on dots.
+		if _, ok := seenSegmentKeys["\x00"+strings.Join(segments, "\x00")]; !ok {
+			seenSegmentKeys["\x00"+strings.Join(segments, "\x00")] = struct{}{}
+			segmentLists = append(segmentLists, segments)
+		}
+		// DCQL claims[].id (OID4VP 1.0 Section 6.3): REQUIRED once
+		// claim_sets is present, OPTIONAL otherwise. Recorded unconditionally
+		// (independent of whether this query happens to use claim_sets) so
+		// claim_sets resolution never depends on parsing order.
+		claimID := strings.TrimSpace(stringValue(claimObject["id"]))
+		if claimID != "" {
+			if _, exists := claimsByID[claimID]; !exists {
+				claimsByID[claimID] = dcqlClaimPath{path: joined, segments: segments}
+			}
+		} else {
+			unclaimedPaths = append(unclaimedPaths, joined)
+			unclaimedSegments = append(unclaimedSegments, segments)
+		}
+	}
+	requirement.RequiredClaimPaths = dedupeStringsDCQL(requiredPaths)
+	sort.Strings(requirement.RequiredClaimPaths)
+	requirement.RequiredClaimPathSegments = segmentLists
+	if len(claimsByID) > 0 {
+		requirement.claimsByID = claimsByID
+	}
+	requirement.unclaimedRequiredPaths = dedupeStringsDCQL(unclaimedPaths)
+	requirement.unclaimedRequiredPathSegments = unclaimedSegments
+	if rawClaimSets, ok := credentialObject["claim_sets"].([]interface{}); ok {
+		for _, rawSet := range rawClaimSets {
+			rawIDs, _ := rawSet.([]interface{})
+			ids := make([]string, 0, len(rawIDs))
+			for _, rawID := range rawIDs {
+				id := strings.TrimSpace(stringValue(rawID))
+				if id == "" {
 					continue
 				}
-				requirement.TrustedAuthorities = append(requirement.TrustedAuthorities, authority)
+				ids = append(ids, id)
 			}
+			if len(ids) == 0 {
+				continue
+			}
+			requirement.ClaimSets = append(requirement.ClaimSets, ids)
 		}
-		requirements = append(requirements, requirement)
 	}
-	return requirements
+	if rawAuthorities, ok := credentialObject["trusted_authorities"].([]interface{}); ok {
+		for _, rawAuthority := range rawAuthorities {
+			authorityObject, _ := rawAuthority.(map[string]interface{})
+			authority := DCQLTrustedAuthority{
+				Type:   strings.TrimSpace(stringValue(authorityObject["type"])),
+				Values: normalizeStringSliceDCQL(authorityObject["values"]),
+			}
+			if authority.Type == "" && len(authority.Values) == 0 {
+				continue
+			}
+			requirement.TrustedAuthorities = append(requirement.TrustedAuthorities, authority)
+		}
+	}
+	return requirement
 }
 
 // RequirementMatchesEvidence evaluates whether a credential satisfies a DCQL requirement.
@@ -188,12 +381,42 @@ func RequirementMatchesEvidence(requirement DCQLCredentialRequirement, evidence 
 	if len(requirement.CredentialTypeValues) > 0 && !intersectsStringSliceDCQL(requirement.CredentialTypeValues, evidence.CredentialTypes) {
 		return false, "dcql_meta_mismatch", "credential type does not satisfy dcql type_values"
 	}
-	for _, claimPath := range requirement.RequiredClaimPaths {
+	if len(requirement.ClaimSets) == 0 {
+		for _, claimPath := range requirement.RequiredClaimPaths {
+			if !HasClaimPath(evidence.FullClaims, claimPath) {
+				return false, "missing_required_claim", fmt.Sprintf("required claim %q is missing from disclosed credential data", claimPath)
+			}
+		}
+		return true, "", ""
+	}
+	// claim_sets present (OID4VP 1.0 Section 6.4.1): claims without an id
+	// cannot be referenced by any alternative and remain unconditionally
+	// required; the id-referenced claims are satisfied if any one full
+	// claim_sets alternative, evaluated in order, is fully disclosed.
+	for _, claimPath := range requirement.unclaimedRequiredPaths {
 		if !HasClaimPath(evidence.FullClaims, claimPath) {
 			return false, "missing_required_claim", fmt.Sprintf("required claim %q is missing from disclosed credential data", claimPath)
 		}
 	}
-	return true, "", ""
+	for _, claimSet := range requirement.ClaimSets {
+		if claimSetSatisfiesEvidence(requirement.claimsByID, evidence, claimSet) {
+			return true, "", ""
+		}
+	}
+	return false, "missing_required_claim_set", fmt.Sprintf("no claim_sets alternative is fully disclosed (attempted %v)", requirement.ClaimSets)
+}
+
+// claimSetSatisfiesEvidence reports whether every claim id in claimSet
+// resolves (via claimsByID) to a path present in the disclosed credential
+// data. An id that does not resolve at all fails the whole alternative.
+func claimSetSatisfiesEvidence(claimsByID map[string]dcqlClaimPath, evidence DCQLCredentialEvidence, claimSet []string) bool {
+	for _, id := range claimSet {
+		resolved, ok := claimsByID[id]
+		if !ok || !HasClaimPath(evidence.FullClaims, resolved.path) {
+			return false
+		}
+	}
+	return true
 }
 
 // RequirementMatchesMdoc evaluates whether an mso_mdoc credential satisfies a
@@ -217,36 +440,82 @@ func RequirementMatchesMdoc(requirement DCQLCredentialRequirement, evidence Mdoc
 			return false, "dcql_trusted_authority_mismatch", "credential issuer Authority Key Identifier does not satisfy dcql trusted_authorities"
 		}
 	}
-	for _, segments := range requirement.RequiredClaimPathSegments {
-		switch len(segments) {
-		case 0:
-			continue
-		case 1:
-			// A single-segment mdoc path selects an entire namespace; require it
-			// to be present with at least one disclosed element.
-			namespace := strings.TrimSpace(segments[0])
-			elements, ok := evidence.NameSpaces[namespace]
-			if !ok || len(elements) == 0 {
-				return false, "missing_required_claim", fmt.Sprintf("required namespace %q is missing from disclosed mdoc data", namespace)
-			}
-		default:
-			// mdoc claim paths are [namespace, elementIdentifier]; any deeper
-			// path is not a valid mdoc selector.
-			if len(segments) != 2 {
-				return false, "missing_required_claim", fmt.Sprintf("mdoc claim path %v must be [namespace, elementIdentifier]", segments)
-			}
-			namespace := strings.TrimSpace(segments[0])
-			element := strings.TrimSpace(segments[1])
-			elements, ok := evidence.NameSpaces[namespace]
-			if !ok {
-				return false, "missing_required_claim", fmt.Sprintf("required namespace %q is missing from disclosed mdoc data", namespace)
-			}
-			if _, ok := elements[element]; !ok {
-				return false, "missing_required_claim", fmt.Sprintf("required element %q in namespace %q is missing from disclosed mdoc data", element, namespace)
+	if len(requirement.ClaimSets) == 0 {
+		for _, segments := range requirement.RequiredClaimPathSegments {
+			if ok, reasonCode, reasonMessage := mdocSegmentDisclosed(evidence, segments); !ok {
+				return false, reasonCode, reasonMessage
 			}
 		}
+		return true, "", ""
 	}
-	return true, "", ""
+	// claim_sets present (OID4VP 1.0 Section 6.4.1): mirrors the SD-JWT VC
+	// branch in RequirementMatchesEvidence above, resolving ids via
+	// RequiredClaimPathSegments/claimsByID alignment instead of the
+	// dot-joined form mdoc cannot use.
+	for _, segments := range requirement.unclaimedRequiredPathSegments {
+		if ok, reasonCode, reasonMessage := mdocSegmentDisclosed(evidence, segments); !ok {
+			return false, reasonCode, reasonMessage
+		}
+	}
+	for _, claimSet := range requirement.ClaimSets {
+		if claimSetSatisfiesMdoc(requirement.claimsByID, evidence, claimSet) {
+			return true, "", ""
+		}
+	}
+	return false, "missing_required_claim_set", fmt.Sprintf("no claim_sets alternative is fully disclosed (attempted %v)", requirement.ClaimSets)
+}
+
+// mdocSegmentDisclosed reports whether a single mdoc claim path
+// ([namespace] or [namespace, elementIdentifier]) is present in the
+// disclosed mdoc evidence. Returns (matched, reasonCode, reasonMessage),
+// mirroring the per-requirement return shape so callers can propagate it
+// directly.
+func mdocSegmentDisclosed(evidence MdocCredentialEvidence, segments []string) (bool, string, string) {
+	switch len(segments) {
+	case 0:
+		return true, "", ""
+	case 1:
+		// A single-segment mdoc path selects an entire namespace; require it
+		// to be present with at least one disclosed element.
+		namespace := strings.TrimSpace(segments[0])
+		elements, ok := evidence.NameSpaces[namespace]
+		if !ok || len(elements) == 0 {
+			return false, "missing_required_claim", fmt.Sprintf("required namespace %q is missing from disclosed mdoc data", namespace)
+		}
+		return true, "", ""
+	default:
+		// mdoc claim paths are [namespace, elementIdentifier]; any deeper
+		// path is not a valid mdoc selector.
+		if len(segments) != 2 {
+			return false, "missing_required_claim", fmt.Sprintf("mdoc claim path %v must be [namespace, elementIdentifier]", segments)
+		}
+		namespace := strings.TrimSpace(segments[0])
+		element := strings.TrimSpace(segments[1])
+		elements, ok := evidence.NameSpaces[namespace]
+		if !ok {
+			return false, "missing_required_claim", fmt.Sprintf("required namespace %q is missing from disclosed mdoc data", namespace)
+		}
+		if _, ok := elements[element]; !ok {
+			return false, "missing_required_claim", fmt.Sprintf("required element %q in namespace %q is missing from disclosed mdoc data", element, namespace)
+		}
+		return true, "", ""
+	}
+}
+
+// claimSetSatisfiesMdoc reports whether every claim id in claimSet resolves
+// (via claimsByID) to an mdoc segment path present in the disclosed
+// evidence. An id that does not resolve at all fails the whole alternative.
+func claimSetSatisfiesMdoc(claimsByID map[string]dcqlClaimPath, evidence MdocCredentialEvidence, claimSet []string) bool {
+	for _, id := range claimSet {
+		resolved, ok := claimsByID[id]
+		if !ok {
+			return false
+		}
+		if ok, _, _ := mdocSegmentDisclosed(evidence, resolved.segments); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // HasClaimPath checks whether a nested claim path exists in a claims map.

--- a/backend/internal/vc/dcql_claim_sets_test.go
+++ b/backend/internal/vc/dcql_claim_sets_test.go
@@ -1,0 +1,314 @@
+package vc
+
+import "testing"
+
+// TestParseDCQLClaimSets confirms claim_sets (OID4VP 1.0 Section 6.1) parses
+// into DCQLCredentialRequirement.ClaimSets as an ordered list of id-lists, and
+// that a query with no claim_sets leaves it empty.
+func TestParseDCQLClaimSets(t *testing.T) {
+	dcql := `{
+		"credentials": [{
+			"id": "pid",
+			"format": "dc+sd-jwt",
+			"meta": {"vct_values": ["urn:eudi:pid:1"]},
+			"claims": [
+				{"id": "gn", "path": ["given_name"]},
+				{"id": "fn", "path": ["family_name"]},
+				{"id": "dob", "path": ["birth_date"]},
+				{"id": "over18", "path": ["age_over_18"]}
+			],
+			"claim_sets": [
+				["gn", "fn", "over18"],
+				["gn", "fn", "dob"]
+			]
+		}]
+	}`
+	req := ParseDCQLCredentialRequirements(dcql)[0]
+	if len(req.ClaimSets) != 2 {
+		t.Fatalf("expected 2 claim_sets alternatives, got %d: %v", len(req.ClaimSets), req.ClaimSets)
+	}
+	if got := req.ClaimSets[0]; len(got) != 3 || got[0] != "gn" || got[1] != "fn" || got[2] != "over18" {
+		t.Fatalf("unexpected first claim_sets alternative: %v", got)
+	}
+	if got := req.ClaimSets[1]; len(got) != 3 || got[2] != "dob" {
+		t.Fatalf("unexpected second claim_sets alternative: %v", got)
+	}
+}
+
+// TestParseDCQLNoClaimSetsLeavesFieldEmpty guards the zero-value backward
+// compatibility bar: a query with no claim_sets key must not populate it.
+func TestParseDCQLNoClaimSetsLeavesFieldEmpty(t *testing.T) {
+	dcql := `{"credentials": [{"id": "degree", "format": "dc+sd-jwt", "claims": [{"path": ["degree"]}]}]}`
+	req := ParseDCQLCredentialRequirements(dcql)[0]
+	if len(req.ClaimSets) != 0 {
+		t.Fatalf("expected no claim_sets, got %v", req.ClaimSets)
+	}
+}
+
+func pidClaimSetDCQL() string {
+	return `{
+		"credentials": [{
+			"id": "pid",
+			"format": "dc+sd-jwt",
+			"meta": {"vct_values": ["urn:eudi:pid:1"]},
+			"claims": [
+				{"id": "gn", "path": ["given_name"]},
+				{"id": "fn", "path": ["family_name"]},
+				{"id": "dob", "path": ["birth_date"]},
+				{"id": "over18", "path": ["age_over_18"]}
+			],
+			"claim_sets": [
+				["gn", "fn", "over18"],
+				["gn", "fn", "dob"]
+			]
+		}]
+	}`
+}
+
+// TestRequirementMatchesEvidenceClaimSetFirstAlternativeSatisfied proves a
+// credential disclosing exactly the first claim_sets alternative (and not the
+// second) is accepted.
+func TestRequirementMatchesEvidenceClaimSetFirstAlternativeSatisfied(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(pidClaimSetDCQL())[0]
+	evidence := CredentialEvidence{
+		Format: "dc+sd-jwt",
+		VCT:    "urn:eudi:pid:1",
+		FullClaims: map[string]interface{}{
+			"given_name":  "Alice",
+			"family_name": "Doe",
+			"age_over_18": true,
+			// birth_date deliberately absent: only the first alternative is disclosed.
+		},
+	}
+	matched, code, msg := RequirementMatchesEvidence(req, evidence)
+	if !matched {
+		t.Fatalf("expected claim_sets first-alternative match, got code=%q msg=%q", code, msg)
+	}
+}
+
+// TestRequirementMatchesEvidenceClaimSetSecondAlternativeSatisfied proves the
+// second alternative alone (without the first) is also sufficient.
+func TestRequirementMatchesEvidenceClaimSetSecondAlternativeSatisfied(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(pidClaimSetDCQL())[0]
+	evidence := CredentialEvidence{
+		Format: "dc+sd-jwt",
+		VCT:    "urn:eudi:pid:1",
+		FullClaims: map[string]interface{}{
+			"given_name":  "Alice",
+			"family_name": "Doe",
+			"birth_date":  "2000-01-01",
+			// age_over_18 deliberately absent: only the second alternative is disclosed.
+		},
+	}
+	matched, code, msg := RequirementMatchesEvidence(req, evidence)
+	if !matched {
+		t.Fatalf("expected claim_sets second-alternative match, got code=%q msg=%q", code, msg)
+	}
+}
+
+// TestRequirementMatchesEvidenceClaimSetNoAlternativeSatisfied proves that
+// disclosing neither alternative in full fails with the new reason code.
+func TestRequirementMatchesEvidenceClaimSetNoAlternativeSatisfied(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(pidClaimSetDCQL())[0]
+	evidence := CredentialEvidence{
+		Format: "dc+sd-jwt",
+		VCT:    "urn:eudi:pid:1",
+		FullClaims: map[string]interface{}{
+			"given_name": "Alice",
+			// family_name missing, so neither alternative (which both require
+			// gn+fn) is fully disclosed.
+		},
+	}
+	matched, code, _ := RequirementMatchesEvidence(req, evidence)
+	if matched {
+		t.Fatal("expected claim_sets denial when no alternative is fully disclosed")
+	}
+	if code != "missing_required_claim_set" {
+		t.Fatalf("expected missing_required_claim_set, got %q", code)
+	}
+}
+
+// TestRequirementMatchesEvidenceClaimSetUnclaimedClaimAlwaysRequired proves a
+// claim with no id (so it cannot appear in any claim_sets alternative) stays
+// unconditionally required even when claim_sets is present.
+func TestRequirementMatchesEvidenceClaimSetUnclaimedClaimAlwaysRequired(t *testing.T) {
+	dcql := `{
+		"credentials": [{
+			"id": "pid",
+			"format": "dc+sd-jwt",
+			"claims": [
+				{"id": "gn", "path": ["given_name"]},
+				{"id": "over18", "path": ["age_over_18"]},
+				{"path": ["nationality"]}
+			],
+			"claim_sets": [
+				["gn", "over18"]
+			]
+		}]
+	}`
+	req := ParseDCQLCredentialRequirements(dcql)[0]
+
+	// The claim_sets alternative is satisfied, but the unclaimed "nationality"
+	// claim is missing.
+	evidence := CredentialEvidence{
+		Format: "dc+sd-jwt",
+		FullClaims: map[string]interface{}{
+			"given_name":  "Alice",
+			"age_over_18": true,
+		},
+	}
+	matched, code, _ := RequirementMatchesEvidence(req, evidence)
+	if matched {
+		t.Fatal("expected denial when the unclaimed required claim is missing")
+	}
+	if code != "missing_required_claim" {
+		t.Fatalf("expected missing_required_claim for the unclaimed claim, got %q", code)
+	}
+
+	evidence.FullClaims["nationality"] = "DE"
+	matched, code, msg := RequirementMatchesEvidence(req, evidence)
+	if !matched {
+		t.Fatalf("expected match once both claim_sets and unclaimed claim are satisfied, got code=%q msg=%q", code, msg)
+	}
+}
+
+// TestSDJWTDCQLMatchingUnchangedWithoutClaimSets is a regression guard for the
+// non-goal: existing (no claim_sets) queries must match exactly as before.
+func TestSDJWTDCQLMatchingUnchangedWithoutClaimSets(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(`{
+		"credentials": [{
+			"id": "degree",
+			"format": "dc+sd-jwt",
+			"claims": [{"path": ["degree"]}, {"path": ["graduation_year"]}]
+		}]
+	}`)[0]
+	if len(req.ClaimSets) != 0 {
+		t.Fatalf("expected no claim_sets, got %v", req.ClaimSets)
+	}
+	evidence := CredentialEvidence{
+		Format: "dc+sd-jwt",
+		FullClaims: map[string]interface{}{
+			"degree": "BSc",
+		},
+	}
+	matched, code, _ := RequirementMatchesEvidence(req, evidence)
+	if matched {
+		t.Fatal("expected denial for missing graduation_year, exactly as before claim_sets support")
+	}
+	if code != "missing_required_claim" {
+		t.Fatalf("expected missing_required_claim, got %q", code)
+	}
+}
+
+func mdocPIDClaimSetDCQL() string {
+	return `{
+		"credentials": [{
+			"id": "mdl",
+			"format": "mso_mdoc",
+			"meta": {"doctype_values": ["org.iso.18013.5.1.mDL"]},
+			"claims": [
+				{"id": "fname", "path": ["org.iso.18013.5.1", "family_name"]},
+				{"id": "docnum", "path": ["org.iso.18013.5.1", "document_number"]},
+				{"id": "portrait", "path": ["org.iso.18013.5.1", "portrait"]}
+			],
+			"claim_sets": [
+				["fname", "docnum"],
+				["fname", "portrait"]
+			]
+		}]
+	}`
+}
+
+// TestRequirementMatchesMdocClaimSetFirstAlternativeSatisfied mirrors the
+// SD-JWT VC claim_sets coverage above for the mdoc
+// (RequiredClaimPathSegments/claimsByID) path.
+func TestRequirementMatchesMdocClaimSetFirstAlternativeSatisfied(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(mdocPIDClaimSetDCQL())[0]
+	evidence := MdocCredentialEvidence{
+		Format:  "mso_mdoc",
+		Doctype: "org.iso.18013.5.1.mDL",
+		NameSpaces: map[string]map[string]struct{}{
+			"org.iso.18013.5.1": {
+				"family_name":     {},
+				"document_number": {},
+			},
+		},
+	}
+	matched, code, msg := RequirementMatchesMdoc(req, evidence)
+	if !matched {
+		t.Fatalf("expected mdoc claim_sets first-alternative match, got code=%q msg=%q", code, msg)
+	}
+}
+
+// TestRequirementMatchesMdocClaimSetSecondAlternativeSatisfied proves the
+// second alternative alone also satisfies the mdoc requirement.
+func TestRequirementMatchesMdocClaimSetSecondAlternativeSatisfied(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(mdocPIDClaimSetDCQL())[0]
+	evidence := MdocCredentialEvidence{
+		Format:  "mso_mdoc",
+		Doctype: "org.iso.18013.5.1.mDL",
+		NameSpaces: map[string]map[string]struct{}{
+			"org.iso.18013.5.1": {
+				"family_name": {},
+				"portrait":    {},
+			},
+		},
+	}
+	matched, code, msg := RequirementMatchesMdoc(req, evidence)
+	if !matched {
+		t.Fatalf("expected mdoc claim_sets second-alternative match, got code=%q msg=%q", code, msg)
+	}
+}
+
+// TestRequirementMatchesMdocClaimSetNoAlternativeSatisfied proves the mdoc
+// path fails with the new reason code when no alternative is fully disclosed.
+func TestRequirementMatchesMdocClaimSetNoAlternativeSatisfied(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(mdocPIDClaimSetDCQL())[0]
+	evidence := MdocCredentialEvidence{
+		Format:  "mso_mdoc",
+		Doctype: "org.iso.18013.5.1.mDL",
+		NameSpaces: map[string]map[string]struct{}{
+			"org.iso.18013.5.1": {
+				"family_name": {},
+			},
+		},
+	}
+	matched, code, _ := RequirementMatchesMdoc(req, evidence)
+	if matched {
+		t.Fatal("expected mdoc denial when no claim_sets alternative is fully disclosed")
+	}
+	if code != "missing_required_claim_set" {
+		t.Fatalf("expected missing_required_claim_set, got %q", code)
+	}
+}
+
+// TestRequirementMatchesMdocUnchangedWithoutClaimSets is a regression guard
+// for the mdoc non-goal: existing (no claim_sets) mdoc queries must match
+// exactly as before.
+func TestRequirementMatchesMdocUnchangedWithoutClaimSets(t *testing.T) {
+	req := ParseDCQLCredentialRequirements(`{
+		"credentials": [{
+			"id": "mdl",
+			"format": "mso_mdoc",
+			"meta": {"doctype_values": ["org.iso.18013.5.1.mDL"]},
+			"claims": [{"path": ["org.iso.18013.5.1", "family_name"]}, {"path": ["org.iso.18013.5.1", "document_number"]}]
+		}]
+	}`)[0]
+	if len(req.ClaimSets) != 0 {
+		t.Fatalf("expected no claim_sets, got %v", req.ClaimSets)
+	}
+	evidence := MdocCredentialEvidence{
+		Format:  "mso_mdoc",
+		Doctype: "org.iso.18013.5.1.mDL",
+		NameSpaces: map[string]map[string]struct{}{
+			"org.iso.18013.5.1": {"family_name": {}},
+		},
+	}
+	matched, code, _ := RequirementMatchesMdoc(req, evidence)
+	if matched {
+		t.Fatal("expected denial for missing document_number, exactly as before claim_sets support")
+	}
+	if code != "missing_required_claim" {
+		t.Fatalf("expected missing_required_claim, got %q", code)
+	}
+}

--- a/backend/internal/vc/dcql_credential_sets_test.go
+++ b/backend/internal/vc/dcql_credential_sets_test.go
@@ -1,0 +1,163 @@
+package vc
+
+import "testing"
+
+// TestParseDCQLQueryCredentialSets confirms the top-level credential_sets
+// array (OID4VP 1.0 Section 6.2) parses into DCQLQuery.CredentialSets with
+// Required defaulting to true when omitted, and honored when explicit.
+func TestParseDCQLQueryCredentialSets(t *testing.T) {
+	dcql := `{
+		"credentials": [
+			{"id": "pid", "format": "dc+sd-jwt", "meta": {"vct_values": ["urn:eudi:pid:1"]}},
+			{"id": "mdl", "format": "mso_mdoc", "meta": {"doctype_values": ["org.iso.18013.5.1.mDL"]}},
+			{"id": "photo_id", "format": "mso_mdoc", "meta": {"doctype_values": ["org.iso.23220.photoid.1"]}}
+		],
+		"credential_sets": [
+			{"options": [["pid"], ["mdl"]]},
+			{"options": [["photo_id"]], "required": false}
+		]
+	}`
+	query := ParseDCQLQuery(dcql)
+	if len(query.Credentials) != 3 {
+		t.Fatalf("expected 3 credential requirements, got %d", len(query.Credentials))
+	}
+	if len(query.CredentialSets) != 2 {
+		t.Fatalf("expected 2 credential_sets entries, got %d", len(query.CredentialSets))
+	}
+	first := query.CredentialSets[0]
+	if !first.Required {
+		t.Fatal("expected required to default to true when omitted")
+	}
+	if len(first.Options) != 2 || first.Options[0][0] != "pid" || first.Options[1][0] != "mdl" {
+		t.Fatalf("unexpected first credential_sets options: %v", first.Options)
+	}
+	second := query.CredentialSets[1]
+	if second.Required {
+		t.Fatal("expected explicit required:false to be honored")
+	}
+	if len(second.Options) != 1 || second.Options[0][0] != "photo_id" {
+		t.Fatalf("unexpected second credential_sets options: %v", second.Options)
+	}
+}
+
+// TestParseDCQLQueryNoCredentialSets guards the zero-value backward
+// compatibility bar for the new top-level parser.
+func TestParseDCQLQueryNoCredentialSets(t *testing.T) {
+	query := ParseDCQLQuery(`{"credentials": [{"id": "mdl", "format": "mso_mdoc"}]}`)
+	if len(query.CredentialSets) != 0 {
+		t.Fatalf("expected no credential_sets, got %v", query.CredentialSets)
+	}
+	if len(query.Credentials) != 1 || query.Credentials[0].ID != "mdl" {
+		t.Fatalf("unexpected credentials: %+v", query.Credentials)
+	}
+}
+
+// TestParseDCQLCredentialRequirementsUnaffectedByCredentialSets is a
+// regression guard: the pre-existing entry point must return identical
+// per-credential requirements regardless of a sibling credential_sets array.
+func TestParseDCQLCredentialRequirementsUnaffectedByCredentialSets(t *testing.T) {
+	withSets := `{
+		"credentials": [{"id": "mdl", "format": "mso_mdoc", "claims": [{"path": ["org.iso.18013.5.1", "family_name"]}]}],
+		"credential_sets": [{"options": [["mdl"]]}]
+	}`
+	withoutSets := `{
+		"credentials": [{"id": "mdl", "format": "mso_mdoc", "claims": [{"path": ["org.iso.18013.5.1", "family_name"]}]}]
+	}`
+	a := ParseDCQLCredentialRequirements(withSets)
+	b := ParseDCQLCredentialRequirements(withoutSets)
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("expected 1 requirement each, got %d and %d", len(a), len(b))
+	}
+	if a[0].ID != b[0].ID || a[0].Format != b[0].Format {
+		t.Fatalf("expected identical requirements, got %+v vs %+v", a[0], b[0])
+	}
+}
+
+func threeCredentialQuery(t *testing.T, setsJSON string) DCQLQuery {
+	t.Helper()
+	dcql := `{
+		"credentials": [
+			{"id": "pid", "format": "dc+sd-jwt"},
+			{"id": "mdl", "format": "mso_mdoc"},
+			{"id": "photo_id", "format": "mso_mdoc"}
+		]` + setsJSON + `
+	}`
+	return ParseDCQLQuery(dcql)
+}
+
+// TestEvaluateCredentialSetsNoSetsAlwaysSatisfied confirms the documented
+// zero-value contract: no CredentialSets means EvaluateCredentialSets always
+// reports satisfied, regardless of what was matched.
+func TestEvaluateCredentialSetsNoSetsAlwaysSatisfied(t *testing.T) {
+	query := threeCredentialQuery(t, "")
+	satisfied, unsatisfied := EvaluateCredentialSets(query, map[string]bool{})
+	if !satisfied || len(unsatisfied) != 0 {
+		t.Fatalf("expected always-satisfied with no credential_sets, got satisfied=%v unsatisfied=%v", satisfied, unsatisfied)
+	}
+}
+
+// TestEvaluateCredentialSetsRequiredOptionSatisfied proves a required set is
+// satisfied when at least one of its options is fully matched.
+func TestEvaluateCredentialSetsRequiredOptionSatisfied(t *testing.T) {
+	query := threeCredentialQuery(t, `, "credential_sets": [{"options": [["pid"], ["mdl"]]}]`)
+	satisfied, unsatisfied := EvaluateCredentialSets(query, map[string]bool{"mdl": true})
+	if !satisfied || len(unsatisfied) != 0 {
+		t.Fatalf("expected satisfied via the mdl option, got satisfied=%v unsatisfied=%v", satisfied, unsatisfied)
+	}
+}
+
+// TestEvaluateCredentialSetsRequiredOptionUnsatisfied proves a required set
+// fails, naming its index, when no option is fully matched.
+func TestEvaluateCredentialSetsRequiredOptionUnsatisfied(t *testing.T) {
+	query := threeCredentialQuery(t, `, "credential_sets": [{"options": [["pid"], ["mdl"]]}]`)
+	satisfied, unsatisfied := EvaluateCredentialSets(query, map[string]bool{"photo_id": true})
+	if satisfied {
+		t.Fatal("expected denial when neither pid nor mdl was matched")
+	}
+	if len(unsatisfied) != 1 || unsatisfied[0] != 0 {
+		t.Fatalf("expected unsatisfied index [0], got %v", unsatisfied)
+	}
+}
+
+// TestEvaluateCredentialSetsOptionalSetUnsatisfiedStillSucceeds proves a
+// required:false set does not fail the overall query even if none of its
+// options are matched.
+func TestEvaluateCredentialSetsOptionalSetUnsatisfiedStillSucceeds(t *testing.T) {
+	query := threeCredentialQuery(t, `, "credential_sets": [{"options": [["photo_id"]], "required": false}]`)
+	satisfied, unsatisfied := EvaluateCredentialSets(query, map[string]bool{})
+	if !satisfied || len(unsatisfied) != 0 {
+		t.Fatalf("expected optional set to not block satisfaction, got satisfied=%v unsatisfied=%v", satisfied, unsatisfied)
+	}
+}
+
+// TestEvaluateCredentialSetsMultipleRequiredSetsNamesEachFailure proves every
+// unsatisfied required set is named, not just the first.
+func TestEvaluateCredentialSetsMultipleRequiredSetsNamesEachFailure(t *testing.T) {
+	query := threeCredentialQuery(t, `, "credential_sets": [{"options": [["pid"]]}, {"options": [["mdl"]]}]`)
+	satisfied, unsatisfied := EvaluateCredentialSets(query, map[string]bool{"photo_id": true})
+	if satisfied {
+		t.Fatal("expected denial when neither required set is satisfied")
+	}
+	if len(unsatisfied) != 2 || unsatisfied[0] != 0 || unsatisfied[1] != 1 {
+		t.Fatalf("expected both set indexes [0 1], got %v", unsatisfied)
+	}
+}
+
+// TestCredentialIDsReferencedByCredentialSets confirms the helper used to
+// tell "unconditionally required" Credential Queries apart from ones only
+// required via a credential_sets alternative.
+func TestCredentialIDsReferencedByCredentialSets(t *testing.T) {
+	query := threeCredentialQuery(t, `, "credential_sets": [{"options": [["pid"], ["mdl"]]}]`)
+	referenced := CredentialIDsReferencedByCredentialSets(query)
+	if !referenced["pid"] || !referenced["mdl"] {
+		t.Fatalf("expected pid and mdl to be referenced, got %v", referenced)
+	}
+	if referenced["photo_id"] {
+		t.Fatalf("expected photo_id to be unreferenced, got %v", referenced)
+	}
+
+	noSets := threeCredentialQuery(t, "")
+	if got := CredentialIDsReferencedByCredentialSets(noSets); got != nil {
+		t.Fatalf("expected nil for a query with no credential_sets, got %v", got)
+	}
+}

--- a/docs/starlight/public/openapi/vc.yaml
+++ b/docs/starlight/public/openapi/vc.yaml
@@ -705,7 +705,12 @@ components:
             mode (`profile: haip`), each `mso_mdoc` credential that does not
             already declare `trusted_authorities` gains an `aki` Trusted
             Authorities Query (OpenID4VP 1.0 Section 6.1.1) whose value is the
-            base64url SubjectKeyIdentifier of the configured IACA root.
+            base64url SubjectKeyIdentifier of the configured IACA root. A
+            Credential Query's `claim_sets` (Section 6.1) and the top-level
+            `credential_sets` (Section 6.2) are both honored: each expresses
+            alternative combinations (of claim `id`s, or of Credential Query
+            `id`s respectively) any one of which satisfies the request, with
+            `credential_sets` entries defaulting to `required: true`.
     CreateAuthorizationResponse:
       type: object
       properties:

--- a/docs/starlight/src/content/docs/protocols/oid4vp.mdx
+++ b/docs/starlight/src/content/docs/protocols/oid4vp.mdx
@@ -263,9 +263,10 @@ appoint its own trust root.
    - nonce binding (VP token nonce matches request nonce)
    - audience binding (VP token audience includes `client_id`, or `origin:<origin>` on the DC API path)
    - token expiry
-   - holder binding (`iss`/`sub` matches wallet identity, `cnf.jkt` matches key thumbprint)
+   - holder binding (`iss`/`sub` matches wallet identity, `cnf.jkt` matches key thumbprint, and for SD-JWT VC, the Key Binding JWT `iat` is within a 5-minute freshness window)
   - credential evidence (issuer signature, subject binding, disclosure integrity, and trust policy checks)
-   - DCQL claim-path completeness (all required claim paths present in disclosed claims)
+   - DCQL claim-path completeness: all required claim paths present in disclosed claims, or, when a Credential Query declares `claim_sets`, at least one alternative combination of claim `id`s fully disclosed
+   - DCQL `credential_sets` (when present): each required Credential Set Query's `options` has at least one fully-matched combination of Credential Query `id`s; `required: false` entries do not block the decision
 5. **Result** — Policy decision is stored and returned as `allowed`/`denied` with `code`, `message`, `reasons`, and `reason_codes`.
 
 ## Endpoints
@@ -289,7 +290,7 @@ appoint its own trust root.
 ## What To Validate
 
 - Authorization request: signed request object with `typ=oauth-authz-req+jwt`, `client_id`, `response_mode`, `response_uri`, `nonce`, `state`, `exp`
-- DCQL contract: exactly one of `dcql_query` or `scope`; required claim paths derived from DCQL are enforced
+- DCQL contract: exactly one of `dcql_query` or `scope`; required claim paths derived from DCQL are enforced, including `claim_sets` alternatives and top-level `credential_sets` combinations when present
 - Client identification: chosen client_id scheme follows OpenID4VP scheme-specific trust validation
 - `direct_post` response: `state` maps to active request and `vp_token` is present
 - `direct_post.jwt` response: decrypts successfully and inner JWT signature/type/audience/subject/expiry checks pass

--- a/openapi/v1/vc.yaml
+++ b/openapi/v1/vc.yaml
@@ -705,7 +705,12 @@ components:
             mode (`profile: haip`), each `mso_mdoc` credential that does not
             already declare `trusted_authorities` gains an `aki` Trusted
             Authorities Query (OpenID4VP 1.0 Section 6.1.1) whose value is the
-            base64url SubjectKeyIdentifier of the configured IACA root.
+            base64url SubjectKeyIdentifier of the configured IACA root. A
+            Credential Query's `claim_sets` (Section 6.1) and the top-level
+            `credential_sets` (Section 6.2) are both honored: each expresses
+            alternative combinations (of claim `id`s, or of Credential Query
+            `id`s respectively) any one of which satisfies the request, with
+            `credential_sets` entries defaulting to `required: true`.
     CreateAuthorizationResponse:
       type: object
       properties:


### PR DESCRIPTION
## What does this PR do?

1. **KB-JWT `iat` freshness**: SD-JWT Key Binding JWTs were only checked for a present `iat`. The verifier now rejects KB-JWTs whose `iat` is outside a ±5-minute window (SD-JWT RFC 9901 §7.3 step 5.e), matching the existing Client Attestation PoP skew pattern.
2. **DCQL `claim_sets`**: Credential Queries can declare alternative combinations of claim `id`s (OID4VP 1.0 §6.1). Matching accepts the first fully-disclosed set; queries without `claim_sets` keep the previous “every path required” behaviour.
3. **DCQL `credential_sets`**: Top-level Credential Set Queries (§6.2 / §6.4.2) are parsed and evaluated on the verifier (JWT/LDP and mso_mdoc paths) and on the single-credential wallet harness so recommended credentials can’t fail verifier policy after presentation. Optional sets (`required: false`) do not block the decision.
Docs and OpenAPI (`dcql_query`) updated to describe the new behaviour.


## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New protocol implementation

## How was this tested?

<!-- Describe how you verified your changes work correctly. -->

- [ ] Ran the affected flow in Looking Glass and verified real-time events
- [ ] Tested locally with `cd backend && go run ./cmd/server` and `cd frontend && npm run dev`
- [x] Other (describe below)

Unit and package tests for the new paths:
- KB-JWT fresh / stale / future `iat` (oid4vp `plugin_test`)
- DCQL `claim_sets` parse + evidence/mdoc matching (`dcql_claim_sets_test`)
- DCQL `credential_sets` parse/evaluate + verifier wiring (oid4vp + mdoc presentation tests) and wallet harness selection (`main_test`)
- Existing DCQL suites left unmodified for backward-compat (no `claim_sets` / no `credential_sets`)


## Validation checklist

<!-- Run the checks that match your change. Mark not applicable items as N/A in the PR description. -->

- [x] Backend: `cd backend && go build ./... && go test ./...`
- [x] Backend lint: `cd backend && golangci-lint run ./...`
- [ ] Frontend: `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- [ ] Frontend references: `cd frontend && npm run verify-refs`
- [ ] JWK thumbprint (RFC 7638): `cd frontend && npm run verify-jwk-thumbprint`
- [ ] Wallet UI: `cd wallet-ui && npx tsc --noEmit && npm run build`
- [x] Docs: `cd docs/starlight && npm run build`
- [x] OpenAPI: `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1`
- [ ] Docker/topology: `cd docker && docker compose config`
- [x] OID4VCI/OID4VP conformance: `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1`

## Checklist

<!-- Complete all items before requesting review. -->

- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] I have read the [CONTRIBUTING](https://github.com/ParleSec/ProtocolSoup/blob/master/CONTRIBUTING.md) guide
- [x] I selected the relevant validation checks above
- [x] I have updated documentation if needed
- [x] I have not committed secrets, credentials, or `.env` files

## Screenshots / Looking Glass output

<!-- If this is a UI change or protocol change, include screenshots or Looking Glass timeline output. -->
