### PR TITLE
UPDATE ssf session transmitter streams + isolation

### DIFF
--- a/backend/internal/protocols/ssf/README.md
+++ b/backend/internal/protocols/ssf/README.md
@@ -145,7 +145,14 @@ When `SSF_AS_JWKS_URI` is set, these endpoints require `Authorization: Bearer` w
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/ssf/actions/{action}` | POST | Trigger a security event |
+| `/ssf/actions/{action}` | POST | Trigger a security event for every eligible stream |
+
+A security event is a Transmitter-wide fact. POST `/ssf/actions/{action}`
+delivers a SET to every **enabled** stream that listed the event in
+`events_requested` and has not removed the subject. Looking Glass sessions
+are not mixed: a Fire in session A does not queue SETs on session B's stream.
+OAuth Stream Management Receivers (empty `session_id`), including OIDF poll
+streams, are included.
 
 **Request Body:**
 ```json

--- a/backend/internal/protocols/ssf/caep_interop_test.go
+++ b/backend/internal/protocols/ssf/caep_interop_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -439,9 +440,9 @@ func TestPushDeliveryToReceiverEndpointURL(t *testing.T) {
 
 	status, body := env.doJSON(t, http.MethodPost, "/ssf/stream", "", map[string]any{
 		"delivery": map[string]string{
-			"method":                DeliveryMethodPush,
-			"endpoint_url":          listener.URL,
-			"authorization_header":  "Bearer receiver-supplied",
+			"method":               DeliveryMethodPush,
+			"endpoint_url":         listener.URL,
+			"authorization_header": "Bearer receiver-supplied",
 		},
 	})
 	if status != http.StatusCreated {
@@ -575,7 +576,7 @@ func TestReplaceStreamPUT(t *testing.T) {
 func TestSubjectAddRemoveFiltersTransmission(t *testing.T) {
 	env := startSSFTestEnv(t)
 	status, body := env.doJSON(t, http.MethodPost, "/ssf/stream", "", map[string]any{
-		"delivery": map[string]string{"method": DeliveryMethodPoll},
+		"delivery":         map[string]string{"method": DeliveryMethodPoll},
 		"events_requested": []string{EventTypeSessionRevoked},
 	})
 	if status != http.StatusCreated {
@@ -665,6 +666,758 @@ func TestRevokedAccessTokenRejected(t *testing.T) {
 	status, body = env.doBearerJSON(t, http.MethodGet, "/ssf/stream", token, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatalf("revoked token %d, want 401: %s [CAEPINTEROP Transmitter as RS]", status, body)
+	}
+}
+
+func TestActionFansOutToSpecPollStream(t *testing.T) {
+	env := startSSFTestEnv(t)
+	if err := env.plugin.storage.DeleteStream(t.Context(), "default"); err != nil {
+		t.Fatal(err)
+	}
+
+	status, body := env.doJSON(t, http.MethodPost, "/ssf/stream", "", map[string]any{
+		"delivery": map[string]string{"method": DeliveryMethodPoll},
+		"events_requested": []string{
+			EventTypeSessionRevoked,
+			EventTypeCredentialChange,
+			EventTypeDeviceComplianceChange,
+		},
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create poll stream %d: %s", status, body)
+	}
+	var stream Stream
+	if err := json.Unmarshal(body, &stream); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID, _ := env.session(t)
+	for _, action := range []string{"session-revoked", "credential-change", "device-compliance-change"} {
+		status, body = env.doJSON(t, http.MethodPost, "/ssf/actions/"+action, sessionID, map[string]string{
+			"subject_identifier": "alice@example.com",
+		})
+		if status != http.StatusOK {
+			t.Fatalf("%s %d: %s", action, status, body)
+		}
+	}
+
+	status, body = env.doJSON(t, http.MethodPost, "/ssf/poll/"+stream.ID, "", map[string]any{
+		"maxEvents":         10,
+		"returnImmediately": true,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("poll %d: %s", status, body)
+	}
+	var poll PollResponse
+	if err := json.Unmarshal(body, &poll); err != nil {
+		t.Fatal(err)
+	}
+	if len(poll.Sets) < 3 {
+		t.Fatalf("poll sets %d, want the three CAEP Interop events queued on the spec stream", len(poll.Sets))
+	}
+
+	found := map[string]bool{}
+	for _, raw := range poll.Sets {
+		decoded, err := DecodeWithoutValidation(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, ev := range decoded.Events {
+			found[ev.Type] = true
+		}
+	}
+	for _, uri := range []string{EventTypeSessionRevoked, EventTypeCredentialChange, EventTypeDeviceComplianceChange} {
+		if !found[uri] {
+			t.Errorf("poll missing %s", uri)
+		}
+	}
+}
+
+// oidfCAEPInteropEvents is what OIDSSFPrepareStreamConfigObjectAddRequestedEvents
+// puts on the CAEP Interop transmitter create body.
+var oidfCAEPInteropEvents = []string{
+	EventTypeSessionRevoked,
+	EventTypeCredentialChange,
+	EventTypeDeviceComplianceChange,
+}
+
+func startOAuthSSFEnv(t *testing.T) (*ssfTestEnv, *crypto.JWTService, string) {
+	t.Helper()
+	asKeys, err := crypto.NewKeySet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(asKeys.PublicJWKS())
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	t.Setenv("SSF_AS_ISSUER", "https://as.example")
+	t.Setenv("SSF_AS_JWKS_URI", jwksSrv.URL)
+	env := startSSFTestEnv(t)
+
+	jwtSvc := crypto.NewJWTService(asKeys, "https://as.example")
+	token, err := jwtSvc.CreateAccessToken("client-a", env.server.URL, ScopeSSFManage+" "+ScopeSSFRead, 15*time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return env, jwtSvc, token
+}
+
+func jsonAudience(v interface{}) []string {
+	switch a := v.(type) {
+	case string:
+		if a == "" {
+			return nil
+		}
+		return []string{a}
+	case []string:
+		return a
+	case []interface{}:
+		out := make([]string, 0, len(a))
+		for _, item := range a {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func requireJSONNumber(t *testing.T, payload map[string]interface{}, field string) {
+	t.Helper()
+	raw, ok := payload[field]
+	if !ok {
+		return
+	}
+	switch raw.(type) {
+	case float64, json.Number, int, int64:
+	default:
+		t.Fatalf("%s MUST be a JSON number, got %T %v", field, raw, raw)
+	}
+}
+
+func requireCAEPReasonObject(t *testing.T, payload map[string]interface{}, field string) {
+	t.Helper()
+	raw, ok := payload[field]
+	if !ok {
+		return
+	}
+	obj, ok := raw.(map[string]interface{})
+	if !ok || len(obj) == 0 {
+		t.Fatalf("%s MUST be a non-empty BCP47 object, got %#v", field, raw)
+	}
+	for lang, msg := range obj {
+		if _, ok := msg.(string); !ok || fmt.Sprint(msg) == "" {
+			t.Fatalf("%s[%s] MUST be a non-empty string, got %#v", field, lang, msg)
+		}
+	}
+}
+
+func parseAndAssertOIDFSET(t *testing.T, env *ssfTestEnv, streamAud []string, compact string) (jwt.MapClaims, string, map[string]interface{}) {
+	t.Helper()
+	parsed, err := jwt.Parse(compact, func(token *jwt.Token) (interface{}, error) {
+		return env.plugin.keySet.RSAPublicKey(), nil
+	}, jwt.WithValidMethods([]string{"RS256"}))
+	if err != nil || parsed == nil || !parsed.Valid {
+		t.Fatalf("SET signature/parse: %v [CAEPIOP-2.6 / OIDSSF-4.1]", err)
+	}
+	if fmt.Sprint(parsed.Header["typ"]) != "secevent+jwt" {
+		t.Fatalf("typ %v [SSF §4.1.1]", parsed.Header["typ"])
+	}
+	if fmt.Sprint(parsed.Header["alg"]) != "RS256" {
+		t.Fatalf("alg %v [CAEPIOP Event Signatures]", parsed.Header["alg"])
+	}
+	if fmt.Sprint(parsed.Header["kid"]) == "" {
+		t.Fatal("SET header kid is empty; JWKS lookup would fail")
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("SET claims type")
+	}
+	if _, ok := claims["sub"]; ok {
+		t.Fatal("JWT sub MUST NOT be present [SSF §4.1.2]")
+	}
+	if _, ok := claims["exp"]; ok {
+		t.Fatal("JWT exp MUST NOT be present [SSF §4.1.7]")
+	}
+	if claims["iss"] != env.plugin.baseURL {
+		t.Fatalf("SET iss %v want %s [SSF §4.1.6]", claims["iss"], env.plugin.baseURL)
+	}
+	if iat, ok := claims["iat"].(float64); ok {
+		if time.Unix(int64(iat), 0).After(time.Now().Add(2 * time.Minute)) {
+			t.Fatalf("iat %v is in the future [RFC 8417 §2.2]", iat)
+		}
+	} else {
+		t.Fatalf("iat MUST be a JSON number, got %T %v", claims["iat"], claims["iat"])
+	}
+	setAud := jsonAudience(claims["aud"])
+	if len(setAud) == 0 {
+		t.Fatal("SET aud missing [SSF §4.1.8]")
+	}
+	streamSet := map[string]struct{}{}
+	for _, a := range streamAud {
+		streamSet[a] = struct{}{}
+	}
+	for _, a := range setAud {
+		if _, ok := streamSet[a]; !ok {
+			t.Fatalf("SET aud %v is not a subset of stream aud %v [RFC 7519 §4.1.3]", setAud, streamAud)
+		}
+	}
+	events, _ := claims["events"].(map[string]interface{})
+	if len(events) != 1 {
+		t.Fatalf("events must contain exactly one event, got %#v [CAEPIOP-2.8.1]", events)
+	}
+	var eventURI string
+	var payload map[string]interface{}
+	for uri, raw := range events {
+		eventURI = uri
+		payload, _ = raw.(map[string]interface{})
+	}
+	if payload == nil {
+		t.Fatalf("event payload must be a JSON object, got %#v", events[eventURI])
+	}
+	if _, ok := payload["subject"]; ok {
+		t.Fatal("event object MUST NOT include nested subject [SSF §3.1.2]")
+	}
+	return claims, eventURI, payload
+}
+
+func mustParseSETHeader(t *testing.T, compact string) map[string]interface{} {
+	t.Helper()
+	parsed, _, err := jwt.NewParser().ParseUnverified(compact, jwt.MapClaims{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed.Header
+}
+
+func pollSetsObject(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("poll JSON: %v %s", err, body)
+	}
+	setsRaw, ok := raw["sets"]
+	if !ok || bytes.Equal(bytes.TrimSpace(setsRaw), []byte("null")) {
+		t.Fatalf("poll sets MUST be a JSON object, got null/missing: %s [RFC 8936 §2.4]", body)
+	}
+	var sets map[string]string
+	if err := json.Unmarshal(setsRaw, &sets); err != nil {
+		t.Fatalf("poll sets object: %v %s", err, setsRaw)
+	}
+	if sets == nil {
+		sets = map[string]string{}
+	}
+	return sets
+}
+
+func TestOIDFCAEPInteropPollModuleLocal(t *testing.T) {
+	env, jwtSvc, token := startOAuthSSFEnv(t)
+
+	status, body := env.doJSON(t, http.MethodGet, "/.well-known/ssf-configuration", "", nil)
+	if status != http.StatusOK {
+		t.Fatalf("metadata %d: %s", status, body)
+	}
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata["issuer"] != env.plugin.baseURL {
+		t.Fatalf("issuer %v", metadata["issuer"])
+	}
+	if metadata["spec_version"] != "1_0" {
+		t.Fatalf("spec_version %v", metadata["spec_version"])
+	}
+	if metadata["default_subjects"] != "ALL" {
+		t.Fatalf("default_subjects %v", metadata["default_subjects"])
+	}
+	for key, val := range metadata {
+		if arr, ok := val.([]interface{}); ok && len(arr) == 0 {
+			t.Errorf("metadata %s is an empty array [OIDSSFEnsureNonEmptyArrayClaimsCheck]", key)
+		}
+	}
+	jwksKids := map[string]bool{}
+	for _, key := range []string{"jwks_uri", "configuration_endpoint", "status_endpoint", "verification_endpoint", "add_subject_endpoint", "remove_subject_endpoint"} {
+		val, _ := metadata[key].(string)
+		if val == "" {
+			t.Errorf("missing %s", key)
+		}
+		if strings.HasPrefix(env.plugin.baseURL, "https://") && val != "" && !strings.HasPrefix(val, "https://") {
+			t.Errorf("%s is not HTTPS: %s [SSF §7.1]", key, val)
+		}
+	}
+	jwksURI, _ := metadata["jwks_uri"].(string)
+	if jwksURI == "" {
+		t.Fatal("jwks_uri required [SSF §7.1]")
+	}
+	jwksPath := strings.TrimPrefix(jwksURI, env.server.URL)
+	status, jwksBody := env.doJSON(t, http.MethodGet, jwksPath, "", nil)
+	if status != http.StatusOK {
+		t.Fatalf("transmitter JWKS %d: %s", status, jwksBody)
+	}
+	var jwks crypto.JWKS
+	if err := json.Unmarshal(jwksBody, &jwks); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range jwks.Keys {
+		if k.Kid != "" {
+			jwksKids[k.Kid] = true
+		}
+	}
+	if len(jwksKids) == 0 {
+		t.Fatal("transmitter JWKS has no kids")
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/stream", token, map[string]any{
+		"description":      "Stream for OIDF Conformance Test-Suite",
+		"delivery":         map[string]string{"method": DeliveryMethodPoll},
+		"events_requested": oidfCAEPInteropEvents,
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create %d: %s [SSF §8.1.1.1]", status, body)
+	}
+	var wire map[string]interface{}
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"stream_id", "iss", "aud", "events_delivered", "delivery"} {
+		if _, ok := wire[field]; !ok {
+			t.Errorf("create missing required %s [SSF §8.1.1]", field)
+		}
+	}
+	if wire["iss"] != metadata["issuer"] {
+		t.Fatalf("stream iss %v != metadata issuer %v [SSF §8.1.1.1]", wire["iss"], metadata["issuer"])
+	}
+	streamAud := jsonAudience(wire["aud"])
+	if len(streamAud) == 0 {
+		t.Fatal("stream aud missing")
+	}
+	if streamAud[0] != "client-a" {
+		t.Fatalf("OAuth stream aud %v, want client-a (access-token sub)", streamAud)
+	}
+	delivered, _ := wire["events_delivered"].([]interface{})
+	gotDelivered := map[string]bool{}
+	for _, raw := range delivered {
+		gotDelivered[fmt.Sprint(raw)] = true
+	}
+	for _, uri := range oidfCAEPInteropEvents {
+		if !gotDelivered[uri] {
+			t.Errorf("events_delivered missing %s (suite expects these CAEP types)", uri)
+		}
+	}
+	delivery, _ := wire["delivery"].(map[string]interface{})
+	if fmt.Sprint(delivery["method"]) != DeliveryMethodPoll {
+		t.Fatalf("delivery.method %v [CAEPIOP-2.3.8.1]", delivery["method"])
+	}
+	streamID := fmt.Sprint(wire["stream_id"])
+	pollURL := fmt.Sprint(delivery["endpoint_url"])
+	wantPoll := env.server.URL + "/ssf/poll/" + streamID
+	if pollURL != wantPoll {
+		t.Fatalf("poll endpoint_url %q want %q [SSF §6.1.2]", pollURL, wantPoll)
+	}
+	pollPath := "/ssf/poll/" + streamID
+
+	status, body = env.doBearerJSON(t, http.MethodGet, "/ssf/stream?stream_id="+streamID, token, nil)
+	if status != http.StatusOK {
+		t.Fatalf("GET stream %d: %s [SSF §8.1.1.2]", status, body)
+	}
+	var readBack map[string]interface{}
+	if err := json.Unmarshal(body, &readBack); err != nil {
+		t.Fatal(err)
+	}
+	if readBack["stream_id"] != streamID {
+		t.Fatalf("GET stream_id %v", readBack["stream_id"])
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodGet, "/ssf/status?stream_id="+streamID, token, nil)
+	if status != http.StatusOK {
+		t.Fatalf("status %d: %s [SSF §8.1.2.1]", status, body)
+	}
+	var st map[string]interface{}
+	if err := json.Unmarshal(body, &st); err != nil {
+		t.Fatal(err)
+	}
+	if st["stream_id"] != streamID || st["status"] != StreamStatusEnabled {
+		t.Fatalf("status body %#v", st)
+	}
+
+	verifyState := "oidf-local-verify-state"
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/verify", token, map[string]string{
+		"stream_id": streamID,
+		"state":     verifyState,
+	})
+	if status != http.StatusNoContent {
+		t.Fatalf("verify %d: %s [SSF §8.1.4.2]", status, body)
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodPost, pollPath, token, map[string]any{
+		"maxEvents":         10,
+		"returnImmediately": true,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("POLL_ONLY %d: %s [RFC 8936]", status, body)
+	}
+	sets := pollSetsObject(t, body)
+	if len(sets) == 0 {
+		t.Fatal("POLL_ONLY after verify returned empty sets; verification SET was not queued")
+	}
+	var verifyJTI string
+	for jti, compact := range sets {
+		if compact == "" || strings.Count(compact, ".") != 2 {
+			t.Fatalf("poll set %s is not a compact JWT", jti)
+		}
+		claims, eventURI, payload := parseAndAssertOIDFSET(t, env, streamAud, compact)
+		if kid := fmt.Sprint(mustParseSETHeader(t, compact)["kid"]); !jwksKids[kid] {
+			t.Fatalf("SET kid %q not in transmitter JWKS", kid)
+		}
+		if eventURI != EventTypeVerification {
+			t.Fatalf("first poll expected verification, got %s", eventURI)
+		}
+		if fmt.Sprint(claims["jti"]) != jti {
+			t.Fatalf("poll key %s != SET jti %v [RFC 8936 §2.4]", jti, claims["jti"])
+		}
+		subID, _ := claims["sub_id"].(map[string]interface{})
+		if fmt.Sprint(subID["format"]) != SubjectFormatOpaque || fmt.Sprint(subID["id"]) != streamID {
+			t.Fatalf("verification sub_id %#v [SSF §8.1.4.1]", subID)
+		}
+		if fmt.Sprint(payload["state"]) != verifyState {
+			t.Fatalf("verification state %v want %s [SSF §8.1.4.2]", payload["state"], verifyState)
+		}
+		verifyJTI = jti
+	}
+
+	for _, action := range []string{"session-revoked", "credential-change", "device-compliance-change"} {
+		status, body = env.doJSON(t, http.MethodPost, "/ssf/actions/"+action, "", map[string]string{
+			"subject_identifier": "alice@example.com",
+		})
+		if status != http.StatusOK {
+			t.Fatalf("Fire %s without Looking Glass session %d: %s", action, status, body)
+		}
+	}
+
+	ack := make([]string, 0, len(sets))
+	for jti := range sets {
+		ack = append(ack, jti)
+	}
+	status, body = env.doBearerJSON(t, http.MethodPost, pollPath, token, map[string]any{
+		"ack":               ack,
+		"maxEvents":         10,
+		"returnImmediately": true,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("POLL_AND_ACK %d: %s", status, body)
+	}
+	caepSets := pollSetsObject(t, body)
+	if _, still := caepSets[verifyJTI]; still {
+		t.Fatal("acknowledged verification SET was retransmitted")
+	}
+
+	received := map[string]bool{}
+	for jti, compact := range caepSets {
+		claims, eventURI, payload := parseAndAssertOIDFSET(t, env, streamAud, compact)
+		if fmt.Sprint(claims["jti"]) != jti {
+			t.Fatalf("poll key %s != SET jti %v", jti, claims["jti"])
+		}
+		received[eventURI] = true
+		requireJSONNumber(t, payload, "event_timestamp")
+		if raw, ok := payload["initiating_entity"]; ok {
+			switch fmt.Sprint(raw) {
+			case InitiatingEntityAdmin, InitiatingEntityUser, InitiatingEntityPolicy, InitiatingEntitySystem:
+			default:
+				t.Fatalf("initiating_entity %v [CAEP §2]", raw)
+			}
+		}
+		requireCAEPReasonObject(t, payload, "reason_admin")
+		requireCAEPReasonObject(t, payload, "reason_user")
+		switch eventURI {
+		case EventTypeCredentialChange:
+			cred, _ := payload["credential_type"].(string)
+			change, _ := payload["change_type"].(string)
+			if cred == "" || change == "" {
+				t.Fatalf("credential-change missing string fields %#v [CAEP §3.3]", payload)
+			}
+		case EventTypeDeviceComplianceChange:
+			cur, _ := payload["current_status"].(string)
+			prev, _ := payload["previous_status"].(string)
+			if cur != ComplianceStatusCompliant && cur != ComplianceStatusNonCompliant {
+				t.Fatalf("current_status %q [CAEP §3.5]", cur)
+			}
+			if prev != ComplianceStatusCompliant && prev != ComplianceStatusNonCompliant {
+				t.Fatalf("previous_status %q [CAEP §3.5]", prev)
+			}
+			subID, _ := claims["sub_id"].(map[string]interface{})
+			if fmt.Sprint(subID["format"]) != SubjectFormatComplex {
+				t.Fatalf("device-compliance sub_id %#v [CAEP §3.5]", subID)
+			}
+		case EventTypeSessionRevoked:
+		case EventTypeVerification:
+		default:
+			t.Fatalf("unexpected event type on CAEP Interop stream: %s", eventURI)
+		}
+	}
+	for _, uri := range oidfCAEPInteropEvents {
+		if !received[uri] {
+			t.Errorf("POLL_AND_ACK missing %s (OIDF OIDSSFEnsureAllCaepInteropEventsReceived)", uri)
+		}
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodPost, pollPath, token, map[string]any{
+		"ack":               keysOf(caepSets),
+		"maxEvents":         10,
+		"returnImmediately": true,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("empty POLL_AND_ACK %d: %s", status, body)
+	}
+	if leftover := pollSetsObject(t, body); len(leftover) != 0 {
+		t.Fatalf("expected empty sets after ack, got %d", len(leftover))
+	}
+
+	readOnly, err := jwtSvc.CreateAccessToken("client-a", env.server.URL, ScopeSSFRead, 15*time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, body = env.doBearerJSON(t, http.MethodPost, pollPath, readOnly, map[string]any{
+		"maxEvents":         10,
+		"returnImmediately": true,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("ssf.read poll %d: %s [CAEPIOP OAuth Scopes]", status, body)
+	}
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/verify", readOnly, map[string]string{
+		"stream_id": streamID,
+		"state":     "should-fail-scope",
+	})
+	if status != http.StatusForbidden {
+		t.Fatalf("ssf.read verify %d, want 403: %s", status, body)
+	}
+	status, body = env.doBearerJSON(t, http.MethodDelete, "/ssf/stream?stream_id="+streamID, readOnly, nil)
+	if status != http.StatusForbidden {
+		t.Fatalf("ssf.read delete %d, want 403: %s", status, body)
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodDelete, "/ssf/stream?stream_id="+streamID, token, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("delete %d: %s [SSF §8.1.1.5]", status, body)
+	}
+	status, body = env.doBearerJSON(t, http.MethodGet, "/ssf/stream?stream_id="+streamID, token, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("GET deleted stream %d, want 404: %s", status, body)
+	}
+}
+
+func TestOIDFCAEPInteropPushModuleLocal(t *testing.T) {
+	env, _, token := startOAuthSSFEnv(t)
+
+	type pushed struct {
+		ct, auth, lg string
+		body         string
+	}
+	var mu sync.Mutex
+	var got []pushed
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		got = append(got, pushed{
+			ct:   r.Header.Get("Content-Type"),
+			auth: r.Header.Get("Authorization"),
+			lg:   r.Header.Get(lookingGlassSessionHeader),
+			body: string(raw),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(listener.Close)
+
+	status, body := env.doBearerJSON(t, http.MethodPost, "/ssf/stream", token, map[string]any{
+		"description": "Stream for OIDF Conformance Test-Suite",
+		"delivery": map[string]string{
+			"method":               DeliveryMethodPush,
+			"endpoint_url":         listener.URL,
+			"authorization_header": "Bearer oidf-push",
+		},
+		"events_requested": oidfCAEPInteropEvents,
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create %d: %s", status, body)
+	}
+	var wire map[string]interface{}
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatal(err)
+	}
+	streamID := fmt.Sprint(wire["stream_id"])
+	streamAud := jsonAudience(wire["aud"])
+	delivery, _ := wire["delivery"].(map[string]interface{})
+	if fmt.Sprint(delivery["method"]) != DeliveryMethodPush || fmt.Sprint(delivery["endpoint_url"]) != listener.URL {
+		t.Fatalf("push delivery %#v", delivery)
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/verify", token, map[string]string{
+		"stream_id": streamID,
+		"state":     "oidf-push-state",
+	})
+	if status != http.StatusNoContent {
+		t.Fatalf("verify %d: %s", status, body)
+	}
+	for _, action := range []string{"session-revoked", "credential-change", "device-compliance-change"} {
+		status, body = env.doJSON(t, http.MethodPost, "/ssf/actions/"+action, "", map[string]string{
+			"subject_identifier": "alice@example.com",
+		})
+		if status != http.StatusOK {
+			t.Fatalf("Fire %s %d: %s", action, status, body)
+		}
+	}
+
+	mu.Lock()
+	received := append([]pushed(nil), got...)
+	mu.Unlock()
+	if len(received) < 4 {
+		t.Fatalf("push deliveries %d, want verification + 3 CAEP", len(received))
+	}
+	found := map[string]bool{}
+	for _, p := range received {
+		if p.ct != "application/secevent+jwt" {
+			t.Errorf("Content-Type %q [RFC 8935]", p.ct)
+		}
+		if p.auth != "Bearer oidf-push" {
+			t.Errorf("Authorization %q [SSF §6.1.1]", p.auth)
+		}
+		if p.lg != "" {
+			t.Errorf("must not send Looking Glass header to external push URL, got %q", p.lg)
+		}
+		_, eventURI, payload := parseAndAssertOIDFSET(t, env, streamAud, p.body)
+		found[eventURI] = true
+		if eventURI == EventTypeVerification && fmt.Sprint(payload["state"]) != "oidf-push-state" {
+			t.Fatalf("verification state %v", payload["state"])
+		}
+	}
+	for _, uri := range append([]string{EventTypeVerification}, oidfCAEPInteropEvents...) {
+		if !found[uri] {
+			t.Errorf("push missing %s", uri)
+		}
+	}
+
+	status, _ = env.doBearerJSON(t, http.MethodDelete, "/ssf/stream?stream_id="+streamID, token, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("delete %d", status)
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestOIDFCAEPInteropNegativePaths(t *testing.T) {
+	env, jwtSvc, token := startOAuthSSFEnv(t)
+
+	req, err := http.NewRequest(http.MethodPost, env.server.URL+"/ssf/stream", strings.NewReader(";{ broken"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("broken JSON create %d, want 400: %s [SSF §8.1.1.1]", resp.StatusCode, raw)
+	}
+
+	status, body := env.doBearerJSON(t, http.MethodPost, "/ssf/stream", "not-a-jwt", map[string]any{
+		"delivery": map[string]string{"method": DeliveryMethodPoll},
+	})
+	if status != http.StatusUnauthorized {
+		t.Fatalf("invalid token create %d, want 401: %s [SSF §8.1.1.1]", status, body)
+	}
+
+	req, err = http.NewRequest(http.MethodGet, env.server.URL+"/ssf/stream", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("missing Authorization %d, want 401: %s", resp.StatusCode, raw)
+	}
+
+	q := env.server.URL + "/ssf/stream?access_token=" + token
+	req, err = http.NewRequest(http.MethodGet, q, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("query access_token was accepted: %s [RFC 6750 §2.3]", raw)
+	}
+
+	createBody := map[string]any{
+		"delivery":         map[string]string{"method": DeliveryMethodPoll},
+		"events_requested": oidfCAEPInteropEvents,
+	}
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/stream", token, createBody)
+	if status != http.StatusCreated {
+		t.Fatalf("first create %d: %s", status, body)
+	}
+	var first Stream
+	if err := json.Unmarshal(body, &first); err != nil {
+		t.Fatal(err)
+	}
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/stream", token, createBody)
+	if status != http.StatusCreated && status != http.StatusConflict {
+		t.Fatalf("duplicate create %d, want 201 or 409: %s [SSF §8.1.1.1]", status, body)
+	}
+
+	status, _ = env.doBearerJSON(t, http.MethodDelete, "/ssf/stream?stream_id="+first.ID, token, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("delete %d", status)
+	}
+	status, body = env.doBearerJSON(t, http.MethodGet, "/ssf/stream?stream_id="+first.ID, token, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("GET unknown stream %d, want 404: %s [SSF §8.1.1.2]", status, body)
+	}
+	status, body = env.doBearerJSON(t, http.MethodDelete, "/ssf/stream?stream_id="+first.ID, token, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("DELETE unknown stream %d, want 404: %s [SSF §8.1.1.5]", status, body)
+	}
+
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/stream", token, createBody)
+	if status != http.StatusCreated {
+		t.Fatalf("recreate %d: %s", status, body)
+	}
+	var owned Stream
+	if err := json.Unmarshal(body, &owned); err != nil {
+		t.Fatal(err)
+	}
+	tokenB, err := jwtSvc.CreateAccessToken("client-b", env.server.URL, ScopeSSFManage+" "+ScopeSSFRead, 15*time.Minute, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, body = env.doBearerJSON(t, http.MethodPost, "/ssf/poll/"+owned.ID, tokenB, map[string]any{
+		"maxEvents":         10,
+		"returnImmediately": true,
+	})
+	if status != http.StatusForbidden {
+		t.Fatalf("client-b poll of client-a stream %d, want 403: %s [SSF §8]", status, body)
 	}
 }
 

--- a/backend/internal/protocols/ssf/handlers.go
+++ b/backend/internal/protocols/ssf/handlers.go
@@ -61,9 +61,9 @@ func (p *Plugin) handleSSFConfiguration(w http.ResponseWriter, r *http.Request) 
 			DeliveryMethodPush,
 			DeliveryMethodPoll,
 		},
-		"configuration_endpoint": p.baseURL + "/ssf/stream",
-		"status_endpoint":        p.baseURL + "/ssf/status",
-		"verification_endpoint":  p.baseURL + "/ssf/verify",
+		"configuration_endpoint":  p.baseURL + "/ssf/stream",
+		"status_endpoint":         p.baseURL + "/ssf/status",
+		"verification_endpoint":   p.baseURL + "/ssf/verify",
 		"add_subject_endpoint":    p.baseURL + "/ssf/subjects/add",
 		"remove_subject_endpoint": p.baseURL + "/ssf/subjects/remove",
 		"authorization_schemes": []map[string]string{
@@ -531,7 +531,10 @@ func (p *Plugin) handleRemoveSubject(w http.ResponseWriter, r *http.Request) {
 // Action Handlers (Interactive Triggers)
 // ====================
 
-// handleTriggerAction handles all action triggers
+// handleTriggerAction handles all action triggers. A security event is a
+// Transmitter-wide fact: every enabled stream that requested the event type
+// and still includes the subject receives a SET (push or poll). Looking Glass
+// sessions stay isolated from each other.
 func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 	action := chi.URLParam(r, "action")
 	sessionID := getSessionID(r)
@@ -547,20 +550,75 @@ func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var stream *Stream
-	var err error
-
 	if sessionID != "" {
-		stream, err = p.storage.GetSessionStream(r.Context(), sessionID, p.baseURL, p.receiverEndpoint, p.receiverToken)
-	} else {
-		stream, err = p.storage.GetDefaultStream(r.Context(), p.baseURL)
+		if _, err := p.storage.GetSessionStream(r.Context(), sessionID, p.baseURL, p.receiverEndpoint, p.receiverToken); err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to get stream")
+			return
+		}
 	}
 
+	streams, err := p.storage.ListStreams(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "Failed to get stream")
+		writeError(w, http.StatusInternalServerError, "Failed to list streams")
 		return
 	}
 
+	var (
+		primary       *StoredEvent
+		primaryStream *Stream
+		delivered     int
+		hardErr       error
+	)
+	for i := range streams {
+		stream := streams[i]
+		if stream.SessionID != "" && stream.SessionID != sessionID {
+			continue
+		}
+		event, triggerErr := p.triggerActionOnStream(r.Context(), action, stream.ID, sessionID, req)
+		if triggerErr != nil {
+			if strings.HasPrefix(triggerErr.Error(), "Unknown action:") {
+				writeError(w, http.StatusBadRequest, triggerErr.Error())
+				return
+			}
+			if skippableDeliveryErr(triggerErr) {
+				continue
+			}
+			hardErr = triggerErr
+			continue
+		}
+		delivered++
+		if primary == nil || stream.SessionID == sessionID {
+			primary = event
+			s := stream
+			primaryStream = &s
+		}
+	}
+
+	if primary == nil {
+		if hardErr != nil {
+			writeError(w, http.StatusInternalServerError, hardErr.Error())
+			return
+		}
+		writeError(w, http.StatusNotFound, "no enabled stream accepts this event")
+		return
+	}
+
+	metadata := GetEventMetadata(primary.EventType)
+	writeJSON(w, http.StatusOK, ActionResponse{
+		EventID:          primary.ID,
+		EventType:        primary.EventType,
+		EventName:        metadata.Name,
+		Category:         string(metadata.Category),
+		Subject:          req.SubjectIdentifier,
+		Status:           primary.Status,
+		DeliveryMethod:   primaryStream.DeliveryMethod,
+		ResponseActions:  metadata.ResponseActions,
+		ZeroTrustImpact:  metadata.ZeroTrustImpact,
+		StreamsDelivered: delivered,
+	})
+}
+
+func (p *Plugin) triggerActionOnStream(ctx context.Context, action, streamID, sessionID string, req ActionRequest) (*StoredEvent, error) {
 	subject := SubjectIdentifier{
 		Format: SubjectFormatEmail,
 		Email:  req.SubjectIdentifier,
@@ -571,15 +629,13 @@ func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 		initiator = InitiatingEntityAdmin
 	}
 
-	var event *StoredEvent
-
 	switch action {
 	case "session-revoked":
 		reason := req.Reason
 		if reason == "" {
 			reason = "Session revoked by administrator"
 		}
-		event, err = p.transmitter.TriggerSessionRevokedWithSession(r.Context(), stream.ID, sessionID, subject, reason, initiator)
+		return p.transmitter.TriggerSessionRevokedWithSession(ctx, streamID, sessionID, subject, reason, initiator)
 
 	case "credential-change":
 		credType := req.CredentialType
@@ -590,7 +646,7 @@ func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 		if changeType == "" {
 			changeType = "update" // CAEP §3.3 default
 		}
-		event, err = p.transmitter.TriggerCredentialChangeWithSession(r.Context(), stream.ID, sessionID, subject, credType, changeType, initiator)
+		return p.transmitter.TriggerCredentialChangeWithSession(ctx, streamID, sessionID, subject, credType, changeType, initiator)
 
 	case "device-compliance-change":
 		current := req.CurrentStatus
@@ -601,7 +657,7 @@ func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 		if previous == "" {
 			previous = ComplianceStatusCompliant
 		}
-		event, err = p.transmitter.TriggerDeviceComplianceChangeWithSession(r.Context(), stream.ID, sessionID, subject, current, previous)
+		return p.transmitter.TriggerDeviceComplianceChangeWithSession(ctx, streamID, sessionID, subject, current, previous)
 
 	case "credential-compromise":
 		reason := req.Reason
@@ -612,25 +668,23 @@ func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 		if credType == "" {
 			credType = CredentialTypePassword
 		}
-		event, err = p.transmitter.TriggerCredentialCompromiseWithSession(r.Context(), stream.ID, sessionID, subject, reason, credType)
+		return p.transmitter.TriggerCredentialCompromiseWithSession(ctx, streamID, sessionID, subject, reason, credType)
 
 	case "account-disabled":
-		reason := req.Reason
-		event, err = p.transmitter.TriggerAccountDisabledWithSession(r.Context(), stream.ID, sessionID, subject, reason, initiator)
+		return p.transmitter.TriggerAccountDisabledWithSession(ctx, streamID, sessionID, subject, req.Reason, initiator)
 
 	case "account-enabled":
-		event, err = p.transmitter.TriggerAccountEnabledWithSession(r.Context(), stream.ID, sessionID, subject, initiator)
+		return p.transmitter.TriggerAccountEnabledWithSession(ctx, streamID, sessionID, subject, initiator)
 
 	case "account-purged":
-		event, err = p.transmitter.TriggerAccountPurgedWithSession(r.Context(), stream.ID, sessionID, subject, initiator)
+		return p.transmitter.TriggerAccountPurgedWithSession(ctx, streamID, sessionID, subject, initiator)
 
 	case "identifier-changed":
 		newValue := req.NewValue
 		if newValue == "" {
-			// Default: simulate an email change for the subject
 			newValue = "updated-" + req.SubjectIdentifier
 		}
-		event, err = p.transmitter.TriggerIdentifierChangedWithSession(r.Context(), stream.ID, sessionID, subject,
+		return p.transmitter.TriggerIdentifierChangedWithSession(ctx, streamID, sessionID, subject,
 			req.SubjectIdentifier, newValue, initiator)
 
 	case "assurance-level-change":
@@ -646,71 +700,44 @@ func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 		if namespace == "" {
 			namespace = AssuranceNamespaceNIST
 		}
-		event, err = p.transmitter.TriggerAssuranceLevelChangeWithSession(r.Context(), stream.ID, sessionID, subject, current, previous, namespace)
+		return p.transmitter.TriggerAssuranceLevelChangeWithSession(ctx, streamID, sessionID, subject, current, previous, namespace)
 
 	case "token-claims-change":
-		// CAEP §3.2: claims is a JSON object of changed claim names -> new values
 		claims := map[string]interface{}{
 			"role":  "viewer",
 			"group": []string{"security-team"},
 			"exp":   time.Now().Add(1 * time.Hour).Unix(),
 		}
 		if req.CurrentStatus != "" {
-			claims["role"] = req.CurrentStatus // allow overriding via request
+			claims["role"] = req.CurrentStatus
 		}
-		event, err = p.transmitter.TriggerTokenClaimsChangeWithSession(r.Context(), stream.ID, sessionID, subject, claims)
+		return p.transmitter.TriggerTokenClaimsChangeWithSession(ctx, streamID, sessionID, subject, claims)
 
 	case "identifier-recycled":
-		oldValue := req.SubjectIdentifier // current subject is the new holder
+		oldValue := req.SubjectIdentifier
 		newValue := req.NewValue
 		if newValue == "" {
-			newValue = "recycled-" + req.SubjectIdentifier // show what the identifier was reassigned to
+			newValue = "recycled-" + req.SubjectIdentifier
 		}
-		event, err = p.transmitter.TriggerIdentifierRecycledWithSession(r.Context(), stream.ID, sessionID, subject, oldValue, newValue)
+		return p.transmitter.TriggerIdentifierRecycledWithSession(ctx, streamID, sessionID, subject, oldValue, newValue)
 
 	case "account-credential-change-required":
 		reason := req.Reason
 		if reason == "" {
 			reason = "Credential rotation policy triggered"
 		}
-		event, err = p.transmitter.TriggerAccountCredentialChangeRequiredWithSession(r.Context(), stream.ID, sessionID, subject, reason, initiator)
+		return p.transmitter.TriggerAccountCredentialChangeRequiredWithSession(ctx, streamID, sessionID, subject, reason, initiator)
 
 	case "sessions-revoked":
-		// RISC §2.11: emit CAEP session-revoked for all sessions, not RISC sessions-revoked.
 		reason := req.Reason
 		if reason == "" {
 			reason = "All sessions revoked due to security incident"
 		}
-		event, err = p.transmitter.TriggerSessionsRevokedWithSession(r.Context(), stream.ID, sessionID, subject, reason, initiator)
+		return p.transmitter.TriggerSessionsRevokedWithSession(ctx, streamID, sessionID, subject, reason, initiator)
 
 	default:
-		writeError(w, http.StatusBadRequest, "Unknown action: "+action)
-		return
+		return nil, fmt.Errorf("Unknown action: %s", action)
 	}
-
-	if err != nil {
-		if err == ErrSubjectNotInStream {
-			writeError(w, http.StatusForbidden, err.Error())
-			return
-		}
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	// Get event metadata for response
-	metadata := GetEventMetadata(event.EventType)
-
-	writeJSON(w, http.StatusOK, ActionResponse{
-		EventID:         event.ID,
-		EventType:       event.EventType,
-		EventName:       metadata.Name,
-		Category:        string(metadata.Category),
-		Subject:         req.SubjectIdentifier,
-		Status:          event.Status,
-		DeliveryMethod:  stream.DeliveryMethod,
-		ResponseActions: metadata.ResponseActions,
-		ZeroTrustImpact: metadata.ZeroTrustImpact,
-	})
 }
 
 // ActionRequest represents a request to trigger an action
@@ -728,15 +755,16 @@ type ActionRequest struct {
 
 // ActionResponse represents the response after triggering an action
 type ActionResponse struct {
-	EventID         string                   `json:"event_id"`
-	EventType       string                   `json:"event_type"`
-	EventName       string                   `json:"event_name"`
-	Category        string                   `json:"category"`
-	Subject         string                   `json:"subject"`
-	Status          string                   `json:"status"`
-	DeliveryMethod  string                   `json:"delivery_method"`
-	ResponseActions []string                 `json:"response_actions"`
-	ZeroTrustImpact string   `json:"zero_trust_impact"`
+	EventID          string   `json:"event_id"`
+	EventType        string   `json:"event_type"`
+	EventName        string   `json:"event_name"`
+	Category         string   `json:"category"`
+	Subject          string   `json:"subject"`
+	Status           string   `json:"status"`
+	DeliveryMethod   string   `json:"delivery_method"`
+	ResponseActions  []string `json:"response_actions"`
+	ZeroTrustImpact  string   `json:"zero_trust_impact"`
+	StreamsDelivered int      `json:"streams_delivered"`
 }
 
 // ====================
@@ -1059,7 +1087,6 @@ func (p *Plugin) handleDecodeSET(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, decoded)
 }
-
 
 // ====================
 // Helpers

--- a/backend/internal/protocols/ssf/handlers.go
+++ b/backend/internal/protocols/ssf/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -531,6 +532,8 @@ func (p *Plugin) handleRemoveSubject(w http.ResponseWriter, r *http.Request) {
 // Action Handlers (Interactive Triggers)
 // ====================
 
+var errUnknownAction = errors.New("unknown action")
+
 // handleTriggerAction handles all action triggers. A security event is a
 // Transmitter-wide fact: every enabled stream that requested the event type
 // and still includes the subject receives a SET (push or poll). Looking Glass
@@ -576,7 +579,7 @@ func (p *Plugin) handleTriggerAction(w http.ResponseWriter, r *http.Request) {
 		}
 		event, triggerErr := p.triggerActionOnStream(r.Context(), action, stream.ID, sessionID, req)
 		if triggerErr != nil {
-			if strings.HasPrefix(triggerErr.Error(), "Unknown action:") {
+			if errors.Is(triggerErr, errUnknownAction) {
 				writeError(w, http.StatusBadRequest, triggerErr.Error())
 				return
 			}
@@ -736,7 +739,7 @@ func (p *Plugin) triggerActionOnStream(ctx context.Context, action, streamID, se
 		return p.transmitter.TriggerSessionsRevokedWithSession(ctx, streamID, sessionID, subject, reason, initiator)
 
 	default:
-		return nil, fmt.Errorf("Unknown action: %s", action)
+		return nil, fmt.Errorf("%w: %s", errUnknownAction, action)
 	}
 }
 

--- a/backend/internal/protocols/ssf/plugin_test.go
+++ b/backend/internal/protocols/ssf/plugin_test.go
@@ -577,6 +577,10 @@ func TestLookingGlassSessionIsolation(t *testing.T) {
 	env := startSSFTestEnv(t)
 	sessionA, _ := env.session(t)
 	sessionB, _ := env.session(t)
+	_ = env.sessionStreamID(t, sessionA)
+	streamB := env.sessionStreamID(t, sessionB)
+	sessBBefore, _ := env.lg.GetSession(sessionB)
+	eventsBeforeB := len(sessBBefore.Events)
 
 	status, body := env.doJSON(t, http.MethodPost, "/ssf/actions/session-revoked", sessionA, map[string]string{
 		"subject_identifier": "alice@example.com",
@@ -590,8 +594,15 @@ func TestLookingGlassSessionIsolation(t *testing.T) {
 	if len(sessA.Events) == 0 {
 		t.Fatal("session A should receive transmitter/receiver events")
 	}
-	if len(sessB.Events) != 0 {
-		t.Fatalf("session B leaked %d events from session A", len(sessB.Events))
+	if len(sessB.Events) != eventsBeforeB {
+		t.Fatalf("session B leaked %d events from session A", len(sessB.Events)-eventsBeforeB)
+	}
+	pendingB, err := env.plugin.storage.GetPendingEvents(t.Context(), streamB, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pendingB) != 0 {
+		t.Fatalf("session B stream queued %d events from session A fire", len(pendingB))
 	}
 }
 

--- a/backend/internal/protocols/ssf/transmitter.go
+++ b/backend/internal/protocols/ssf/transmitter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -29,6 +30,21 @@ type Transmitter struct {
 	// Event broadcast channels
 	eventListeners []chan<- TransmitterEvent
 	listenerMu     sync.RWMutex
+}
+
+// Delivery skip errors: the Transmitter omits this stream and continues
+// fan-out to other Receivers.
+var (
+	ErrStreamDisabled    = errors.New("stream is disabled")
+	ErrStreamPaused      = errors.New("stream is paused")
+	ErrEventNotRequested = errors.New("event type not requested by receiver")
+)
+
+func skippableDeliveryErr(err error) bool {
+	return errors.Is(err, ErrSubjectNotInStream) ||
+		errors.Is(err, ErrStreamDisabled) ||
+		errors.Is(err, ErrStreamPaused) ||
+		errors.Is(err, ErrEventNotRequested)
 }
 
 // TransmitterEvent represents an event in the transmission pipeline
@@ -119,9 +135,9 @@ func (t *Transmitter) GenerateEvent(ctx context.Context, streamID string, event 
 	if !frameworkEvent {
 		switch stream.Status {
 		case StreamStatusDisabled:
-			return nil, fmt.Errorf("stream is disabled")
+			return nil, ErrStreamDisabled
 		case StreamStatusPaused:
-			return nil, fmt.Errorf("stream is paused")
+			return nil, ErrStreamPaused
 		case StreamStatusEnabled, "":
 		}
 	}
@@ -137,7 +153,7 @@ func (t *Transmitter) GenerateEvent(ctx context.Context, streamID string, event 
 			}
 		}
 		if !eventRequested {
-			return nil, fmt.Errorf("event type %s not requested by receiver", event.EventType)
+			return nil, fmt.Errorf("%w: %s", ErrEventNotRequested, event.EventType)
 		}
 
 		allowed, allowErr := t.storage.SubjectIsTransmittable(ctx, streamID, subjectToClaim(event.Subject))
@@ -212,7 +228,7 @@ func (t *Transmitter) GenerateEvent(ctx context.Context, streamID string, event 
 		SubjectID: event.Subject.Email,
 		EventType: event.EventType,
 		SessionID: event.SessionID,
-		Data: glassData,
+		Data:      glassData,
 	})
 
 	// Broadcast: SET Signed

--- a/docs/packages/ssf.md
+++ b/docs/packages/ssf.md
@@ -70,7 +70,7 @@
 
 ### Lab And Inspection APIs
 
-- `POST /ssf/actions/{action}`
+- `POST /ssf/actions/{action}` -- transmitter-wide event: every enabled stream that requested the type and still includes the subject gets a SET (Looking Glass sessions stay isolated from each other)
 - `GET /ssf/events`
 - `GET /ssf/received`
 - `GET /ssf/responses`

--- a/docs/starlight/src/content/docs/deploy/services/ssf.mdx
+++ b/docs/starlight/src/content/docs/deploy/services/ssf.mdx
@@ -31,7 +31,7 @@ Use SSF service to test security event stream configuration, CAEP/RISC event del
 - `GET /ssf/subjects` -- Looking Glass demo identities
 - `POST /ssf/subjects/add` -- add subject (`stream_id` + RFC 9493 `subject`; **200**)
 - `POST /ssf/subjects/remove` -- remove subject (`stream_id` + RFC 9493 `subject`; **204**)
-- `POST /ssf/actions/{action}` -- trigger event actions
+- `POST /ssf/actions/{action}` -- trigger event actions for every eligible stream (push and poll)
 - `POST /ssf/poll/{stream_id}` -- poll delivery (Transmitter-supplied URL)
 
 ### Receiver

--- a/docs/starlight/src/content/docs/protocols/ssf.mdx
+++ b/docs/starlight/src/content/docs/protocols/ssf.mdx
@@ -16,7 +16,7 @@ description: "Real-time security event sharing with CAEP and RISC events."
 
 SSF is a durable session in [Looking Glass](/using/looking-glass/): `/looking-glass?protocol=ssf`. Catalog flow IDs are presets into one Looking Glass session (they fill the event/delivery chrome). They do not replace the chrome.
 
-**Fire event** encodes and delivers a CAEP/RISC SET for the selected subject. That is the only Looking Glass control that mutates RP account state. **Verify stream** reads transmitter metadata and POSTs `/verify`; it does not revoke sessions or disable accounts.
+- **Fire event** encodes and delivers a CAEP/RISC SET for the selected subject to every enabled stream that requested that event type (the Looking Glass lab stream and any Stream Management poll/push Receivers). That is the only Looking Glass control that mutates RP account state. **Verify stream** reads transmitter metadata and POSTs `/verify`; it does not revoke sessions or disable accounts.
 
 SSF remains its own image (`protocolsoup-ssf`) behind the gateway, the same way SCIM does. RP security state is stored on the SSF service. After a verified CAEP `session-revoked` SET, the receiver also POSTs to federation over HTTP so Alice/Bob OAuth sessions actually die.
 
@@ -64,7 +64,7 @@ The lab action `sessions-revoked` maps to CAEP `session-revoked` (all sessions).
 | `/ssf/subjects` | GET | Looking Glass demo identities |
 | `/ssf/subjects/add` | POST | Add Subject (`stream_id` + RFC 9493 `subject`; **200** empty) |
 | `/ssf/subjects/remove` | POST | Remove Subject (`stream_id` + RFC 9493 `subject`; **204**) |
-| `/ssf/actions/{action}` | POST | Trigger event action |
+| `/ssf/actions/{action}` | POST | Trigger event action (fan-out to eligible streams) |
 | `/ssf/poll/{stream_id}` | POST | Poll delivery (RFC 8936). URL is Transmitter-supplied on the stream. |
 
 ### Receiver

--- a/docs/starlight/src/content/docs/using/looking-glass.mdx
+++ b/docs/starlight/src/content/docs/using/looking-glass.mdx
@@ -122,7 +122,7 @@ The built-in token decoder is available at `POST /api/lookingglass/decode`. It h
 
 SSF is a protocol in Looking Glass (`/looking-glass?protocol=ssf`), not a separate sandbox. Catalog flow IDs (`caep-session-revoked`, `ssf-push-delivery`, …) are presets into one durable session: they fill the subject/event/delivery chrome. They are not a second execute path.
 
-- **Fire event** sends a CAEP/RISC SET for the chrome subject and event. That is what changes RP posture on the State tab (and, for `session-revoked`, the federation revoke-subject hop).
+- **Fire event** sends a CAEP/RISC SET for the chrome subject and event to every eligible Transmitter stream (push and poll). That is what changes RP posture on the State tab (and, for `session-revoked`, the federation revoke-subject hop). Other Looking Glass sessions are not notified.
 - **Verify stream** only does `GET /.well-known/ssf-configuration`, stream configuration (`GET` list, `POST` create if the list is empty), JWKS, and `POST /verify`. It does not revoke sessions or disable accounts.
 - Transmitter and Receiver timeline plus unstripped SET/JWKS wire capture (Flow tab is Looking Glass bus only)
 - After CAEP `session-revoked`, a real HTTP hop to federation `POST /oauth2/demo/caep/revoke-subject` so OAuth sessions die


### PR DESCRIPTION
## What does this PR do?

<!-- Briefly describe the change and its motivation. Link to the related issue if one exists. -->
Updates the ssf transmitter session binding to establish one admin action, a SET for every enabled stream that requested the type and still includes the subject. Other Looking Glass sessions stay isolated. 


## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New protocol implementation

## How was this tested?

<!-- Describe how you verified your changes work correctly. -->

- [ ] Ran the affected flow in Looking Glass and verified real-time events
- [ ] Tested locally with `cd backend && go run ./cmd/server` and `cd frontend && npm run dev`
- [x] Other (describe below)
ssf go tests

## Validation checklist

<!-- Run the checks that match your change. Mark not applicable items as N/A in the PR description. -->

- [x] Backend: `cd backend && go build ./... && go test ./...`
- [x] Backend lint: `cd backend && golangci-lint run ./...`
- [ ] Frontend: `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- [ ] Frontend references: `cd frontend && npm run verify-refs`
- [ ] JWK thumbprint (RFC 7638): `cd frontend && npm run verify-jwk-thumbprint`
- [ ] DPoP proof generation / deep-links (RFC 9449): `cd frontend && npm run verify-dpop`
- [ ] Wallet UI: `cd wallet-ui && npx tsc --noEmit && npm run build`
- [x] Docs: `cd docs/starlight && npm run build`
- [ ] OpenAPI: `npx @redocly/cli lint --config redocly.yaml gateway@v1 scim@v1 federation@v1 vc@v1`
- [ ] Docker/topology: `cd docker && docker compose config`
- [ ] OID4VCI/OID4VP conformance: `cd backend && go test ./internal/protocols/oid4vci ./internal/protocols/oid4vp -count=1`

## Checklist

<!-- Complete all items before requesting review. -->

- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] I have read the [CONTRIBUTING](https://github.com/ParleSec/ProtocolSoup/blob/master/CONTRIBUTING.md) guide
- [x] I selected the relevant validation checks above
- [x] I have updated documentation if needed
- [x] I have not committed secrets, credentials, or `.env` files

## Screenshots / Looking Glass output

<!-- If this is a UI change or protocol change, include screenshots or Looking Glass timeline output. -->
