### PR TITLE
UPDATE SSF transmitter for CAEP Interop push Stream Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,10 +64,8 @@ __debug_bin
 *.db*
 *.sqlite
 
-# Temporary
-tmp/
-temp/
-.tmp/
+# Local OIDF / protocol findings logs (keep on disk, do not commit)
+docs/conformance/
 
 # SPIFFE bootstrap private keys (stored in Fly secrets)
 docker/spire/server-fly/bootstrap-ca.key

--- a/backend/internal/core/bootstrap.go
+++ b/backend/internal/core/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/ParleSec/ProtocolSoup/internal/crypto"
@@ -11,6 +12,7 @@ import (
 	"github.com/ParleSec/ProtocolSoup/internal/mockidp"
 	"github.com/ParleSec/ProtocolSoup/internal/palette"
 	"github.com/ParleSec/ProtocolSoup/internal/plugin"
+	"github.com/ParleSec/ProtocolSoup/pkg/models"
 )
 
 // BootstrapOptions controls which shared dependencies are initialized.
@@ -65,6 +67,7 @@ func Bootstrap(opts BootstrapOptions) (*BootstrapResult, error) {
 		}
 		idp = mockidp.NewMockIdP(keySet)
 		idp.SetIssuer(cfg.BaseURL)
+		registerSSFConformanceClients(idp)
 		log.Printf("Mock Identity Provider initialized with issuer: %s", cfg.BaseURL)
 	}
 
@@ -148,4 +151,32 @@ func validateProductionBaseURL(cfg *Config) error {
 		return fmt.Errorf("SHOWCASE_BASE_URL must be a pathless HTTPS origin in production")
 	}
 	return nil
+}
+
+// registerSSFConformanceClients provisions confidential client_credentials
+// clients for the CAEP Interop transmitter plan. A secretless confidential
+// client is never registered; both id and secret must be supplied.
+func registerSSFConformanceClients(idp *mockidp.MockIdP) {
+	if idp == nil {
+		return
+	}
+	register := func(idEnv, secretEnv, name string) {
+		id := strings.TrimSpace(os.Getenv(idEnv))
+		secret := os.Getenv(secretEnv)
+		if id == "" || secret == "" {
+			return
+		}
+		idp.RegisterClient(&models.Client{
+			ID:                      id,
+			Secret:                  secret,
+			Name:                    name,
+			GrantTypes:              []string{"client_credentials"},
+			Scopes:                  []string{"ssf.read", "ssf.manage"},
+			Public:                  false,
+			TokenEndpointAuthMethod: "client_secret_post",
+		})
+		log.Printf("Registered SSF Stream Management client %s", id)
+	}
+	register("SSF_CONFORMANCE_CLIENT_ID", "SSF_CONFORMANCE_CLIENT_SECRET", "SSF CAEP Interop transmitter")
+	register("SSF_CONFORMANCE_CLIENT_ID_2", "SSF_CONFORMANCE_CLIENT_SECRET_2", "SSF CAEP Interop isolation")
 }

--- a/backend/internal/protocols/oauth2/clientauth_jwt.go
+++ b/backend/internal/protocols/oauth2/clientauth_jwt.go
@@ -828,7 +828,7 @@ func (p *Plugin) handleAuthorizationServerMetadata(w http.ResponseWriter, r *htt
 		"authorization_endpoint":                issuer + "/authorize",
 		"token_endpoint":                        issuer + "/token",
 		"jwks_uri":                              strings.TrimRight(p.baseURL, "/") + "/api/.well-known/jwks.json",
-		"scopes_supported":                      []string{"profile", "email", "api:read", "api:write"},
+		"scopes_supported":                      []string{"profile", "email", "api:read", "api:write", "ssf.read", "ssf.manage"},
 		"response_types_supported":              []string{"code"},
 		"grant_types_supported":                 []string{"authorization_code", "refresh_token", "client_credentials"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "private_key_jwt"},

--- a/backend/internal/protocols/oauth2/handlers.go
+++ b/backend/internal/protocols/oauth2/handlers.go
@@ -1036,11 +1036,19 @@ func (p *Plugin) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 		// RFC 9449 Section 4.1: bind the token to the presented proof key.
 		accessTokenClaims = dpop.WithCnfJKT(accessTokenClaims, dpopJKT)
 	}
+	audience := clientID
+	ttl := time.Hour
+	expiresIn := 3600
+	if grantsSSFScope(scope) {
+		audience = p.ssfResourceAudience()
+		ttl = 15 * time.Minute
+		expiresIn = 900
+	}
 	accessToken, err := jwtService.CreateAccessToken(
 		clientID, // Subject is the client itself
-		clientID,
+		audience,
 		scope,
-		time.Hour,
+		ttl,
 		accessTokenClaims,
 	)
 	if err != nil {
@@ -1056,7 +1064,7 @@ func (p *Plugin) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 	tokenResponse := models.TokenResponse{
 		AccessToken: accessToken,
 		TokenType:   tokenType,
-		ExpiresIn:   3600,
+		ExpiresIn:   expiresIn,
 		Scope:       scope,
 	}
 
@@ -1067,7 +1075,7 @@ func (p *Plugin) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 		"to":                "Client",
 		"access_token":      tokenResponse.AccessToken,
 		"token_type":        tokenType,
-		"expires_in":        3600,
+		"expires_in":        expiresIn,
 		"scope":             scope,
 		"scopes":            strings.Fields(scope),
 		"has_refresh_token": false,
@@ -1436,6 +1444,22 @@ func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(data)
+}
+
+func grantsSSFScope(scope string) bool {
+	for _, item := range strings.Fields(scope) {
+		if item == "ssf.read" || item == "ssf.manage" {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Plugin) ssfResourceAudience() string {
+	if v := strings.TrimSpace(os.Getenv("SSF_RESOURCE")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return strings.TrimRight(p.baseURL, "/")
 }
 
 // RFC 6749 Section 5.2 error URIs - links to relevant documentation

--- a/backend/internal/protocols/oauth2/resource_test.go
+++ b/backend/internal/protocols/oauth2/resource_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/ParleSec/ProtocolSoup/internal/dpop"
+	"github.com/ParleSec/ProtocolSoup/pkg/models"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // computeTestATH mirrors the unexported dpop.computeATH (RFC 9449 Section
@@ -285,5 +287,57 @@ func TestProtectedResourceRejectsMissingAuthorization(t *testing.T) {
 	}
 	if headers.Get("WWW-Authenticate") == "" {
 		t.Fatal("expected a WWW-Authenticate challenge header")
+	}
+}
+
+func TestSSFClientCredentialsIssuesShortLivedResourceAudience(t *testing.T) {
+	server := newOAuthAssertionTestServer(t)
+	server.idp.RegisterClient(&models.Client{
+		ID:         "ssf-manage-client",
+		Secret:     "ssf-manage-secret",
+		Name:       "SSF Stream Management",
+		GrantTypes: []string{"client_credentials"},
+		Scopes:     []string{"ssf.read", "ssf.manage"},
+	})
+
+	tokenRequest, err := http.NewRequest(http.MethodPost, server.server.URL+"/oauth2/token", strings.NewReader(url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {"ssf-manage-client"},
+		"client_secret": {"ssf-manage-secret"},
+		"scope":         {"ssf.manage"},
+	}.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenResponse, err := http.DefaultClient.Do(tokenRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tokenResponse.Body.Close()
+	var tokenBody map[string]interface{}
+	if err := json.NewDecoder(tokenResponse.Body).Decode(&tokenBody); err != nil {
+		t.Fatal(err)
+	}
+	if tokenResponse.StatusCode != http.StatusOK {
+		t.Fatalf("token status = %d body %#v", tokenResponse.StatusCode, tokenBody)
+	}
+	if expires, _ := tokenBody["expires_in"].(float64); expires != 900 {
+		t.Fatalf("expires_in = %v, want 900 [CAEPINTEROP short-lived]", tokenBody["expires_in"])
+	}
+	accessToken, _ := tokenBody["access_token"].(string)
+	if accessToken == "" {
+		t.Fatal("missing access_token")
+	}
+	parsed, _, err := jwt.NewParser().ParseUnverified(accessToken, jwt.MapClaims{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims, _ := parsed.Claims.(jwt.MapClaims)
+	if got, _ := claims["aud"].(string); got != server.plugin.baseURL {
+		t.Fatalf("aud %v want %s", claims["aud"], server.plugin.baseURL)
+	}
+	if claims["scope"] != "ssf.manage" {
+		t.Fatalf("scope %v", claims["scope"])
 	}
 }

--- a/backend/internal/protocols/ssf/README.md
+++ b/backend/internal/protocols/ssf/README.md
@@ -53,11 +53,11 @@ The service also starts a **standalone receiver** on `SSF_RECEIVER_PORT` (defaul
 
 ## Session-Based Isolation
 
-Looking Glass owns the session. SSF does not mint a parallel `ssf_session_id`.
+Looking Glass owns the session. SSF does not mint a parallel `ssf_session_id`. Spec Stream Management is addressed by `stream_id` ([SSF] §8.1.1). `X-Looking-Glass-Session` is a presentation-layer filter that tags lab streams; it is not a substitute for `stream_id` on `/ssf/stream`, `/ssf/status`, or `/ssf/verify`.
 
 1. **Session ID**: Looking Glass `POST /api/protocols/ssf/demo/{flow}` returns an owned session. Catalog flow IDs are presets into that same Looking Glass session.
-2. **Header Propagation**: Client and server-to-server hops send `X-Looking-Glass-Session` (query `lg_session` when headers cannot be set). Push delivery copies the same header. The SET itself MUST NOT carry the session id (RFC 8417).
-3. **Database Storage**: Session ID is stored in `events.session_id`, not in SET claims.
+2. **Header Propagation**: Client and lab hops send `X-Looking-Glass-Session` (query `lg_session` when headers cannot be set). Push delivery copies that header only when the destination is the internal receiver. External `endpoint_url` values do not receive it. The SET itself MUST NOT carry the session id (RFC 8417).
+3. **Database Storage**: Session ID is stored in `events.session_id` and `streams.session_id`, not in SET claims.
 4. **RP state**: `ReceiverActionExecutor` keys posture as `sessionID:email` in SQLite on this service. Alice/Bob emails match MockIdP users for identifier continuity only.
 
 ```
@@ -117,18 +117,18 @@ Local/demo `issuer` may be `http://` (SSF §7.1 wants `https`). Same lab TLS sto
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/ssf/stream` | POST | Create a new stream (nested `delivery`) |
-| `/ssf/stream` | GET | List streams, or one stream with `?stream_id=` |
+| `/ssf/stream` | POST | Create a new stream (**201**; nested `delivery`; default method poll if omitted) |
+| `/ssf/stream` | GET | List this Receiver's streams, or one stream with `?stream_id=` |
 | `/ssf/stream` | PATCH | Update a stream (`stream_id` required) |
-| `/ssf/stream` | DELETE | Delete a stream (`stream_id` required) |
+| `/ssf/stream` | DELETE | Delete a stream (`stream_id` query required; **204**) |
 
 ### Stream Status & Verification (SSF §8.1.4)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/ssf/status` | GET | Get stream status |
+| `/ssf/status` | GET | Get stream status (`stream_id` required; `{stream_id, status}`) |
 | `/ssf/status` | POST | Update stream status (enabled/paused/disabled) |
-| `/ssf/verify` | POST | Trigger verification SET (`stream_id` required; **204**) |
+| `/ssf/verify` | POST | Trigger verification SET (`stream_id` required; `state` optional; **204**) |
 
 ### Subject Management
 

--- a/backend/internal/protocols/ssf/auth.go
+++ b/backend/internal/protocols/ssf/auth.go
@@ -1,0 +1,222 @@
+package ssf
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// CAEP Interoperability Profile §2.7.3 OAuth Scopes.
+const (
+	ScopeSSFRead   = "ssf.read"
+	ScopeSSFManage = "ssf.manage"
+)
+
+// receiverIdentity is the Event Receiver bound to a Stream Management request.
+// [SSF] §8: authorisation MUST associate a Receiver with one or more stream IDs
+// and aud values.
+type receiverIdentity struct {
+	ID     string
+	Scopes []string
+}
+
+func (id receiverIdentity) hasScope(need string) bool {
+	for _, scope := range id.Scopes {
+		if scope == ScopeSSFManage {
+			return true
+		}
+		if scope == need {
+			return true
+		}
+	}
+	return false
+}
+
+func parseScopeClaim(raw interface{}) []string {
+	switch v := raw.(type) {
+	case string:
+		return strings.Fields(v)
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return v
+	default:
+		return nil
+	}
+}
+
+// authenticateReceiver binds a Stream Management request to a Receiver.
+//
+// [CAEPINTEROP] The SSF Transmitter as a Resource Server:
+// MUST accept tokens in the Authorization header (RFC 6750 §2.1) and MUST NOT
+// accept them as a URI query parameter (RFC 6750 §2.3).
+//
+// Looking Glass sessions remain a presentation-layer filter: a valid
+// X-Looking-Glass-Session identifies the demo Receiver without a bearer token.
+// When SSF_AS_JWKS_URI is set and neither a bearer token nor a Looking Glass
+// session is present, the request is 401.
+func (p *Plugin) authenticateReceiver(w http.ResponseWriter, r *http.Request, need string) (receiverIdentity, bool) {
+	if strings.TrimSpace(r.URL.Query().Get("access_token")) != "" {
+		p.writeBearerError(w, http.StatusBadRequest, "invalid_request",
+			"access tokens MUST NOT be passed in the URI query parameter (RFC 6750 Section 2.3)")
+		return receiverIdentity{}, false
+	}
+
+	header := strings.TrimSpace(r.Header.Get("Authorization"))
+	if header != "" {
+		typ, token, ok := strings.Cut(header, " ")
+		if !ok || !strings.EqualFold(typ, "Bearer") || strings.TrimSpace(token) == "" {
+			p.writeBearerError(w, http.StatusUnauthorized, "invalid_token", "Authorization header must use the Bearer scheme")
+			return receiverIdentity{}, false
+		}
+		ident, err := p.validateBearerJWT(strings.TrimSpace(token))
+		if err != nil {
+			p.writeBearerError(w, http.StatusUnauthorized, "invalid_token", "access token validation failed")
+			return receiverIdentity{}, false
+		}
+		if !ident.hasScope(need) {
+			p.writeBearerError(w, http.StatusForbidden, "insufficient_scope",
+				"the request requires a scope that the access token does not grant")
+			return receiverIdentity{}, false
+		}
+		return ident, true
+	}
+
+	if sessionID := getSessionID(r); sessionID != "" {
+		return receiverIdentity{
+			ID:     "session:" + sessionID,
+			Scopes: []string{ScopeSSFManage},
+		}, true
+	}
+
+	if strings.TrimSpace(p.asJWKSURI) != "" {
+		p.writeBearerError(w, http.StatusUnauthorized, "invalid_token", "authorization is required")
+		return receiverIdentity{}, false
+	}
+
+	return receiverIdentity{
+		ID:     "anonymous",
+		Scopes: []string{ScopeSSFManage},
+	}, true
+}
+
+func (p *Plugin) validateBearerJWT(tokenString string) (receiverIdentity, error) {
+	if strings.TrimSpace(p.asJWKSURI) == "" || p.jwksFetch == nil {
+		return receiverIdentity{}, fmt.Errorf("authorization server JWKS is not configured")
+	}
+
+	parser := jwt.NewParser(jwt.WithValidMethods([]string{"RS256"}))
+	unverified := jwt.MapClaims{}
+	_, _, err := parser.ParseUnverified(tokenString, unverified)
+	if err != nil {
+		return receiverIdentity{}, err
+	}
+
+	jwks, err := p.jwksFetch.Fetch(p.asJWKSURI)
+	if err != nil {
+		return receiverIdentity{}, fmt.Errorf("fetch AS JWKS: %w", err)
+	}
+
+	token, err := jwt.ParseWithClaims(tokenString, jwt.MapClaims{}, func(token *jwt.Token) (interface{}, error) {
+		kid, _ := token.Header["kid"].(string)
+		var jwk interface{ ToPublicKey() (interface{}, error) }
+		if kid != "" {
+			key, keyErr := jwks.GetKeyByID(kid)
+			if keyErr != nil {
+				return nil, keyErr
+			}
+			jwk = key
+		} else if len(jwks.Keys) == 1 {
+			jwk = &jwks.Keys[0]
+		} else {
+			return nil, fmt.Errorf("token kid is required when the AS JWKS has multiple keys")
+		}
+		return jwk.ToPublicKey()
+	}, jwt.WithValidMethods([]string{"RS256"}), jwt.WithExpirationRequired())
+	if err != nil || token == nil || !token.Valid {
+		if err == nil {
+			err = fmt.Errorf("invalid access token")
+		}
+		return receiverIdentity{}, err
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return receiverIdentity{}, fmt.Errorf("invalid access token claims")
+	}
+
+	iss, _ := claims["iss"].(string)
+	if p.asIssuer != "" && iss != p.asIssuer {
+		return receiverIdentity{}, fmt.Errorf("invalid issuer")
+	}
+
+	if p.asAudience != "" {
+		switch aud := claims["aud"].(type) {
+		case string:
+			if aud != p.asAudience {
+				return receiverIdentity{}, fmt.Errorf("invalid audience")
+			}
+		case []interface{}:
+			found := false
+			for _, item := range aud {
+				if s, ok := item.(string); ok && s == p.asAudience {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return receiverIdentity{}, fmt.Errorf("invalid audience")
+			}
+		default:
+			return receiverIdentity{}, fmt.Errorf("invalid audience")
+		}
+	}
+
+	clientID, _ := claims["sub"].(string)
+	if clientID == "" {
+		clientID, _ = claims["client_id"].(string)
+	}
+	if clientID == "" {
+		return receiverIdentity{}, fmt.Errorf("access token missing client identifier")
+	}
+
+	return receiverIdentity{
+		ID:     clientID,
+		Scopes: parseScopeClaim(claims["scope"]),
+	}, nil
+}
+
+// writeBearerError returns an RFC 6750 Section 3.1 error response.
+func (p *Plugin) writeBearerError(w http.ResponseWriter, status int, errCode, description string) {
+	params := []string{`realm="ssf"`}
+	if errCode != "" {
+		params = append(params, fmt.Sprintf(`error=%q`, errCode))
+	}
+	if description != "" {
+		params = append(params, fmt.Sprintf(`error_description=%q`, description))
+	}
+	w.Header().Set("WWW-Authenticate", "Bearer "+strings.Join(params, ", "))
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, status, map[string]string{
+		"error":             errCode,
+		"error_description": description,
+	})
+}
+
+func writeStreamJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, status, data)
+}
+
+func writeNoContent(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/protocols/ssf/caep_interop_test.go
+++ b/backend/internal/protocols/ssf/caep_interop_test.go
@@ -1,0 +1,517 @@
+package ssf
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ParleSec/ProtocolSoup/internal/crypto"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestCAEPInteropTransmitterMetadata(t *testing.T) {
+	env := startSSFTestEnv(t)
+	status, body := env.doJSON(t, http.MethodGet, "/.well-known/ssf-configuration", "", nil)
+	if status != http.StatusOK {
+		t.Fatalf("well-known %d: %s", status, body)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg["spec_version"] != "1_0" {
+		t.Fatalf("spec_version %v, want 1_0 [CAEPINTEROP Specification Version]", cfg["spec_version"])
+	}
+	if cfg["issuer"] != env.server.URL {
+		t.Fatalf("issuer %v want %s [SSF §7.2.4]", cfg["issuer"], env.server.URL)
+	}
+	if cfg["default_subjects"] != "ALL" {
+		t.Fatalf("default_subjects %v, want ALL [CAEPINTEROP Implicitly Added Subjects]", cfg["default_subjects"])
+	}
+	schemes, _ := cfg["authorization_schemes"].([]interface{})
+	foundRFC6749 := false
+	for _, raw := range schemes {
+		obj, _ := raw.(map[string]interface{})
+		if fmt.Sprint(obj["spec_urn"]) == "urn:ietf:rfc:6749" {
+			foundRFC6749 = true
+		}
+	}
+	if !foundRFC6749 {
+		t.Fatalf("authorization_schemes missing urn:ietf:rfc:6749, got %#v", schemes)
+	}
+	methods, _ := cfg["delivery_methods_supported"].([]interface{})
+	joined := fmt.Sprint(methods)
+	if !strings.Contains(joined, DeliveryMethodPush) || !strings.Contains(joined, DeliveryMethodPoll) {
+		t.Fatalf("delivery_methods_supported %v", methods)
+	}
+	for _, key := range []string{"jwks_uri", "configuration_endpoint", "status_endpoint", "verification_endpoint"} {
+		val, _ := cfg[key].(string)
+		if val == "" {
+			t.Errorf("missing %s [CAEPINTEROP Transmitters]", key)
+		}
+	}
+
+	status, body = env.doJSON(t, http.MethodPost, "/ssf/actions/session-revoked", "", map[string]string{
+		"subject_identifier": "alice@example.com",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("action %d: %s", status, body)
+	}
+	stream, err := env.plugin.storage.GetDefaultStream(t.Context(), env.plugin.baseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := env.plugin.storage.GetEvents(t.Context(), stream.ID, "", 1)
+	if err != nil || len(events) == 0 {
+		t.Fatalf("stored events: %v len=%d", err, len(events))
+	}
+	decoded, err := DecodeWithoutValidation(events[0].SETToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Issuer != cfg["issuer"] {
+		t.Fatalf("SET iss %q != metadata issuer %v [SSF §7.2.4]", decoded.Issuer, cfg["issuer"])
+	}
+}
+
+func TestStreamIDLifecycleWithoutLookingGlassHeader(t *testing.T) {
+	env := startSSFTestEnv(t)
+	_ = env.plugin.storage.DeleteStream(t.Context(), "default")
+
+	status, body := env.doJSON(t, http.MethodGet, "/ssf/stream", "", nil)
+	if status != http.StatusOK {
+		t.Fatalf("empty list %d: %s", status, body)
+	}
+	if strings.TrimSpace(string(body)) != "[]" && !bytes.Equal(bytes.TrimSpace(body), []byte("[]\n")) {
+		var listed []Stream
+		if err := json.Unmarshal(body, &listed); err != nil {
+			t.Fatalf("list must be a JSON array, got %s", body)
+		}
+		if len(listed) != 0 {
+			t.Fatalf("want empty list for new receiver, got %#v", listed)
+		}
+	}
+	req, err := http.NewRequest(http.MethodGet, env.server.URL+"/ssf/stream", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.Header.Get("Cache-Control") != "no-store" {
+		t.Errorf("Cache-Control %q, want no-store [SSF §8.1.1.2]", resp.Header.Get("Cache-Control"))
+	}
+
+	status, body = env.doJSON(t, http.MethodPost, "/ssf/stream", "", map[string]any{
+		"delivery": map[string]string{
+			"method":       DeliveryMethodPush,
+			"endpoint_url": "https://receiver.example/ssf-push",
+		},
+		"events_requested": []string{
+			EventTypeSessionRevoked,
+			"https://example.invalid/unknown-event",
+		},
+		"description": "caep interop",
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create %d: %s", status, body)
+	}
+	var created Stream
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatal(err)
+	}
+	if created.ID == "" || strings.HasPrefix(created.ID, "session-") {
+		t.Fatalf("stream_id %q", created.ID)
+	}
+	if created.DeliveryMethod != DeliveryMethodPush || created.DeliveryEndpoint != "https://receiver.example/ssf-push" {
+		t.Fatalf("delivery %#v %#v", created.DeliveryMethod, created.DeliveryEndpoint)
+	}
+	delivered := eventsDelivered(created.EventsSupported, created.EventsRequested)
+	if len(delivered) != 1 || delivered[0] != EventTypeSessionRevoked {
+		t.Fatalf("events_delivered %v (unknown URIs must be ignored)", delivered)
+	}
+
+	status, body = env.doJSON(t, http.MethodPost, "/ssf/stream", "", map[string]any{})
+	if status != http.StatusCreated {
+		t.Fatalf("create default poll %d: %s", status, body)
+	}
+	var pollStream Stream
+	if err := json.Unmarshal(body, &pollStream); err != nil {
+		t.Fatal(err)
+	}
+	if pollStream.DeliveryMethod != DeliveryMethodPoll {
+		t.Fatalf("absent delivery must default to poll URN, got %s [SSF §8.1.1.1]", pollStream.DeliveryMethod)
+	}
+
+	status, body = env.doJSON(t, http.MethodGet, "/ssf/stream?stream_id="+created.ID, "", nil)
+	if status != http.StatusOK {
+		t.Fatalf("get one %d: %s", status, body)
+	}
+	var one Stream
+	if err := json.Unmarshal(body, &one); err != nil {
+		t.Fatal(err)
+	}
+	if one.ID != created.ID {
+		t.Fatalf("got %s want %s", one.ID, created.ID)
+	}
+
+	status, body = env.doJSON(t, http.MethodGet, "/ssf/status?stream_id="+created.ID, "", nil)
+	if status != http.StatusOK {
+		t.Fatalf("status %d: %s", status, body)
+	}
+	var st map[string]interface{}
+	if err := json.Unmarshal(body, &st); err != nil {
+		t.Fatal(err)
+	}
+	if st["stream_id"] != created.ID || st["status"] != StreamStatusEnabled {
+		t.Fatalf("status body %#v [SSF §8.1.2.1]", st)
+	}
+
+	status, body = env.doJSON(t, http.MethodGet, "/ssf/status", "", nil)
+	if status == http.StatusOK {
+		t.Fatalf("status without stream_id must not succeed: %s", body)
+	}
+
+	status, _ = env.doJSON(t, http.MethodDelete, "/ssf/stream?stream_id="+created.ID, "", nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("delete %d", status)
+	}
+	status, _ = env.doJSON(t, http.MethodGet, "/ssf/stream?stream_id="+created.ID, "", nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("deleted stream GET %d, want 404", status)
+	}
+}
+
+func TestOAuthResourceServerIsolationAndQueryToken(t *testing.T) {
+	asKeys, err := crypto.NewKeySet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(asKeys.PublicJWKS())
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	t.Setenv("SSF_AS_ISSUER", "https://as.example")
+	t.Setenv("SSF_AS_JWKS_URI", jwksSrv.URL)
+	env := startSSFTestEnv(t)
+
+	jwtSvc := crypto.NewJWTService(asKeys, "https://as.example")
+	tokenA, err := jwtSvc.CreateAccessToken("client-a", env.server.URL, ScopeSSFManage, 15*time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenB, err := jwtSvc.CreateAccessToken("client-b", env.server.URL, ScopeSSFManage, 15*time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readOnly, err := jwtSvc.CreateAccessToken("client-a", env.server.URL, ScopeSSFRead, 15*time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createBody := map[string]any{
+		"delivery": map[string]string{
+			"method":       DeliveryMethodPush,
+			"endpoint_url": "https://receiver.example/ssf-push",
+		},
+	}
+	status, body := env.doBearerJSON(t, http.MethodPost, "/ssf/stream", tokenA, createBody)
+	if status != http.StatusCreated {
+		t.Fatalf("create %d: %s", status, body)
+	}
+	var created Stream
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatal(err)
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodGet, "/ssf/stream?stream_id="+created.ID, tokenB, nil)
+	if status != http.StatusForbidden {
+		t.Fatalf("client-b GET %d, want 403: %s", status, body)
+	}
+	status, body = env.doBearerJSON(t, http.MethodDelete, "/ssf/stream?stream_id="+created.ID, tokenB, nil)
+	if status != http.StatusForbidden {
+		t.Fatalf("client-b DELETE %d, want 403: %s", status, body)
+	}
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/verify", tokenB, map[string]string{"stream_id": created.ID})
+	if status != http.StatusForbidden {
+		t.Fatalf("client-b verify %d, want 403: %s", status, body)
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/stream", readOnly, createBody)
+	if status != http.StatusForbidden {
+		t.Fatalf("ssf.read create %d, want 403 insufficient_scope: %s", status, body)
+	}
+	req, err := http.NewRequest(http.MethodPost, env.server.URL+"/ssf/stream", bytes.NewReader(mustJSON(createBody)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+readOnly)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if !strings.Contains(resp.Header.Get("WWW-Authenticate"), "insufficient_scope") {
+		t.Fatalf("WWW-Authenticate %q [RFC 6750 §3.1]", resp.Header.Get("WWW-Authenticate"))
+	}
+
+	q := env.server.URL + "/ssf/stream?access_token=" + tokenA
+	req, err = http.NewRequest(http.MethodGet, q, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("query access_token was accepted: %s", raw)
+	}
+}
+
+func TestSETProfileConformance(t *testing.T) {
+	env := startSSFTestEnv(t)
+	sessionID, _ := env.session(t)
+	streamID := env.sessionStreamID(t, sessionID)
+
+	assertSET := func(t *testing.T, token string, eventURI string, check func(jwt.MapClaims, map[string]interface{})) {
+		t.Helper()
+		parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fmt.Sprint(parsed.Header["typ"]) != "secevent+jwt" {
+			t.Fatalf("typ %v [SSF §4.1.1]", parsed.Header["typ"])
+		}
+		if fmt.Sprint(parsed.Header["alg"]) != "RS256" {
+			t.Fatalf("alg %v [CAEPINTEROP Event Signatures]", parsed.Header["alg"])
+		}
+		claims, _ := parsed.Claims.(jwt.MapClaims)
+		if _, ok := claims["sub"]; ok {
+			t.Error("JWT sub MUST NOT be present [SSF §4.1.2]")
+		}
+		if _, ok := claims["exp"]; ok {
+			t.Error("JWT exp MUST NOT be present [SSF §4.1.7]")
+		}
+		if claims["iss"] != env.plugin.baseURL {
+			t.Errorf("iss %v want %s", claims["iss"], env.plugin.baseURL)
+		}
+		if claims["txn"] == nil || fmt.Sprint(claims["txn"]) == "" {
+			t.Error("txn SHOULD be present [SSF §4.1.9]")
+		}
+		subID, _ := claims["sub_id"].(map[string]interface{})
+		if subID == nil {
+			t.Fatal("sub_id required [SSF §3.1]")
+		}
+		events, _ := claims["events"].(map[string]interface{})
+		if len(events) != 1 {
+			t.Fatalf("events must contain exactly one event, got %#v [CAEPINTEROP]", events)
+		}
+		payload, _ := events[eventURI].(map[string]interface{})
+		if payload == nil {
+			t.Fatalf("missing %s in %#v", eventURI, events)
+		}
+		check(claims, payload)
+	}
+
+	status, body := env.doJSON(t, http.MethodPost, "/ssf/actions/session-revoked", sessionID, map[string]string{
+		"subject_identifier": "alice@example.com",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("session-revoked %d: %s", status, body)
+	}
+	token, _ := compactSETFromSession(t, env, sessionID)
+	assertSET(t, token, EventTypeSessionRevoked, func(_ jwt.MapClaims, payload map[string]interface{}) {
+		reason, _ := payload["reason_admin"].(map[string]interface{})
+		if reason == nil || fmt.Sprint(reason["en"]) == "" {
+			t.Fatalf("reason_admin must be a non-empty object, got %#v", payload["reason_admin"])
+		}
+	})
+
+	status, body = env.doJSON(t, http.MethodPost, "/ssf/actions/credential-change", sessionID, map[string]string{
+		"subject_identifier": "alice@example.com",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("credential-change %d: %s", status, body)
+	}
+	token, _ = compactSETFromSession(t, env, sessionID)
+	assertSET(t, token, EventTypeCredentialChange, func(_ jwt.MapClaims, payload map[string]interface{}) {
+		if payload["change_type"] == nil || payload["credential_type"] == nil {
+			t.Fatalf("credential-change missing members %#v", payload)
+		}
+		reason, _ := payload["reason_admin"].(map[string]interface{})
+		if reason == nil || fmt.Sprint(reason["en"]) == "" {
+			t.Fatalf("credential-change reason_admin %#v", payload["reason_admin"])
+		}
+	})
+
+	status, body = env.doJSON(t, http.MethodPost, "/ssf/verify", sessionID, map[string]string{
+		"stream_id": streamID,
+	})
+	if status != http.StatusNoContent {
+		t.Fatalf("verify without state %d: %s", status, body)
+	}
+	token, _ = compactSETFromSession(t, env, sessionID)
+	assertSET(t, token, EventTypeVerification, func(claims jwt.MapClaims, payload map[string]interface{}) {
+		subID, _ := claims["sub_id"].(map[string]interface{})
+		if fmt.Sprint(subID["format"]) != SubjectFormatOpaque || fmt.Sprint(subID["id"]) != streamID {
+			t.Fatalf("verification sub_id %#v", subID)
+		}
+		if _, ok := payload["state"]; ok {
+			t.Fatalf("state must be omitted when not supplied, got %#v", payload["state"])
+		}
+	})
+
+	if _, err := env.plugin.transmitter.TriggerStreamUpdated(t.Context(), streamID, StreamStatusPaused, "lab", sessionID); err != nil {
+		t.Fatal(err)
+	}
+	token, _ = compactSETFromSession(t, env, sessionID)
+	assertSET(t, token, EventTypeStreamUpdated, func(claims jwt.MapClaims, payload map[string]interface{}) {
+		subID, _ := claims["sub_id"].(map[string]interface{})
+		if fmt.Sprint(subID["id"]) != streamID {
+			t.Fatalf("stream-updated sub_id %#v", subID)
+		}
+		if payload["status"] != StreamStatusPaused {
+			t.Fatalf("status %v", payload["status"])
+		}
+	})
+
+	bad := SETClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    env.plugin.baseURL,
+			Subject:   "must-not-be-present",
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "bad-jti",
+			Audience:  jwt.ClaimStrings{env.plugin.baseURL},
+		},
+		Events:    map[string]interface{}{EventTypeSessionRevoked: map[string]string{}},
+		SubjectID: &SETSubject{Format: SubjectFormatEmail, Email: "alice@example.com"},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, bad)
+	tok.Header["typ"] = "secevent+jwt"
+	signed, err := tok.SignedString(env.plugin.keySet.RSAPrivateKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := NewSETDecoder(env.plugin.keySet.RSAPublicKey(), env.plugin.baseURL, "")
+	if _, err := decoder.Decode(signed); err == nil {
+		t.Fatal("SET carrying sub or exp must fail validation [SSF §4.1.2 / §4.1.7]")
+	}
+
+	if bits := env.plugin.keySet.RSAPrivateKey().N.BitLen(); bits < 2048 {
+		t.Fatalf("RSA key %d bits, CAEPINTEROP requires >= 2048", bits)
+	}
+}
+
+func TestPushDeliveryToReceiverEndpointURL(t *testing.T) {
+	env := startSSFTestEnv(t)
+	var gotCT, gotAuth, gotLG string
+	var gotBody []byte
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		gotAuth = r.Header.Get("Authorization")
+		gotLG = r.Header.Get(lookingGlassSessionHeader)
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(listener.Close)
+
+	status, body := env.doJSON(t, http.MethodPost, "/ssf/stream", "", map[string]any{
+		"delivery": map[string]string{
+			"method":                DeliveryMethodPush,
+			"endpoint_url":          listener.URL,
+			"authorization_header":  "Bearer receiver-supplied",
+		},
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create %d: %s", status, body)
+	}
+	var stream Stream
+	if err := json.Unmarshal(body, &stream); err != nil {
+		t.Fatal(err)
+	}
+
+	status, body = env.doJSON(t, http.MethodPost, "/ssf/verify", "", map[string]string{
+		"stream_id": stream.ID,
+		"state":     "probe",
+	})
+	if status != http.StatusNoContent {
+		t.Fatalf("verify %d: %s", status, body)
+	}
+	if gotCT != "application/secevent+jwt" {
+		t.Fatalf("Content-Type %q [RFC 8935]", gotCT)
+	}
+	if gotAuth != "Bearer receiver-supplied" {
+		t.Fatalf("Authorization %q [SSF §6.1.1]", gotAuth)
+	}
+	if gotLG != "" {
+		t.Fatalf("must not send Looking Glass header to an external push URL, got %q", gotLG)
+	}
+	decoded, err := DecodeWithoutValidation(string(gotBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Subject == nil || decoded.Subject.Format != SubjectFormatOpaque || decoded.Subject.ID != stream.ID {
+		t.Fatalf("verification sub_id %#v", decoded.Subject)
+	}
+	if len(decoded.Events) != 1 || decoded.Events[0].Type != EventTypeVerification {
+		t.Fatalf("events %#v", decoded.Events)
+	}
+	if decoded.Events[0].Payload.State != "probe" {
+		t.Fatalf("state %q", decoded.Events[0].Payload.State)
+	}
+
+	env.plugin.minVerifyInt = 60
+	status, _ = env.doJSON(t, http.MethodPost, "/ssf/verify", "", map[string]string{
+		"stream_id": stream.ID,
+		"state":     "again",
+	})
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("second verify %d, want 429", status)
+	}
+}
+
+func (e *ssfTestEnv) doBearerJSON(t *testing.T, method, path, token string, body any) (int, []byte) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(mustJSON(body))
+	}
+	req, err := http.NewRequest(method, e.server.URL+path, reader)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw
+}
+
+func mustJSON(v any) []byte {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}

--- a/backend/internal/protocols/ssf/events.go
+++ b/backend/internal/protocols/ssf/events.go
@@ -1,11 +1,16 @@
 package ssf
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 // SSF Framework event types
 const (
-	// Verification event per SSF §7
+	// Verification event per SSF §7 / §8.1.4.1
 	EventTypeVerification = "https://schemas.openid.net/secevent/ssf/event-type/verification"
+	// Stream Updated event per SSF §8.1.5
+	EventTypeStreamUpdated = "https://schemas.openid.net/secevent/ssf/event-type/stream-updated"
 )
 
 // Event URIs for CAEP (Continuous Access Evaluation Profile)
@@ -63,6 +68,7 @@ type EventCategory string
 const (
 	CategoryCAEP EventCategory = "CAEP"
 	CategoryRISC EventCategory = "RISC"
+	CategorySSF  EventCategory = "SSF"
 )
 
 // EventMetadata contains metadata about an event type
@@ -91,6 +97,18 @@ func GetEventMetadata(eventURI string) EventMetadata {
 
 // eventMetadataRegistry contains all supported event types with their metadata
 var eventMetadataRegistry = map[string]EventMetadata{
+	EventTypeVerification: {
+		URI:         EventTypeVerification,
+		Name:        "Verification",
+		Description: "Transmitter verification event for an Event Stream",
+		Category:    CategorySSF,
+	},
+	EventTypeStreamUpdated: {
+		URI:         EventTypeStreamUpdated,
+		Name:        "Stream Updated",
+		Description: "Transmitter-initiated Event Stream status change",
+		Category:    CategorySSF,
+	},
 	// CAEP Events
 	EventTypeSessionRevoked: {
 		URI:         EventTypeSessionRevoked,
@@ -253,6 +271,7 @@ func GetAllEventTypes() map[EventCategory][]EventMetadata {
 	result := map[EventCategory][]EventMetadata{
 		CategoryCAEP: {},
 		CategoryRISC: {},
+		CategorySSF:  {},
 	}
 	for _, meta := range eventMetadataRegistry {
 		result[meta.Category] = append(result[meta.Category], meta)
@@ -264,8 +283,12 @@ func GetAllEventTypes() map[EventCategory][]EventMetadata {
 func GetSupportedEventURIs() []string {
 	uris := make([]string, 0, len(eventMetadataRegistry))
 	for uri := range eventMetadataRegistry {
+		if uri == EventTypeVerification || uri == EventTypeStreamUpdated {
+			continue
+		}
 		uris = append(uris, uri)
 	}
+	sort.Strings(uris)
 	return uris
 }
 
@@ -311,6 +334,9 @@ type SecurityEvent struct {
 
 	// For verification events (SSF §7)
 	State string `json:"state,omitempty"`
+
+	// For stream-updated events (SSF §8.1.5)
+	StreamStatus string `json:"stream_status,omitempty"`
 }
 
 // ReasonInfo provides human-readable reason information

--- a/backend/internal/protocols/ssf/handlers.go
+++ b/backend/internal/protocols/ssf/handlers.go
@@ -2,6 +2,7 @@ package ssf
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 )
 
 // getSessionID extracts or generates a session ID from the request
@@ -59,11 +61,15 @@ func (p *Plugin) handleSSFConfiguration(w http.ResponseWriter, r *http.Request) 
 			DeliveryMethodPush,
 			DeliveryMethodPoll,
 		},
-		"configuration_endpoint":  p.baseURL + "/ssf/stream",
-		"status_endpoint":         p.baseURL + "/ssf/status",
-		"verification_endpoint":   p.baseURL + "/ssf/verify",
-		"add_subject_endpoint":    p.baseURL + "/ssf/subjects",
+		"configuration_endpoint": p.baseURL + "/ssf/stream",
+		"status_endpoint":        p.baseURL + "/ssf/status",
+		"verification_endpoint":  p.baseURL + "/ssf/verify",
+		"add_subject_endpoint":   p.baseURL + "/ssf/subjects",
 		"remove_subject_endpoint": p.baseURL + "/ssf/subjects",
+		"authorization_schemes": []map[string]string{
+			{"spec_urn": "urn:ietf:rfc:6749"},
+		},
+		"default_subjects": "ALL",
 		"critical_subject_members": []string{
 			"user",
 			"device",
@@ -89,29 +95,34 @@ func (p *Plugin) handleJWKS(w http.ResponseWriter, r *http.Request) {
 // handleGetStream returns stream configuration (SSF §8.1.1.2).
 // Without stream_id the Transmitter returns a list. With stream_id, one stream or 404.
 func (p *Plugin) handleGetStream(w http.ResponseWriter, r *http.Request) {
+	ident, ok := p.authenticateReceiver(w, r, ScopeSSFRead)
+	if !ok {
+		return
+	}
+
 	streamID := strings.TrimSpace(r.URL.Query().Get("stream_id"))
 	if streamID == "" {
-		streams, err := p.listStreamsForRequest(r)
+		streams, err := p.storage.ListStreamsForReceiver(r.Context(), ident.ID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Failed to list streams")
 			return
 		}
-		writeJSON(w, http.StatusOK, streams)
+		writeStreamJSON(w, http.StatusOK, streams)
 		return
 	}
 
-	stream, err := p.getStreamForRequest(r, streamID)
+	stream, err := p.ownedStream(r.Context(), ident, streamID, w)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "Stream not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, stream)
+	writeStreamJSON(w, http.StatusOK, stream)
 }
 
 type streamConfigBody struct {
 	StreamID        string          `json:"stream_id"`
 	EventsRequested []string        `json:"events_requested"`
 	Delivery        *StreamDelivery `json:"delivery"`
+	Description     string          `json:"description"`
 	Status          string          `json:"status"`
 }
 
@@ -122,31 +133,26 @@ func requestStreamID(r *http.Request, bodyID string) string {
 	return strings.TrimSpace(bodyID)
 }
 
-func (p *Plugin) listStreamsForRequest(r *http.Request) ([]Stream, error) {
-	sessionID := getSessionID(r)
-	if sessionID != "" {
-		stream, err := p.storage.GetSessionStream(r.Context(), sessionID, p.baseURL, p.receiverEndpoint, p.receiverToken)
-		if err != nil {
-			return nil, err
-		}
-		return []Stream{*stream}, nil
-	}
-	return p.storage.ListStreams(r.Context())
-}
-
-func (p *Plugin) getStreamForRequest(r *http.Request, streamID string) (*Stream, error) {
-	stream, err := p.storage.GetStream(r.Context(), streamID)
+func (p *Plugin) ownedStream(ctx context.Context, ident receiverIdentity, streamID string, w http.ResponseWriter) (*Stream, error) {
+	stream, err := p.storage.GetStreamByID(ctx, streamID)
 	if err != nil {
+		writeError(w, http.StatusNotFound, "Stream not found")
 		return nil, err
 	}
-	if sessionID := getSessionID(r); sessionID != "" && stream.ID != "session-"+sessionID {
-		return nil, fmt.Errorf("stream not found")
+	if stream.ReceiverID != ident.ID {
+		p.writeBearerError(w, http.StatusForbidden, "insufficient_scope", "the Event Receiver is not allowed to access this stream")
+		return nil, fmt.Errorf("forbidden")
 	}
 	return stream, nil
 }
 
 // handleUpdateStream updates stream configuration (SSF §8.1.1). stream_id is REQUIRED.
 func (p *Plugin) handleUpdateStream(w http.ResponseWriter, r *http.Request) {
+	ident, ok := p.authenticateReceiver(w, r, ScopeSSFManage)
+	if !ok {
+		return
+	}
+
 	var update streamConfigBody
 	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body")
@@ -159,9 +165,8 @@ func (p *Plugin) handleUpdateStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stream, err := p.getStreamForRequest(r, streamID)
+	stream, err := p.ownedStream(r.Context(), ident, streamID, w)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "Stream not found")
 		return
 	}
 
@@ -179,9 +184,15 @@ func (p *Plugin) handleUpdateStream(w http.ResponseWriter, r *http.Request) {
 		if update.Delivery.EndpointURL != "" {
 			stream.DeliveryEndpoint = update.Delivery.EndpointURL
 		}
+		if update.Delivery.AuthorizationHeader != "" {
+			stream.AuthorizationHeader = update.Delivery.AuthorizationHeader
+		}
 	}
-	if len(update.EventsRequested) > 0 {
+	if update.EventsRequested != nil {
 		stream.EventsRequested = update.EventsRequested
+	}
+	if update.Description != "" {
+		stream.Description = update.Description
 	}
 	if update.Status != "" {
 		stream.Status = update.Status
@@ -192,39 +203,55 @@ func (p *Plugin) handleUpdateStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, stream)
+	writeStreamJSON(w, http.StatusOK, stream)
 }
 
-// handleCreateStream creates a new stream per SSF §8.1.1.
+// handleCreateStream creates a new stream per SSF §8.1.1.1.
 func (p *Plugin) handleCreateStream(w http.ResponseWriter, r *http.Request) {
-	var req streamConfigBody
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	ident, ok := p.authenticateReceiver(w, r, ScopeSSFManage)
+	if !ok {
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-
-	if req.Delivery == nil || req.Delivery.Method == "" {
-		writeError(w, http.StatusBadRequest, "delivery.method is required")
-		return
+	var req streamConfigBody
+	if len(bytes.TrimSpace(body)) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid request body")
+			return
+		}
 	}
 
-	switch req.Delivery.Method {
+	deliveryMethod := DeliveryMethodPoll
+	endpointURL := ""
+	authzHeader := ""
+	if req.Delivery != nil {
+		if req.Delivery.Method != "" {
+			deliveryMethod = req.Delivery.Method
+		}
+		endpointURL = req.Delivery.EndpointURL
+		authzHeader = req.Delivery.AuthorizationHeader
+	}
+
+	switch deliveryMethod {
 	case DeliveryMethodPush, DeliveryMethodPoll:
 	default:
 		writeError(w, http.StatusBadRequest,
-			fmt.Sprintf("Invalid delivery.method: %q (must be %q or %q)", req.Delivery.Method, DeliveryMethodPush, DeliveryMethodPoll))
+			fmt.Sprintf("Invalid delivery.method: %q (must be %q or %q)", deliveryMethod, DeliveryMethodPush, DeliveryMethodPoll))
 		return
 	}
 
-	if req.Delivery.Method == DeliveryMethodPush && req.Delivery.EndpointURL == "" {
-		writeError(w, http.StatusBadRequest, "delivery.endpoint_url is required for push delivery")
-		return
-	}
-
-	sessionID := getSessionID(r)
-	streamID := generateID()
-	if sessionID != "" {
-		streamID = "session-" + sessionID
+	if deliveryMethod == DeliveryMethodPush && endpointURL == "" {
+		if strings.HasPrefix(ident.ID, "session:") {
+			endpointURL = p.receiverEndpoint
+		} else {
+			writeError(w, http.StatusBadRequest, "delivery.endpoint_url is required for push delivery")
+			return
+		}
 	}
 
 	eventsRequested := req.EventsRequested
@@ -232,15 +259,31 @@ func (p *Plugin) handleCreateStream(w http.ResponseWriter, r *http.Request) {
 		eventsRequested = GetSupportedEventURIs()
 	}
 
+	audience := []string{ident.ID}
+	if strings.HasPrefix(ident.ID, "session:") || ident.ID == "anonymous" {
+		audience = []string{p.baseURL + "/receiver"}
+	}
+
+	bearer := ""
+	if strings.HasPrefix(ident.ID, "session:") {
+		bearer = p.receiverToken
+	}
+
 	stream := Stream{
-		ID:               streamID,
-		Issuer:           p.baseURL,
-		Audience:         []string{p.baseURL + "/receiver"},
-		EventsSupported:  GetSupportedEventURIs(),
-		EventsRequested:  eventsRequested,
-		DeliveryMethod:   req.Delivery.Method,
-		DeliveryEndpoint: req.Delivery.EndpointURL,
-		Status:           StreamStatusEnabled,
+		ID:                  generateStreamID(),
+		Issuer:              p.baseURL,
+		Audience:            audience,
+		EventsSupported:     GetSupportedEventURIs(),
+		EventsRequested:     eventsRequested,
+		DeliveryMethod:      deliveryMethod,
+		DeliveryEndpoint:    endpointURL,
+		AuthorizationHeader: authzHeader,
+		BearerToken:         bearer,
+		Status:              StreamStatusEnabled,
+		ReceiverID:          ident.ID,
+		SessionID:           getSessionID(r),
+		Description:         req.Description,
+		MinVerificationSecs: p.minVerifyInt,
 	}
 
 	if err := p.storage.CreateStream(r.Context(), stream); err != nil {
@@ -248,11 +291,16 @@ func (p *Plugin) handleCreateStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, stream)
+	writeStreamJSON(w, http.StatusCreated, stream)
 }
 
-// handleDeleteStream deletes a stream. stream_id is REQUIRED (SSF §8.1.1).
+// handleDeleteStream deletes a stream. stream_id is REQUIRED (SSF §8.1.1.5).
 func (p *Plugin) handleDeleteStream(w http.ResponseWriter, r *http.Request) {
+	ident, ok := p.authenticateReceiver(w, r, ScopeSSFManage)
+	if !ok {
+		return
+	}
+
 	var req streamConfigBody
 	if r.Body != nil && r.Body != http.NoBody {
 		_ = json.NewDecoder(r.Body).Decode(&req)
@@ -263,8 +311,7 @@ func (p *Plugin) handleDeleteStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := p.getStreamForRequest(r, streamID); err != nil {
-		writeError(w, http.StatusNotFound, "Stream not found")
+	if _, err := p.ownedStream(r.Context(), ident, streamID, w); err != nil {
 		return
 	}
 
@@ -273,7 +320,7 @@ func (p *Plugin) handleDeleteStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	writeNoContent(w)
 }
 
 // ====================
@@ -715,9 +762,99 @@ func (p *Plugin) handleAcknowledge(w http.ResponseWriter, r *http.Request) {
 // handleVerification triggers a verification SET per SSF §8.1.4.2.
 // Success is 204 No Content with an empty body. stream_id is REQUIRED.
 func (p *Plugin) handleVerification(w http.ResponseWriter, r *http.Request) {
+	ident, ok := p.authenticateReceiver(w, r, ScopeSSFManage)
+	if !ok {
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
 	var req struct {
 		StreamID string `json:"stream_id"`
 		State    string `json:"state"`
+	}
+	if len(bytes.TrimSpace(body)) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid request body")
+			return
+		}
+	}
+
+	streamID := requestStreamID(r, req.StreamID)
+	if streamID == "" {
+		writeSSFError(w, http.StatusBadRequest, "invalid_request", "stream_id is required")
+		return
+	}
+
+	stream, err := p.ownedStream(r.Context(), ident, streamID, w)
+	if err != nil {
+		return
+	}
+
+	interval := stream.MinVerificationSecs
+	if interval <= 0 {
+		interval = p.minVerifyInt
+	}
+	if interval > 0 && stream.LastVerificationAt != nil {
+		elapsed := time.Since(*stream.LastVerificationAt)
+		if elapsed < time.Duration(interval)*time.Second {
+			writeError(w, http.StatusTooManyRequests, "verification requests exceed min_verification_interval")
+			return
+		}
+	}
+
+	if _, err := p.transmitter.TriggerVerification(r.Context(), stream.ID, req.State, getSessionID(r)); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	_ = p.storage.RecordVerification(r.Context(), stream.ID, time.Now())
+
+	writeNoContent(w)
+}
+
+// ====================
+// Stream Status (SSF §6)
+// ====================
+
+// handleGetStatus returns the current stream status per SSF §6.
+func (p *Plugin) handleGetStatus(w http.ResponseWriter, r *http.Request) {
+	ident, ok := p.authenticateReceiver(w, r, ScopeSSFRead)
+	if !ok {
+		return
+	}
+
+	streamID := strings.TrimSpace(r.URL.Query().Get("stream_id"))
+	if streamID == "" {
+		writeSSFError(w, http.StatusBadRequest, "invalid_request", "stream_id is required")
+		return
+	}
+
+	stream, err := p.ownedStream(r.Context(), ident, streamID, w)
+	if err != nil {
+		return
+	}
+
+	writeStreamJSON(w, http.StatusOK, map[string]interface{}{
+		"stream_id": stream.ID,
+		"status":    stream.Status,
+	})
+}
+
+// handleUpdateStatus updates the stream status per SSF §6.
+// Accepts: enabled, paused, disabled.
+func (p *Plugin) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
+	ident, ok := p.authenticateReceiver(w, r, ScopeSSFManage)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		StreamID string `json:"stream_id"`
+		Status   string `json:"status"`
+		Reason   string `json:"reason"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -731,86 +868,16 @@ func (p *Plugin) handleVerification(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.State == "" {
-		writeError(w, http.StatusBadRequest, "state is required per SSF §8.1.4")
-		return
-	}
-
-	stream, err := p.getStreamForRequest(r, streamID)
-	if err != nil {
-		writeError(w, http.StatusNotFound, "Stream not found")
-		return
-	}
-
-	if _, err := p.transmitter.TriggerVerification(r.Context(), stream.ID, req.State, getSessionID(r)); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	w.WriteHeader(http.StatusNoContent)
-}
-
-// ====================
-// Stream Status (SSF §6)
-// ====================
-
-// handleGetStatus returns the current stream status per SSF §6.
-func (p *Plugin) handleGetStatus(w http.ResponseWriter, r *http.Request) {
-	sessionID := getSessionID(r)
-	var stream *Stream
-	var err error
-
-	if sessionID != "" {
-		stream, err = p.storage.GetSessionStream(r.Context(), sessionID, p.baseURL, p.receiverEndpoint, p.receiverToken)
-	} else {
-		stream, err = p.storage.GetDefaultStream(r.Context(), p.baseURL)
-	}
-
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "Failed to get stream")
-		return
-	}
-
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"status": stream.Status,
-	})
-}
-
-// handleUpdateStatus updates the stream status per SSF §6.
-// Accepts: enabled, paused, disabled.
-func (p *Plugin) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
-	sessionID := getSessionID(r)
-
-	var req struct {
-		Status string `json:"status"`
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
-		return
-	}
-
-	// Validate status value
 	switch req.Status {
 	case StreamStatusEnabled, StreamStatusPaused, StreamStatusDisabled:
-		// Valid
 	default:
 		writeError(w, http.StatusBadRequest,
 			fmt.Sprintf("Invalid status: %q (must be enabled, paused, or disabled)", req.Status))
 		return
 	}
 
-	var stream *Stream
-	var err error
-
-	if sessionID != "" {
-		stream, err = p.storage.GetSessionStream(r.Context(), sessionID, p.baseURL, p.receiverEndpoint, p.receiverToken)
-	} else {
-		stream, err = p.storage.GetDefaultStream(r.Context(), p.baseURL)
-	}
-
+	stream, err := p.ownedStream(r.Context(), ident, streamID, w)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "Failed to get stream")
 		return
 	}
 
@@ -820,8 +887,9 @@ func (p *Plugin) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"status": stream.Status,
+	writeStreamJSON(w, http.StatusOK, map[string]interface{}{
+		"stream_id": stream.ID,
+		"status":    stream.Status,
 	})
 }
 
@@ -946,6 +1014,10 @@ func writeSSFError(w http.ResponseWriter, status int, errCode, description strin
 
 func generateID() string {
 	return randomString(8)
+}
+
+func generateStreamID() string {
+	return strings.ReplaceAll(uuid.New().String(), "-", "")
 }
 
 func randomString(n int) string {

--- a/backend/internal/protocols/ssf/plugin.go
+++ b/backend/internal/protocols/ssf/plugin.go
@@ -30,6 +30,14 @@ type Plugin struct {
 	receiverPort     int
 	receiverToken    string // Bearer token for authenticated push delivery
 	receiverEndpoint string // Public-facing receiver push URL (baseURL/ssf/receiver/push)
+
+	// Authorization server used to validate Stream Management access tokens.
+	// [CAEPINTEROP] §2.7: the AS MAY be a different entity from the Transmitter.
+	asIssuer     string
+	asJWKSURI    string
+	asAudience   string
+	jwksFetch    *crypto.JWKSFetcher
+	minVerifyInt int // seconds; SSF §8.1.1 min_verification_interval
 }
 
 // NewPlugin creates a new SSF plugin
@@ -79,6 +87,18 @@ func (p *Plugin) Initialize(ctx context.Context, config plugin.PluginConfig) err
 	// 2. No localhost URLs leak into event data shown to users
 	// 3. Real HTTP traffic still flows between transmitter and receiver
 	p.receiverEndpoint = strings.TrimRight(p.baseURL, "/") + "/ssf/receiver/push"
+
+	p.asIssuer = strings.TrimRight(strings.TrimSpace(os.Getenv("SSF_AS_ISSUER")), "/")
+	p.asJWKSURI = strings.TrimSpace(os.Getenv("SSF_AS_JWKS_URI"))
+	p.asAudience = strings.TrimRight(strings.TrimSpace(os.Getenv("SSF_RESOURCE")), "/")
+	if p.asAudience == "" {
+		p.asAudience = strings.TrimRight(p.baseURL, "/")
+	}
+	p.jwksFetch = crypto.NewJWKSFetcher(5 * time.Minute)
+	p.minVerifyInt = 10
+	if strings.EqualFold(config.Environment, "production") && p.asJWKSURI == "" {
+		log.Printf("[SSF] WARNING: SSF_AS_JWKS_URI is unset in production; Stream Management will not require bearer tokens")
+	}
 
 	// Initialize SQLite storage
 	dataDir := getDataDir()

--- a/backend/internal/protocols/ssf/plugin_test.go
+++ b/backend/internal/protocols/ssf/plugin_test.go
@@ -144,10 +144,26 @@ func (e *ssfTestEnv) sessionStreamID(t *testing.T, sessionID string) string {
 	if err := json.Unmarshal(body, &streams); err != nil {
 		t.Fatalf("decode stream list: %v %s", err, body)
 	}
-	if len(streams) == 0 || streams[0].ID == "" {
-		t.Fatal("GET /stream without stream_id must return a list")
+	if len(streams) > 0 && streams[0].ID != "" {
+		return streams[0].ID
 	}
-	return streams[0].ID
+	status, body = e.doJSON(t, http.MethodPost, "/ssf/stream", sessionID, map[string]any{
+		"delivery": map[string]string{
+			"method":       DeliveryMethodPush,
+			"endpoint_url": e.server.URL + "/ssf/receiver/push",
+		},
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create stream %d: %s", status, body)
+	}
+	var created Stream
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("decode created stream: %v %s", err, body)
+	}
+	if created.ID == "" {
+		t.Fatal("created stream missing stream_id")
+	}
+	return created.ID
 }
 
 func compactSETFromSession(t *testing.T, env *ssfTestEnv, sessionID string) (token string, claims jwt.MapClaims) {

--- a/backend/internal/protocols/ssf/set.go
+++ b/backend/internal/protocols/ssf/set.go
@@ -47,6 +47,7 @@ type EventPayload struct {
 	OldValue         string                 `json:"old-value,omitempty"`
 	Claims           map[string]interface{} `json:"claims,omitempty"` // CAEP §3.2: changed claims
 	State            string                 `json:"state,omitempty"`  // SSF §7: verification event state
+	StreamStatus     string                 `json:"status,omitempty"` // SSF §8.1.5 stream-updated
 }
 
 // SETEncoder handles encoding security events into SET tokens
@@ -93,9 +94,13 @@ func (e *SETEncoder) Encode(event SecurityEvent, audience []string, jti string) 
 	// MUST NOT include a nested subject claim. Verification (SSF §8.1.4.1)
 	// is only {state} inside the event object plus opaque sub_id = stream_id.
 	eventPayload := EventPayload{}
-	if event.EventType == EventTypeVerification {
+	switch event.EventType {
+	case EventTypeVerification:
 		eventPayload.State = event.State
-	} else {
+	case EventTypeStreamUpdated:
+		eventPayload.StreamStatus = event.StreamStatus
+		eventPayload.Reason = event.Reason
+	default:
 		if !event.EventTimestamp.IsZero() {
 			eventPayload.EventTimestamp = event.EventTimestamp.Unix()
 		}
@@ -209,6 +214,21 @@ func (d *SETDecoder) Decode(tokenString string) (*DecodedSET, error) {
 	claims, ok := token.Claims.(*SETClaims)
 	if !ok || !token.Valid {
 		return nil, fmt.Errorf("invalid SET claims")
+	}
+
+	// SSF §4.1.2 / §4.1.3: the JWT sub claim MUST NOT be present.
+	if claims.Subject != "" {
+		return nil, fmt.Errorf("SET MUST NOT contain JWT sub (SSF §4.1.2)")
+	}
+	// SSF §4.1.7 / §4.1.3: the JWT exp claim MUST NOT be present.
+	if claims.ExpiresAt != nil {
+		return nil, fmt.Errorf("SET MUST NOT contain JWT exp (SSF §4.1.7)")
+	}
+	if claims.SubjectID == nil {
+		return nil, fmt.Errorf("SET MUST contain top-level sub_id (SSF §3.1)")
+	}
+	if len(claims.Events) != 1 {
+		return nil, fmt.Errorf("SET events claim MUST contain exactly one event")
 	}
 
 	// Validate issuer

--- a/backend/internal/protocols/ssf/storage.go
+++ b/backend/internal/protocols/ssf/storage.go
@@ -62,6 +62,11 @@ func (s *Storage) initSchema() error {
 		delivery_endpoint TEXT,
 		bearer_token TEXT,
 		status TEXT NOT NULL DEFAULT 'enabled',
+		receiver_id TEXT NOT NULL DEFAULT '',
+		session_id TEXT NOT NULL DEFAULT '',
+		description TEXT NOT NULL DEFAULT '',
+		authorization_header TEXT NOT NULL DEFAULT '',
+		last_verification_at DATETIME,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
@@ -140,6 +145,13 @@ func (s *Storage) initSchema() error {
 
 	// Migration: add session_id column to events if it doesn't already exist (for pre-existing DBs)
 	_, _ = s.db.Exec(`ALTER TABLE events ADD COLUMN session_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = s.db.Exec(`ALTER TABLE streams ADD COLUMN receiver_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = s.db.Exec(`ALTER TABLE streams ADD COLUMN session_id TEXT NOT NULL DEFAULT ''`)
+	_, _ = s.db.Exec(`ALTER TABLE streams ADD COLUMN description TEXT NOT NULL DEFAULT ''`)
+	_, _ = s.db.Exec(`ALTER TABLE streams ADD COLUMN authorization_header TEXT NOT NULL DEFAULT ''`)
+	_, _ = s.db.Exec(`ALTER TABLE streams ADD COLUMN last_verification_at DATETIME`)
+	_, _ = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_streams_receiver ON streams(receiver_id)`)
+	_, _ = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_streams_session ON streams(session_id)`)
 
 	return nil
 }
@@ -148,36 +160,43 @@ func (s *Storage) initSchema() error {
 // Wire JSON follows OpenID SSF 1.0 Final §8.1.1 (nested delivery, distinct
 // events_supported / events_delivered). Internal fields stay unexported-on-wire.
 type Stream struct {
-	ID               string    `json:"stream_id"`
-	Issuer           string    `json:"iss"`
-	Audience         []string  `json:"aud"`
-	EventsSupported  []string  `json:"-"`
-	EventsRequested  []string  `json:"events_requested"`
-	DeliveryMethod   string    `json:"-"`
-	DeliveryEndpoint string    `json:"-"`
-	BearerToken      string    `json:"-"`
-	Status           string    `json:"status"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID                  string
+	Issuer              string
+	Audience            []string
+	EventsSupported     []string
+	EventsRequested     []string
+	DeliveryMethod      string
+	DeliveryEndpoint    string
+	BearerToken         string
+	AuthorizationHeader string
+	Status              string
+	ReceiverID          string
+	SessionID           string
+	Description         string
+	MinVerificationSecs int
+	LastVerificationAt  *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 // StreamDelivery is the SSF §8.1.1 nested delivery object.
 type StreamDelivery struct {
-	Method      string `json:"method"`
-	EndpointURL string `json:"endpoint_url,omitempty"`
+	Method              string `json:"method"`
+	EndpointURL         string `json:"endpoint_url,omitempty"`
+	AuthorizationHeader string `json:"authorization_header,omitempty"`
 }
 
 type streamWire struct {
-	StreamID         string         `json:"stream_id"`
-	Iss              string         `json:"iss"`
-	Aud              []string       `json:"aud"`
-	EventsSupported  []string       `json:"events_supported"`
-	EventsRequested  []string       `json:"events_requested"`
-	EventsDelivered  []string       `json:"events_delivered"`
-	Delivery         StreamDelivery `json:"delivery"`
-	Status           string         `json:"status"`
-	CreatedAt        time.Time      `json:"created_at,omitempty"`
-	UpdatedAt        time.Time      `json:"updated_at,omitempty"`
+	StreamID                string         `json:"stream_id"`
+	Iss                     string         `json:"iss"`
+	Aud                     []string       `json:"aud"`
+	EventsSupported         []string       `json:"events_supported"`
+	EventsRequested         []string       `json:"events_requested"`
+	EventsDelivered         []string       `json:"events_delivered"`
+	Delivery                StreamDelivery `json:"delivery"`
+	Status                  string         `json:"status"`
+	Description             string         `json:"description,omitempty"`
+	MinVerificationInterval int            `json:"min_verification_interval,omitempty"`
 }
 
 func eventsDelivered(supported, requested []string) []string {
@@ -203,12 +222,13 @@ func (s Stream) MarshalJSON() ([]byte, error) {
 		EventsRequested: s.EventsRequested,
 		EventsDelivered: eventsDelivered(s.EventsSupported, s.EventsRequested),
 		Delivery: StreamDelivery{
-			Method:      s.DeliveryMethod,
-			EndpointURL: s.DeliveryEndpoint,
+			Method:              s.DeliveryMethod,
+			EndpointURL:         s.DeliveryEndpoint,
+			AuthorizationHeader: s.AuthorizationHeader,
 		},
-		Status:    s.Status,
-		CreatedAt: s.CreatedAt,
-		UpdatedAt: s.UpdatedAt,
+		Status:                  s.Status,
+		Description:             s.Description,
+		MinVerificationInterval: s.MinVerificationSecs,
 	})
 }
 
@@ -224,9 +244,10 @@ func (s *Stream) UnmarshalJSON(data []byte) error {
 	s.EventsRequested = wire.EventsRequested
 	s.DeliveryMethod = wire.Delivery.Method
 	s.DeliveryEndpoint = wire.Delivery.EndpointURL
+	s.AuthorizationHeader = wire.Delivery.AuthorizationHeader
 	s.Status = wire.Status
-	s.CreatedAt = wire.CreatedAt
-	s.UpdatedAt = wire.UpdatedAt
+	s.Description = wire.Description
+	s.MinVerificationSecs = wire.MinVerificationInterval
 	return nil
 }
 
@@ -250,66 +271,91 @@ func (s *Storage) CreateStream(ctx context.Context, stream Stream) error {
 	requested, _ := json.Marshal(stream.EventsRequested)
 
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO streams (id, issuer, audience, events_supported, events_requested, 
-			delivery_method, delivery_endpoint, bearer_token, status)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO streams (id, issuer, audience, events_supported, events_requested,
+			delivery_method, delivery_endpoint, bearer_token, status,
+			receiver_id, session_id, description, authorization_header)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		stream.ID, stream.Issuer, string(audience), string(supported), string(requested),
-		stream.DeliveryMethod, stream.DeliveryEndpoint, stream.BearerToken, stream.Status)
+		stream.DeliveryMethod, stream.DeliveryEndpoint, stream.BearerToken, stream.Status,
+		stream.ReceiverID, stream.SessionID, stream.Description, stream.AuthorizationHeader)
 	return err
 }
 
-// GetStream retrieves a stream by ID
-func (s *Storage) GetStream(ctx context.Context, streamID string) (*Stream, error) {
-	row := s.db.QueryRowContext(ctx, `
-		SELECT id, issuer, audience, events_supported, events_requested, 
-			delivery_method, delivery_endpoint, COALESCE(bearer_token, ''), status, created_at, updated_at
-		FROM streams WHERE id = ?`, streamID)
+const streamSelectCols = `id, issuer, audience, events_supported, events_requested,
+	delivery_method, delivery_endpoint, COALESCE(bearer_token, ''), status, created_at, updated_at,
+	COALESCE(receiver_id, ''), COALESCE(session_id, ''), COALESCE(description, ''),
+	COALESCE(authorization_header, ''), last_verification_at`
 
+func scanStream(scanner interface {
+	Scan(dest ...any) error
+}) (*Stream, error) {
 	var stream Stream
 	var audience, supported, requested string
-	err := row.Scan(&stream.ID, &stream.Issuer, &audience, &supported, &requested,
+	var lastVerify sql.NullTime
+	err := scanner.Scan(&stream.ID, &stream.Issuer, &audience, &supported, &requested,
 		&stream.DeliveryMethod, &stream.DeliveryEndpoint, &stream.BearerToken, &stream.Status,
-		&stream.CreatedAt, &stream.UpdatedAt)
+		&stream.CreatedAt, &stream.UpdatedAt,
+		&stream.ReceiverID, &stream.SessionID, &stream.Description, &stream.AuthorizationHeader,
+		&lastVerify)
 	if err != nil {
 		return nil, err
 	}
-
 	_ = json.Unmarshal([]byte(audience), &stream.Audience)
 	_ = json.Unmarshal([]byte(supported), &stream.EventsSupported)
 	_ = json.Unmarshal([]byte(requested), &stream.EventsRequested)
-
+	if lastVerify.Valid {
+		stream.LastVerificationAt = &lastVerify.Time
+	}
 	return &stream, nil
 }
 
-// ListStreams returns every stored stream (SSF §8.1.1.2 GET without stream_id).
-func (s *Storage) ListStreams(ctx context.Context) ([]Stream, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, issuer, audience, events_supported, events_requested,
-			delivery_method, delivery_endpoint, COALESCE(bearer_token, ''), status, created_at, updated_at
-		FROM streams ORDER BY created_at ASC`)
+// GetStream retrieves a stream by ID.
+func (s *Storage) GetStream(ctx context.Context, streamID string) (*Stream, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+streamSelectCols+` FROM streams WHERE id = ?`, streamID)
+	return scanStream(row)
+}
+
+// GetStreamByID is the spec-facing lookup ([SSF] §8.1.1).
+func (s *Storage) GetStreamByID(ctx context.Context, streamID string) (*Stream, error) {
+	return s.GetStream(ctx, streamID)
+}
+
+func (s *Storage) listStreams(ctx context.Context, where string, args ...any) ([]Stream, error) {
+	query := `SELECT ` + streamSelectCols + ` FROM streams`
+	if where != "" {
+		query += " WHERE " + where
+	}
+	query += " ORDER BY created_at ASC"
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var streams []Stream
+	streams := []Stream{}
 	for rows.Next() {
-		var stream Stream
-		var audience, supported, requested string
-		if err := rows.Scan(&stream.ID, &stream.Issuer, &audience, &supported, &requested,
-			&stream.DeliveryMethod, &stream.DeliveryEndpoint, &stream.BearerToken, &stream.Status,
-			&stream.CreatedAt, &stream.UpdatedAt); err != nil {
+		stream, err := scanStream(rows)
+		if err != nil {
 			return nil, err
 		}
-		_ = json.Unmarshal([]byte(audience), &stream.Audience)
-		_ = json.Unmarshal([]byte(supported), &stream.EventsSupported)
-		_ = json.Unmarshal([]byte(requested), &stream.EventsRequested)
-		streams = append(streams, stream)
-	}
-	if streams == nil {
-		streams = []Stream{}
+		streams = append(streams, *stream)
 	}
 	return streams, rows.Err()
+}
+
+// ListStreams returns every stored stream. Prefer ListStreamsForReceiver on spec endpoints.
+func (s *Storage) ListStreams(ctx context.Context) ([]Stream, error) {
+	return s.listStreams(ctx, "")
+}
+
+// ListStreamsForReceiver returns streams owned by receiverID ([SSF] §8.1.1.2).
+func (s *Storage) ListStreamsForReceiver(ctx context.Context, receiverID string) ([]Stream, error) {
+	return s.listStreams(ctx, "receiver_id = ?", receiverID)
+}
+
+// ListStreamsForSession returns streams tagged with a Looking Glass session.
+func (s *Storage) ListStreamsForSession(ctx context.Context, sessionID string) ([]Stream, error) {
+	return s.listStreams(ctx, "session_id = ?", sessionID)
 }
 
 // GetDefaultStream gets or creates a default stream for the sandbox
@@ -329,6 +375,7 @@ func (s *Storage) GetDefaultStream(ctx context.Context, issuer string) (*Stream,
 		DeliveryMethod:   DeliveryMethodPush,
 		DeliveryEndpoint: issuer + "/ssf/push",
 		Status:           StreamStatusEnabled,
+		ReceiverID:       "anonymous",
 	}
 
 	if err := s.CreateStream(ctx, defaultStream); err != nil {
@@ -348,10 +395,21 @@ func (s *Storage) UpdateStream(ctx context.Context, stream Stream) error {
 		UPDATE streams SET 
 			audience = ?, events_supported = ?, events_requested = ?,
 			delivery_method = ?, delivery_endpoint = ?, bearer_token = ?, status = ?,
+			receiver_id = ?, session_id = ?, description = ?, authorization_header = ?,
 			updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?`,
 		string(audience), string(supported), string(requested),
-		stream.DeliveryMethod, stream.DeliveryEndpoint, stream.BearerToken, stream.Status, stream.ID)
+		stream.DeliveryMethod, stream.DeliveryEndpoint, stream.BearerToken, stream.Status,
+		stream.ReceiverID, stream.SessionID, stream.Description, stream.AuthorizationHeader,
+		stream.ID)
+	return err
+}
+
+// RecordVerification stamps last_verification_at for min_verification_interval.
+func (s *Storage) RecordVerification(ctx context.Context, streamID string, at time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE streams SET last_verification_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+		at, streamID)
 	return err
 }
 
@@ -599,7 +657,7 @@ func (s *Storage) CleanupSecurityStates(ctx context.Context, maxAge time.Duratio
 	res, err := s.db.ExecContext(ctx, `
 		DELETE FROM security_states
 		WHERE stream_id IN (
-			SELECT id FROM streams WHERE id LIKE 'session-%' AND updated_at < ?
+			SELECT id FROM streams WHERE session_id != '' AND updated_at < ?
 		)`, cutoff)
 	if err != nil {
 		return 0, err
@@ -843,27 +901,19 @@ func (s *Storage) SeedDemoData(ctx context.Context, baseURL string) error {
 	return nil
 }
 
-// GetSessionStream gets or creates a stream for a specific session.
+// GetSessionStream gets or creates a stream for a Looking Glass session.
 // deliveryEndpoint and bearerToken configure push delivery to the standalone receiver.
 func (s *Storage) GetSessionStream(ctx context.Context, sessionID, issuer, deliveryEndpoint, bearerToken string) (*Stream, error) {
-	streamID := "session-" + sessionID
-
-	stream, err := s.GetStream(ctx, streamID)
-	if err == nil {
-		// Ensure the delivery endpoint stays in sync with the current configuration.
-		// Existing session streams may point to a stale endpoint if the backend
-		// was restarted with updated routing.
-		if stream.DeliveryEndpoint != deliveryEndpoint || stream.BearerToken != bearerToken {
-			stream.DeliveryEndpoint = deliveryEndpoint
-			stream.BearerToken = bearerToken
-			_ = s.UpdateStream(ctx, *stream)
-		}
-		return stream, nil
+	existing, err := s.ListStreamsForSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) > 0 {
+		return &existing[0], nil
 	}
 
-	// Create session-specific stream pointing to the standalone receiver
 	sessionStream := Stream{
-		ID:               streamID,
+		ID:               generateStreamID(),
 		Issuer:           issuer,
 		Audience:         []string{issuer + "/receiver"},
 		EventsSupported:  GetSupportedEventURIs(),
@@ -872,6 +922,8 @@ func (s *Storage) GetSessionStream(ctx context.Context, sessionID, issuer, deliv
 		DeliveryEndpoint: deliveryEndpoint,
 		BearerToken:      bearerToken,
 		Status:           StreamStatusEnabled,
+		ReceiverID:       "session:" + sessionID,
+		SessionID:        sessionID,
 	}
 
 	if err := s.CreateStream(ctx, sessionStream); err != nil {
@@ -945,15 +997,14 @@ func (s *Storage) CleanupOldSessions(ctx context.Context, maxAge time.Duration) 
 	var count int
 	row := s.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM streams 
-		WHERE id LIKE 'session-%' AND updated_at < ?`, cutoff)
+		WHERE session_id != '' AND updated_at < ?`, cutoff)
 	if err := row.Scan(&count); err != nil {
 		return 0, err
 	}
 
-	// Delete old session streams (cascades to subjects and events)
 	_, err := s.db.ExecContext(ctx, `
 		DELETE FROM streams 
-		WHERE id LIKE 'session-%' AND updated_at < ?`, cutoff)
+		WHERE session_id != '' AND updated_at < ?`, cutoff)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/protocols/ssf/transmitter.go
+++ b/backend/internal/protocols/ssf/transmitter.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -109,20 +111,24 @@ func (t *Transmitter) GenerateEvent(ctx context.Context, streamID string, event 
 		return nil, fmt.Errorf("stream not found: %w", err)
 	}
 
-	// SSF §6: Enforce stream status. Disabled/paused streams MUST NOT generate events.
-	// Empty status is treated as enabled for backward compatibility with pre-existing streams.
-	switch stream.Status {
-	case StreamStatusDisabled:
-		return nil, fmt.Errorf("stream is disabled")
-	case StreamStatusPaused:
-		return nil, fmt.Errorf("stream is paused")
-	case StreamStatusEnabled, "":
-		// OK - proceed
+	// SSF §6: Enforce stream status. Disabled/paused streams MUST NOT generate
+	// events. Verification and stream-updated are framework events: verification
+	// is always permitted ([SSF] §8.1.4), and stream-updated MUST be sent before
+	// the Transmitter pauses or disables the stream ([SSF] §8.1.5).
+	frameworkEvent := event.EventType == EventTypeVerification || event.EventType == EventTypeStreamUpdated
+	if !frameworkEvent {
+		switch stream.Status {
+		case StreamStatusDisabled:
+			return nil, fmt.Errorf("stream is disabled")
+		case StreamStatusPaused:
+			return nil, fmt.Errorf("stream is paused")
+		case StreamStatusEnabled, "":
+		}
 	}
 
 	// Check if event type is requested by receiver.
-	// Verification events (SSF §7) are framework-level and always permitted.
-	if event.EventType != EventTypeVerification {
+	// Framework events MAY be sent even when not listed in events_requested ([SSF] §8.1.5).
+	if !frameworkEvent {
 		eventRequested := false
 		for _, requested := range stream.EventsRequested {
 			if requested == event.EventType {
@@ -143,6 +149,10 @@ func (t *Transmitter) GenerateEvent(ctx context.Context, streamID string, event 
 	event.IssuedAt = time.Now()
 	if event.EventTimestamp.IsZero() {
 		event.EventTimestamp = event.IssuedAt
+	}
+	// SSF §4.1.9 SHOULD set txn; ProtocolSoup demos share one cause across SETs.
+	if event.TransactionID == "" {
+		event.TransactionID = uuid.New().String()
 	}
 
 	// Broadcast: Action Triggered
@@ -386,13 +396,16 @@ func (t *Transmitter) attemptDelivery(ctx context.Context, stream *Stream, event
 	// (full SET body, RFC 8935). Skip CaptureMiddleware so Wire is not duplicated.
 	req.Header.Set(lookingglass.SkipCaptureHeader, "1")
 
-	// Add bearer token if configured for authenticated push delivery
-	if stream.BearerToken != "" {
+	// [SSF] §6.1.1: honour Receiver-supplied authorization_header on every push.
+	if strings.TrimSpace(stream.AuthorizationHeader) != "" {
+		req.Header.Set("Authorization", stream.AuthorizationHeader)
+	} else if stream.BearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+stream.BearerToken)
 	}
 
-	// Session id travels on the delivery header, not inside the SET (RFC 8417).
-	if event.SessionID != "" {
+	// Looking Glass session is a presentation-layer header for the internal
+	// receiver only. Never send it to an external conformance push URL.
+	if event.SessionID != "" && isInternalPushEndpoint(t.baseURL, stream.DeliveryEndpoint) {
 		req.Header.Set(lookingGlassSessionHeader, event.SessionID)
 	}
 
@@ -570,6 +583,7 @@ func (t *Transmitter) TriggerCredentialChangeWithSession(ctx context.Context, st
 		CredentialType:   credentialType,
 		ChangeType:       changeType, // CAEP §3.3: REQUIRED (create | revoke | update | delete)
 		InitiatingEntity: initiator,
+		ReasonAdmin:      &ReasonInfo{EN: "Credential " + changeType + " for " + credentialType},
 	}
 	return t.GenerateEvent(ctx, streamID, event)
 }
@@ -833,4 +847,56 @@ func (t *Transmitter) TriggerSessionsRevokedWithSession(ctx context.Context, str
 	}
 
 	return t.GenerateEvent(ctx, streamID, event)
+}
+
+// TriggerStreamUpdated emits a stream-updated SET ([SSF] §8.1.5) with opaque
+// sub_id equal to stream_id. Call this before a Transmitter-initiated pause
+// or disable, and after a Transmitter-initiated re-enable.
+func (t *Transmitter) TriggerStreamUpdated(ctx context.Context, streamID, status, reason, sessionID string) (*StoredEvent, error) {
+	event := SecurityEvent{
+		EventType:      EventTypeStreamUpdated,
+		EventTimestamp: time.Now(),
+		SessionID:      sessionID,
+		StreamStatus:   status,
+		Reason:         reason,
+		Subject: SubjectIdentifier{
+			Format: SubjectFormatOpaque,
+			ID:     streamID,
+		},
+	}
+	return t.GenerateEvent(ctx, streamID, event)
+}
+
+// UpdateStatusAsTransmitter sends stream-updated, then writes the new status.
+// Receiver-initiated POST /status does not use this path ([SSF] §8.1.2).
+func (t *Transmitter) UpdateStatusAsTransmitter(ctx context.Context, streamID, status, reason, sessionID string) error {
+	if _, err := t.TriggerStreamUpdated(ctx, streamID, status, reason, sessionID); err != nil {
+		return err
+	}
+	stream, err := t.storage.GetStream(ctx, streamID)
+	if err != nil {
+		return err
+	}
+	stream.Status = status
+	return t.storage.UpdateStream(ctx, *stream)
+}
+
+func isInternalPushEndpoint(baseURL, endpoint string) bool {
+	if endpoint == "" {
+		return false
+	}
+	base := strings.TrimRight(baseURL, "/")
+	if base != "" && (strings.HasPrefix(endpoint, base+"/ssf/receiver/") ||
+		strings.HasPrefix(endpoint, base+"/ssf/push")) {
+		return true
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	host := parsed.Hostname()
+	if host == "127.0.0.1" || host == "localhost" || host == "::1" {
+		return strings.Contains(parsed.Path, "/ssf/")
+	}
+	return false
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -174,6 +174,9 @@ services:
       - SSF_DATA_DIR=/app/data
       - FEDERATION_SERVICE_URL=http://federation-service:8080
       - SSF_TO_FEDERATION_TOKEN=${SSF_TO_FEDERATION_TOKEN:-ssf-federation-caep-lab}
+      - SSF_AS_ISSUER=http://localhost:8080
+      - SSF_AS_JWKS_URI=http://federation-service:8080/api/.well-known/jwks.json
+      - SSF_RESOURCE=http://localhost:8080
     depends_on:
       federation-service:
         condition: service_healthy

--- a/docs/packages/federation.md
+++ b/docs/packages/federation.md
@@ -39,6 +39,9 @@
 | `MOCKIDP_ADMIN_PASSWORD` | No | `(auto-generated)` | Demo user password override |
 | `MOCKIDP_DEMO_CLIENT_SECRET` | No | `(auto-generated)` | OAuth/OIDC demo-app client secret override |
 | `MOCKIDP_MACHINE_CLIENT_SECRET` | No | `(auto-generated)` | OAuth machine-client secret override |
+| `SSF_RESOURCE` | No | `SHOWCASE_BASE_URL` | Audience written into `ssf.read` / `ssf.manage` client-credentials tokens |
+| `SSF_CONFORMANCE_CLIENT_ID` | No | `(empty)` | Optional confidential Stream Management client. Requires `SSF_CONFORMANCE_CLIENT_SECRET`. |
+| `SSF_CONFORMANCE_CLIENT_SECRET` | No | `(empty)` | Matching secret. A secretless confidential client is never registered. |
 
 ### Storage And Volumes
 
@@ -71,7 +74,10 @@
 - `POST /oauth2/demo/caep/revoke-subject` (SSF receiver CAEP hook; bearer `SSF_TO_FEDERATION_TOKEN`)
 
 The OAuth token endpoint supports `private_key_jwt` for the
-`client_credentials` grant with RS256, ES256, and EdDSA assertions. The
+`client_credentials` grant with RS256, ES256, and EdDSA assertions. Client
+credentials tokens that include `ssf.read` or `ssf.manage` last 900 seconds and
+use `SSF_RESOURCE` (default `SHOWCASE_BASE_URL`) as `aud` so the SSF Transmitter
+can validate them as a resource server. The
 browser registration endpoint requires the session's one-time-returned owner
 capability, accepts one public JWK Set while the session is active, creates the
 real isolated client ID, expires it after 10 minutes, and returns the exact

--- a/docs/packages/ssf.md
+++ b/docs/packages/ssf.md
@@ -5,7 +5,7 @@
 - **Image:** `ghcr.io/parlesec/protocolsoup-ssf`
 - **Purpose:** Provide SSF transmitter and receiver behavior for CAEP/RISC event workflows with real SET generation and processing. Looking Glass is the run surface; this image stays independent of federation.
 - **Topology role:** Can run standalone or behind `protocolsoup-gateway` as `/ssf`; includes a secondary receiver listener for push-delivery demos.
-- **Discovery:** `GET /.well-known/ssf-configuration` on the issuer (`spec_version` `"1_0"`). Local/demo `issuer` may be `http://` (SSF §7.1 wants `https`).
+- **Discovery:** `GET /.well-known/ssf-configuration` on the issuer (`spec_version` `"1_0"`). Local/demo `issuer` may be `http://` (SSF §7.1 wants `https`). The document includes `authorization_schemes` (`urn:ietf:rfc:6749`) and `default_subjects` `"ALL"`.
 
 ## Runtime Contract
 
@@ -31,6 +31,11 @@
 | `SSF_DATA_DIR` | No | `./data` | SQLite storage directory |
 | `SSF_RECEIVER_PORT` | No | `8081` | Standalone receiver listener port |
 | `SSF_RECEIVER_TOKEN` | No | `(auto-generated)` | Bearer token expected by receiver push delivery |
+| `SSF_AS_ISSUER` | No | `(empty)` | Authorization server `iss` for Stream Management access tokens. Required with `SSF_AS_JWKS_URI` when the Transmitter acts as an OAuth resource server. |
+| `SSF_AS_JWKS_URI` | No | `(empty)` | JWKS URL used to verify those access tokens. When set, Stream Management requires `Authorization: Bearer` or a Looking Glass session. |
+| `SSF_RESOURCE` | No | `SHOWCASE_BASE_URL` | JWT `aud` the Transmitter expects. Federation issues `ssf.read` / `ssf.manage` tokens with this audience. |
+| `SSF_CONFORMANCE_CLIENT_ID` | No | `(empty)` | Confidential client id registered at the main AS for Stream Management. Ignored unless `SSF_CONFORMANCE_CLIENT_SECRET` is also set. |
+| `SSF_CONFORMANCE_CLIENT_SECRET` | No | `(empty)` | Client secret for that confidential client. Never register a secretless confidential client. |
 | `FEDERATION_SERVICE_URL` | No | loopback from `SHOWCASE_LISTEN_ADDR` | Federation base URL for post-CAEP `revoke-subject` |
 | `SSF_TO_FEDERATION_TOKEN` | No | `(empty)` | Bearer token shared with federation for that demo API. Production secret — set via `fly secrets set`, Without it the CAEP `session-revoked` demo hop returns 401. |
 
@@ -56,9 +61,9 @@
 
 ### Stream, Subject, And Delivery APIs
 
-- `POST|GET|PATCH|DELETE /ssf/stream` (nested `delivery`; GET without `stream_id` returns a list)
-- `GET|POST /ssf/status`
-- `POST /ssf/verify` (`stream_id` required; 204 empty)
+- `POST|GET|PATCH|DELETE /ssf/stream` (nested `delivery`; GET without `stream_id` returns that Receiver's stream list, including `[]`)
+- `GET|POST /ssf/status` (`stream_id` required; status body includes `stream_id`)
+- `POST /ssf/verify` (`stream_id` required; `state` optional; 204 empty)
 - `GET|POST /ssf/subjects`
 - `DELETE /ssf/subjects/{id}`
 - `GET|POST /ssf/poll`
@@ -117,6 +122,7 @@ services:
 ## Security Hardening
 
 - Set `SSF_RECEIVER_TOKEN` explicitly outside local demos.
+- Set `SSF_AS_ISSUER` and `SSF_AS_JWKS_URI` when Stream Management is exposed beyond Looking Glass. Tokens are JWTs from the main authorization server (`ssf.read` / `ssf.manage`, client credentials, 900s).
 - Set `SSF_TO_FEDERATION_TOKEN` on both `ssf-service` and `federation-service`.
 - Keep `8081` receiver port internal unless external push testing requires exposure.
 - Restrict `SHOWCASE_CORS_ORIGINS` to trusted frontend origins.

--- a/docs/starlight/src/content/docs/deploy/environment-variables.mdx
+++ b/docs/starlight/src/content/docs/deploy/environment-variables.mdx
@@ -69,6 +69,11 @@ All ProtocolSoup backend services share a common set of core variables. Individu
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SSF_RECEIVER_TOKEN` | - | Bearer token the receiver accepts for event delivery. |
+| `SSF_AS_ISSUER` | - | Authorization server `iss` checked on Stream Management access tokens. |
+| `SSF_AS_JWKS_URI` | - | JWKS URL used to verify Stream Management bearer JWTs. When set, those APIs require `Authorization: Bearer` or `X-Looking-Glass-Session`. |
+| `SSF_RESOURCE` | `SHOWCASE_BASE_URL` | JWT `aud` the SSF Transmitter expects. The OAuth 2.0 token endpoint issues `ssf.read` / `ssf.manage` client-credentials tokens with this audience and a 900 second lifetime. |
+| `SSF_CONFORMANCE_CLIENT_ID` | - | Optional confidential client id registered at process start for Stream Management. Ignored unless `SSF_CONFORMANCE_CLIENT_SECRET` is also set. |
+| `SSF_CONFORMANCE_CLIENT_SECRET` | - | Matching client secret. A secretless confidential client is never registered. Optional `_2` pair: `SSF_CONFORMANCE_CLIENT_ID_2` / `SSF_CONFORMANCE_CLIENT_SECRET_2`. |
 | `FEDERATION_SERVICE_URL` | loopback from listen addr | On the SSF service, federation base URL for CAEP `revoke-subject`. Compose: `http://federation-service:8080`. Fly/monolith: `http://127.0.0.1:8080`. |
 | `SSF_TO_FEDERATION_TOKEN` | - | Shared bearer token; set on both SSF and federation. Production secret — set via `fly secrets set`, never via committed config. Without it the CAEP `session-revoked` demo hop returns 401. |
 

--- a/docs/starlight/src/content/docs/deploy/services/federation.mdx
+++ b/docs/starlight/src/content/docs/deploy/services/federation.mdx
@@ -31,6 +31,7 @@ Use federation when you need OAuth 2.0, OIDC, SAML 2.0, OID4VCI, and OID4VP in a
 - `POST /oauth2/demo/clients/machine-client-pkjwt/jwks` (owned, active-session, one-shot public-key registration)
 - `POST /oauth2/demo/caep/revoke-subject` (SSF CAEP session-revoked hook; bearer `SSF_TO_FEDERATION_TOKEN`)
 - `/oauth2/token` optionally accepts a `DPoP` proof header (RFC 9449), binding the issued access token (and, for `authorization_code` public clients, the refresh token) to the proof's key
+- Client credentials tokens with `ssf.read` / `ssf.manage` last 900 seconds and carry `aud` = `SSF_RESOURCE` (default `SHOWCASE_BASE_URL`)
 
 ### OIDC
 
@@ -67,6 +68,7 @@ Use federation when you need OAuth 2.0, OIDC, SAML 2.0, OID4VCI, and OID4VP in a
 | `OAUTH2_REPLAY_REDIS_URL` | Demo and production | In-memory in development/tests | Shared replay store. Production requires a reachable `rediss://` secret; demo may use `redis://` on a private local network. Also backs the RFC 9449 DPoP proof `jti` replay stores for both oauth2 and OID4VCI. |
 | `SHOWCASE_DPOP_NONCE_REQUIRED` | No | `false` | Enables the RFC 9449 §8 nonce challenge at oauth2's `/oauth2/token` and OID4VCI's own `/oid4vci/token`. |
 | `SHOWCASE_DPOP_RESOURCE_NONCE_REQUIRED` | No | `false` | Enables the same challenge, independently, at OID4VCI's resource-server endpoints. |
+| `SSF_RESOURCE` | No | `SHOWCASE_BASE_URL` | Audience written into `ssf.read` / `ssf.manage` client-credentials tokens |
 | `OID4VP_VERIFIER_ATTESTATION_ISSUER` | No | `<SHOWCASE_BASE_URL>/oid4vp/verifier-attestation` | Issuer URL exposed for `verifier_attestation` metadata and JWKS |
 | `OID4VP_VERIFIER_ATTESTATION_CLIENT_ID` | No | `verifier_attestation:<public-host>` | Verifier client ID used when `client_id_scheme=verifier_attestation` |
 | `OID4VP_VERIFIER_ATTESTATION_PRIVATE_KEY_PEM` | No | Ephemeral in-memory key | PEM-encoded stable signing key for verifier attestation JWTs and JWKS |

--- a/docs/starlight/src/content/docs/deploy/services/ssf.mdx
+++ b/docs/starlight/src/content/docs/deploy/services/ssf.mdx
@@ -25,9 +25,9 @@ Use SSF service to test security event stream configuration, CAEP/RISC event del
 
 ### Transmitter
 
-- `POST|GET|PATCH|DELETE /ssf/stream` -- stream management (nested `delivery`; GET without `stream_id` returns a list)
-- `GET|POST /ssf/status` -- stream status
-- `POST /ssf/verify` -- verification (`stream_id` required; **204**)
+- `POST|GET|PATCH|DELETE /ssf/stream` -- stream management (nested `delivery`; GET without `stream_id` returns that Receiver's list)
+- `GET|POST /ssf/status` -- stream status (`stream_id` required)
+- `POST /ssf/verify` -- verification (`stream_id` required; `state` optional; **204**)
 - `GET|POST /ssf/subjects` -- subject management
 - `POST /ssf/actions/{action}` -- trigger event actions
 - `GET|POST /ssf/poll` -- poll delivery
@@ -63,6 +63,9 @@ Lab action `sessions-revoked` emits CAEP `session-revoked` (all sessions).
 | `SSF_DATA_DIR` | No | `./data` | Stream and receiver state directory |
 | `SSF_RECEIVER_PORT` | No | `8081` | Standalone receiver listener port |
 | `SSF_RECEIVER_TOKEN` | No | auto-generated | Bearer token for push delivery authentication |
+| `SSF_AS_ISSUER` | No | empty | Authorization server issuer for Stream Management JWTs |
+| `SSF_AS_JWKS_URI` | No | empty | JWKS URL used to verify Stream Management access tokens |
+| `SSF_RESOURCE` | No | `SHOWCASE_BASE_URL` | Expected JWT `aud` for those tokens |
 | `FEDERATION_SERVICE_URL` | No | loopback | Federation base URL for CAEP `revoke-subject` |
 | `SSF_TO_FEDERATION_TOKEN` | No | empty | Shared bearer token with federation |
 
@@ -80,7 +83,8 @@ docker run -p 8080:8080 -p 8081:8081 \
 
 - Port `8081` runs the standalone receiver. Keep it private unless you intentionally test external push delivery.
 - Push delivery to `{baseURL}/ssf/receiver/push` is proxied to the internal receiver on port `8081` and returns **202**.
-- Discovery is `GET /.well-known/ssf-configuration` on the issuer (`spec_version` `"1_0"`). Local/demo issuer may be `http://`.
+- Discovery is `GET /.well-known/ssf-configuration` on the issuer (`spec_version` `"1_0"`). Local/demo issuer may be `http://`. The document includes `authorization_schemes` and `default_subjects` `"ALL"`.
+- Stream Management is `stream_id` addressed. When `SSF_AS_JWKS_URI` is set, those endpoints require an OAuth bearer token (`ssf.read` / `ssf.manage`) or a Looking Glass session header. Looking Glass remains a presentation-layer filter; it is not a spec Stream identifier.
 - After a verified CAEP `session-revoked` SET, the receiver POSTs to `FEDERATION_SERVICE_URL/oauth2/demo/caep/revoke-subject` so MockIdP sessions and tokens die. The hop is visible on Looking Glass. If federation is unreachable, the SET still succeeds and the glass box shows the failed outbound request.
 - The receiver validates SETs and executes response actions (session revocation, credential compromise, etc.) via `ReceiverActionExecutor` on this service. RP posture stays in SSF SQLite; OAuth death is the HTTP call above, not shared memory.
 - Looking Glass is the run surface: `/looking-glass?protocol=ssf`. The Flow tab is Looking Glass bus events only. Catalog flow IDs are presets into one durable Looking Glass session. Do not fold this image into federation.

--- a/docs/starlight/src/content/docs/protocols/ssf.mdx
+++ b/docs/starlight/src/content/docs/protocols/ssf.mdx
@@ -58,9 +58,9 @@ The lab action `sessions-revoked` maps to CAEP `session-revoked` (all sessions).
 |------|---------|---------|
 | `/.well-known/ssf-configuration` | GET | SSF discovery (issuer insertion, SSF §7.2) |
 | `/ssf/jwks` | GET | Transmitter JWKS |
-| `/ssf/stream` | POST, GET, PATCH, DELETE | Stream CRUD (`GET` without `stream_id` returns a list; nested `delivery`) |
-| `/ssf/status` | GET, POST | Stream status |
-| `/ssf/verify` | POST | Stream verification (`stream_id` required; **204** empty) |
+| `/ssf/stream` | POST, GET, PATCH, DELETE | Stream CRUD (`GET` without `stream_id` returns that Receiver's list; nested `delivery`) |
+| `/ssf/status` | GET, POST | Stream status (`stream_id` required; body includes `stream_id`) |
+| `/ssf/verify` | POST | Stream verification (`stream_id` required; `state` optional; **204** empty) |
 | `/ssf/subjects` | GET, POST | Subject management |
 | `/ssf/actions/{action}` | POST | Trigger event action |
 | `/ssf/poll` | GET, POST | Poll delivery (RFC 8936 `sets` / `acks` / `setErrs`) |
@@ -96,10 +96,12 @@ Local/demo `issuer` may be `http://` (SSF §7.1 wants `https`). Same lab TLS sto
 ## What To Validate
 
 - Stream configuration: nested `delivery: { method, endpoint_url }`, `events_supported` vs `events_delivered`
-- Discovery: `GET /.well-known/ssf-configuration`, `spec_version` `"1_0"`, `issuer` identical to SET `iss`
-- SET structure: `iss`, `iat`, `jti`, `aud`, `events`, top-level `sub_id`, no JWT `sub`, `typ=secevent+jwt`
-- Push delivery: `Content-Type: application/secevent+jwt`, signature, **202** (not 200)
+- Discovery: `GET /.well-known/ssf-configuration`, `spec_version` `"1_0"`, `issuer` identical to SET `iss`, `authorization_schemes` includes `urn:ietf:rfc:6749`, `default_subjects` `"ALL"`
+- Stream management is `stream_id` addressed. `GET /ssf/stream` without `stream_id` returns that Receiver's list (`[]` when none). Create is **201**. Delete is **204**.
+- Stream Management is an OAuth 2.0 resource server when `SSF_AS_JWKS_URI` is set: `ssf.read` / `ssf.manage`, bearer header only (no query `access_token`)
+- SET structure: `iss`, `iat`, `jti`, `aud`, `events` (exactly one event), top-level `sub_id`, no JWT `sub` or `exp`, `typ=secevent+jwt`, RS256
+- Push delivery: `Content-Type: application/secevent+jwt`, signature, **202** (not 200); push URL is the Receiver's `delivery.endpoint_url`
 - Poll delivery: `sets` map keyed by `jti`; unacknowledged SETs retransmit; `maxEvents: 0` is ack-only; `acks` / `setErrs` on the next poll
-- Verification: `stream_id` required, **204** empty, verification SET `sub_id` opaque stream id
+- Verification: `stream_id` required, **204** empty, verification SET `sub_id` opaque stream id; `state` echoed only when supplied
 - CAEP/RISC members: `namespace` + `current_level`; `credential_type`; `not-compliant`; RISC `reason` only `hijacking` | `bulk-account`
 - Looking Glass Flow tab is the Looking Glass bus only (no executor-local spoof timeline)

--- a/docs/starlight/src/content/docs/using/looking-glass.mdx
+++ b/docs/starlight/src/content/docs/using/looking-glass.mdx
@@ -123,7 +123,7 @@ The built-in token decoder is available at `POST /api/lookingglass/decode`. It h
 SSF is a protocol in Looking Glass (`/looking-glass?protocol=ssf`), not a separate sandbox. Catalog flow IDs (`caep-session-revoked`, `ssf-push-delivery`, …) are presets into one durable session: they fill the subject/event/delivery chrome. They are not a second execute path.
 
 - **Fire event** sends a CAEP/RISC SET for the chrome subject and event. That is what changes RP posture on the State tab (and, for `session-revoked`, the federation revoke-subject hop).
-- **Verify stream** only does `GET /.well-known/ssf-configuration`, `GET /stream`, JWKS, and `POST /verify`. It does not revoke sessions or disable accounts.
+- **Verify stream** only does `GET /.well-known/ssf-configuration`, stream configuration (`GET` list, `POST` create if the list is empty), JWKS, and `POST /verify`. It does not revoke sessions or disable accounts.
 - Transmitter and Receiver timeline plus unstripped SET/JWKS wire capture (Flow tab is Looking Glass bus only)
 - After CAEP `session-revoked`, a real HTTP hop to federation `POST /oauth2/demo/caep/revoke-subject` so OAuth sessions die
 - SET metadata overlay on the Tokens tab (decoded from the signed compact JWT)

--- a/fly.toml
+++ b/fly.toml
@@ -52,8 +52,15 @@ primary_region = 'syd'
   # SCIM Configuration - uses subdirectory of shared volume
   SCIM_DATA_DIR = '/data/scim'
 
-  # SSF stream and RP posture persistence on the shared volume
+	# SSF stream and RP posture persistence on the shared volume
   SSF_DATA_DIR = '/data/ssf'
+
+  # SSF Transmitter as an OAuth 2.0 resource server (CAEP Interop Profile).
+  # The AS is federation on this host; the Transmitter validates bearer JWTs
+  # against the same JWKS. Conformance client secrets are fly secrets, not env.
+  SSF_AS_ISSUER = 'https://protocolsoup.com'
+  SSF_AS_JWKS_URI = 'https://protocolsoup.com/api/.well-known/jwks.json'
+  SSF_RESOURCE = 'https://protocolsoup.com'
 
   # Cross-service CAEP: SSF receiver POSTs to federation over loopback HTTP.
   FEDERATION_SERVICE_URL = 'http://127.0.0.1:8080'
@@ -63,6 +70,10 @@ primary_region = 'syd'
 # - SCIM_API_TOKEN: Bearer token for SCIM authentication
 # - SSF_TO_FEDERATION_TOKEN: Bearer token shared with federation for the CAEP
 #   session-revoked demo hop. Without it the hop returns 401.
+# - SSF_CONFORMANCE_CLIENT_ID / SSF_CONFORMANCE_CLIENT_SECRET: confidential
+#   client_credentials client allowed to call SSF Stream Management (ssf.manage).
+#   Optional SSF_CONFORMANCE_CLIENT_ID_2 / SSF_CONFORMANCE_CLIENT_SECRET_2 for
+#   a second receiver used in isolation tests. Never set an id without a secret.
 # - OAUTH2_REPLAY_REDIS_URL: rediss:// URL for shared private_key_jwt replay protection;
 #   also backs the RFC 9449 DPoP proof jti replay stores for oauth2 and OID4VCI
 #   (distinct key prefix/instance). Optional SHOWCASE_DPOP_NONCE_REQUIRED and

--- a/frontend/src/lookingglass/flows/ssf-lab.ts
+++ b/frontend/src/lookingglass/flows/ssf-lab.ts
@@ -76,7 +76,7 @@ export class SSFLabExecutor extends FlowExecutorBase {
     })
   }
 
-  private async resolveStreamID(): Promise<string> {
+	private async resolveStreamID(): Promise<string> {
     const { data } = await this.jsonRequest('GET', `${this.config.baseUrl}/stream`, {
       step: 'List stream configuration',
       rfcReference: 'OpenID SSF 1.0 Section 8.1.1.2',
@@ -89,7 +89,18 @@ export class SSFLabExecutor extends FlowExecutorBase {
       const id = (data as { stream_id?: string }).stream_id
       if (id) return id
     }
-    throw new Error('stream_id missing from GET /stream')
+    const created = await this.jsonRequest('POST', `${this.config.baseUrl}/stream`, {
+      body: {
+        delivery: { method: SSF_DELIVERY_PUSH },
+      },
+      step: 'Create Event Stream',
+      rfcReference: 'OpenID SSF 1.0 Section 8.1.1.1',
+    })
+    const streamId = (created.data as { stream_id?: string })?.stream_id
+    if (!streamId) {
+      throw new Error('stream_id missing from POST /stream')
+    }
+    return streamId
   }
 
   private async patchDelivery(method: string): Promise<void> {


### PR DESCRIPTION
## What does this PR do?

<!-- Briefly describe the change and its motivation. Link to the related issue if one exists. -->

Aligns the existing SSF transmitter with the OpenID CAEP Interop Profile Stream Management surface for the **push** delivery variant (`ssf_profile=caep_interop`, `delivery_methods=push`).


## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New protocol implementation

## How was this tested?

<!-- Describe how you verified your changes work correctly. -->

- [ ] Ran the affected flow in Looking Glass and verified real-time events
- [ ] Tested locally with `cd backend && go run ./cmd/server` and `cd frontend && npm run dev`
- [x] Other (describe below)

`go test ./internal/protocols/ssf ./internal/protocols/oauth2 ./internal/core` plus the full validation checklist below. New coverage lives in `caep_interop_test.go` (metadata, stream lifecycle without Looking Glass headers, OAuth isolation, query-token rejection, SET profile, external push listener) and `TestSSFClientCredentialsIssuesShortLivedResourceAudience`.


## Validation checklist

<!-- Run the checks that match your change. Mark not applicable items as N/A in the PR description. -->

- [x] Backend: `cd backend && go build ./... && go test ./...`
- [x] Backend lint: `cd backend && golangci-lint run ./...`
- [x] Frontend: `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- [x] Frontend references: `cd frontend && npm run verify-refs`
- [x] JWK thumbprint (RFC 7638): `cd frontend && npm run verify-jwk-thumbprint`
- [x] DPoP proof generation / deep-links (RFC 9449): `cd frontend && npm run verify-dpop`
- [x] Wallet UI: `cd wallet-ui && npx tsc --noEmit && npm run build`
- [x] Docs: `cd docs/starlight && npm run build`
- [x] OpenAPI: `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1`
- [x] Docker/topology: `cd docker && docker compose config`
- [x] OID4VCI/OID4VP conformance: `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1`

## Checklist

<!-- Complete all items before requesting review. -->

- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] I have read the [CONTRIBUTING](https://github.com/ParleSec/ProtocolSoup/blob/master/CONTRIBUTING.md) guide
- [x] I selected the relevant validation checks above
- [x] I have updated documentation if needed
- [x] I have not committed secrets, credentials, or `.env` files

## Screenshots / Looking Glass output

<!-- If this is a UI change or protocol change, include screenshots or Looking Glass timeline output. -->
